### PR TITLE
[#3]Fix unhandled BufferUnderflowException in LoadingAvroDeserializer when `read.null.on.failure` is enabled

### DIFF
--- a/kafka-avro/src/test/java/io/atleon/kafka/avro/LoadingAvroSerDeTest.java
+++ b/kafka-avro/src/test/java/io/atleon/kafka/avro/LoadingAvroSerDeTest.java
@@ -48,6 +48,17 @@ public abstract class LoadingAvroSerDeTest extends AbstractSerDeTest {
     }
 
     @Test
+    public void invalidAvroDataWithoutSchemaIDCanBeNulledOut() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(AvroSerDe.SCHEMA_REGISTRY_URL_CONFIG, "<NOT_USED>");
+        configs.put(LoadingAvroDeserializer.READ_NULL_ON_FAILURE_PROPERTY, true);
+
+        deserializer.configure(configs, false);
+
+        assertNull(deserializer.deserialize(AbstractSerDeTest.TOPIC, new byte[]{0, 1, 2, 3}));
+    }
+
+    @Test
     public void nonAvroDataCanBeDeserializedAsNull() {
         Map<String, Object> configs = new HashMap<>();
         configs.put(AvroSerDe.SCHEMA_REGISTRY_URL_CONFIG, "<NOT_USED>");

--- a/kafka-avro/src/test/java/io/atleon/kafka/avro/ReflectDecoderAvroSerDeTest.java
+++ b/kafka-avro/src/test/java/io/atleon/kafka/avro/ReflectDecoderAvroSerDeTest.java
@@ -6,9 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ReflectAvroSerDeTest extends LoadingAvroSerDeTest {
+public class ReflectDecoderAvroSerDeTest extends LoadingAvroSerDeTest {
 
-    public ReflectAvroSerDeTest() {
+    public ReflectDecoderAvroSerDeTest() {
         super(TestReflectEncoderAvroSerializer::new, TestReflectDecoderAvroDeserializer::new);
     }
 


### PR DESCRIPTION
### :pencil: Description

Detect and handle cases where Avro data has valid first byte but not enough bytes for Schema ID, and `read.null.on.failure` is enabled

### :link: Related Issues

#3 