### PR TITLE
Bump Kafka and Confluent to 2.8.1 and 6.2.2

### DIFF
--- a/kafka-avro-embedded/pom.xml
+++ b/kafka-avro-embedded/pom.xml
@@ -50,6 +50,10 @@
                     <artifactId>kafka-clients</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>

--- a/kafka-embedded/src/main/java/io/atleon/kafka/embedded/EmbeddedKafka.java
+++ b/kafka-embedded/src/main/java/io/atleon/kafka/embedded/EmbeddedKafka.java
@@ -5,7 +5,6 @@ import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
 import org.apache.kafka.common.utils.Time;
 import scala.Option;
-import scala.collection.immutable.Seq$;
 
 import java.net.URL;
 import java.nio.file.Files;
@@ -78,7 +77,7 @@ public final class EmbeddedKafka {
 
     private static void startLocalKafka(KafkaConfig kafkaConfig) {
         try {
-            new KafkaServer(kafkaConfig, Time.SYSTEM, Option.empty(), Seq$.MODULE$.empty()).startup();
+            new KafkaServer(kafkaConfig, Time.SYSTEM, Option.empty(), false).startup();
         } catch (Exception e) {
             throw new IllegalStateException("Could not start local Kafka Server", e);
         }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -11,9 +11,9 @@
     <packaging>pom</packaging>
 
     <properties>
-        <apache-kafka.version>2.6.2</apache-kafka.version>
+        <apache-kafka.version>2.8.1</apache-kafka.version>
         <avro.version>1.10.2</avro.version>
-        <confluent.version>6.0.4</confluent.version> <!-- https://docs.confluent.io/platform/current/installation/versions-interoperability.html -->
+        <confluent.version>6.2.2</confluent.version> <!-- https://docs.confluent.io/platform/current/installation/versions-interoperability.html -->
         <guava.version>20.0</guava.version>
         <jackson.version>2.12.3</jackson.version>
         <javassist.version>3.27.0-GA</javassist.version>
@@ -25,7 +25,7 @@
         <reactor-kafka.version>1.3.7</reactor-kafka.version>
         <reactor-rabbitmq.version>1.5.4</reactor-rabbitmq.version>
         <scala.version>2.13.6</scala.version>
-        <slf4j.version>1.7.31</slf4j.version>
+        <slf4j.version>1.7.32</slf4j.version>
         <snappy-java.version>1.1.8.1</snappy-java.version>
         <spring.version>5.3.7</spring.version>
         <zookeeper.version>3.6.3</zookeeper.version>


### PR DESCRIPTION
### :pencil: Description
Upgrading to more recent versions of Kafka and Confluent
