### PR TITLE
#45: Move `Configurable` to `util` module

### DIFF
--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQMessageFactory.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQMessageFactory.java
@@ -1,6 +1,7 @@
 package io.atleon.rabbitmq;
 
 import io.atleon.core.AloFactory;
+import io.atleon.util.Configurable;
 
 public interface AloRabbitMQMessageFactory<T> extends AloFactory<RabbitMQMessage<T>>, Configurable {
 

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/BodyDeserializer.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/BodyDeserializer.java
@@ -1,5 +1,7 @@
 package io.atleon.rabbitmq;
 
+import io.atleon.util.Configurable;
+
 public interface BodyDeserializer<T> extends Configurable {
 
     T deserialize(SerializedBody body);

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/BodySerializer.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/BodySerializer.java
@@ -1,5 +1,7 @@
 package io.atleon.rabbitmq;
 
+import io.atleon.util.Configurable;
+
 public interface BodySerializer<T> extends Configurable {
 
     SerializedBody serialize(T t);

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/Configurable.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/Configurable.java
@@ -1,8 +1,6 @@
 package io.atleon.rabbitmq;
 
-import java.util.Map;
+@Deprecated
+public interface Configurable extends io.atleon.util.Configurable {
 
-public interface Configurable {
-
-    void configure(Map<String, ?> properties);
 }

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQConfig.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQConfig.java
@@ -2,8 +2,7 @@ package io.atleon.rabbitmq;
 
 import com.rabbitmq.client.ConnectionFactory;
 import io.atleon.util.ConfigLoading;
-import io.atleon.util.Instantiation;
-import io.atleon.util.TypeResolution;
+import io.atleon.util.Configurable;
 
 import java.util.List;
 import java.util.Map;
@@ -30,23 +29,14 @@ public class RabbitMQConfig {
     }
 
     public <T extends Configurable> List<T> loadListOfConfigured(String property) {
-        List<T> configurables = ConfigLoading.loadListOrEmpty(properties, property, Instantiation::one);
-        configurables.forEach(interceptor -> interceptor.configure(properties));
-        return configurables;
+        return ConfigLoading.loadListOfConfigured(properties, property);
     }
 
     public <T extends Configurable> Optional<T> loadConfigured(String property) {
-        return ConfigLoading.<Class<? extends T>>load(properties, property, TypeResolution::classForQualifiedName)
-            .map(this::createConfigured);
+        return ConfigLoading.loadConfigured(properties, property);
     }
 
     public <T extends Configurable> T loadConfiguredOrThrow(String property) {
-        return createConfigured(ConfigLoading.loadOrThrow(properties, property, TypeResolution::classForQualifiedName));
-    }
-
-    private <T extends Configurable> T createConfigured(Class<? extends T> configurableClass) {
-        T configurable = Instantiation.one(configurableClass);
-        configurable.configure(properties);
-        return configurable;
+        return ConfigLoading.loadConfiguredOrThrow(properties, property);
     }
 }

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQMessageSendInterceptor.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQMessageSendInterceptor.java
@@ -1,5 +1,7 @@
 package io.atleon.rabbitmq;
 
+import io.atleon.util.Configurable;
+
 public interface RabbitMQMessageSendInterceptor<T> extends Configurable {
 
     RabbitMQMessage<T> onSend(RabbitMQMessage<T> rabbitMQMessage, SerializedBody serializedBody);

--- a/util/src/main/java/io/atleon/util/Configurable.java
+++ b/util/src/main/java/io/atleon/util/Configurable.java
@@ -1,0 +1,8 @@
+package io.atleon.util;
+
+import java.util.Map;
+
+public interface Configurable {
+
+    void configure(Map<String, ?> properties);
+}


### PR DESCRIPTION
### :pencil: Description

Standardize on usage of `io.atleon.util.Configurable` and move its functionalit to `util`

### :link: Related Issues
#45 