### PR TITLE
#57: Make SQS Message deletion non-blocking

### DIFF
--- a/aws-sns/src/main/java/io/atleon/aws/sns/SnsSender.java
+++ b/aws-sns/src/main/java/io/atleon/aws/sns/SnsSender.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
  * A low-level sender of {@link SnsMessage}s. Sent Messages contain the raw String body payload and
  * may reference correlated metadata that is propagated downstream with the Result of sending any
  * given Message.
- * <P>
+ * <p>
  * At most one instance of an {@link SnsAsyncClient} is kept and can be closed upon invoking
  * {@link SnsSender#close()}. However, if after closing, more sent Publishers are subscribed to, a
  * new Client instance will be created and cached.

--- a/aws-sqs/src/main/java/io/atleon/aws/sqs/SqsMessageVisibilityChanger.java
+++ b/aws-sqs/src/main/java/io/atleon/aws/sqs/SqsMessageVisibilityChanger.java
@@ -11,9 +11,8 @@ public interface SqsMessageVisibilityChanger {
     /**
      * Changes the visibility timeout of the associated {@link SqsMessage} by the provided duration
      * and may mark the message as no longer in flight. When stillInFlight is "false", it implies
-     * that processing of the Message has terminated and another Message might possibly be
-     * requested. When stillInFlight is "true", it implies that the message is still being
-     * processed.
+     * that processing of the Message has terminated and another Message might be requested. When
+     * stillInFlight is "true", it implies that the message is still being processed.
      *
      * @param timeout The amount of time to reset the visibility by, by whole seconds
      * @param stillInFlight Whether Message is still being processed

--- a/core/src/main/java/io/atleon/core/DrainableQueue.java
+++ b/core/src/main/java/io/atleon/core/DrainableQueue.java
@@ -1,0 +1,69 @@
+package io.atleon.core;
+
+import reactor.core.publisher.Sinks;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.Consumer;
+
+/**
+ * A thread-safe non-blocking Queue which may have items added to it and be drained by at most one
+ * thread. This is useful when a certain action on a given resource must be serialized, but
+ * invocations on that resource may come concurrently from multiple threads.
+ *
+ * @param <T> The type of elements held by this Queue
+ */
+public final class DrainableQueue<T> {
+
+    private static final AtomicIntegerFieldUpdater<DrainableQueue> DRAINS_IN_PROGRESS =
+        AtomicIntegerFieldUpdater.newUpdater(DrainableQueue.class, "drainsInProgress");
+
+    private volatile int drainsInProgress;
+
+    private final Queue<T> queue = new ConcurrentLinkedQueue<>();
+
+    private final Consumer<? super T> drain;
+
+    private DrainableQueue(Consumer<? super T> drain) {
+        this.drain = drain;
+    }
+
+    /**
+     * Creates a {@link DrainableQueue} that wraps the emissions of next items on a
+     * {@link Sinks.Many}. Next emissions will fail fast if any of the sink's emissions are invoked
+     * externally and not serialized with the created Queue.
+     *
+     * @param sink The sink into which queued items will be emitted
+     * @param <T> The type of items emitted in to the sink
+     * @return A new DrainableQueue
+     */
+    public static <T> DrainableQueue<T> onEmitNext(Sinks.Many<T> sink) {
+        return new DrainableQueue<>(t -> sink.emitNext(t, Sinks.EmitFailureHandler.FAIL_FAST));
+    }
+
+    /**
+     * Adds an item to this Queue and attempts to drain it. If another thread is already draining,
+     * that thread may be the one to drain this item, rather than the calling thread.
+     *
+     * @param t The item to add
+     */
+    public void addAndDrain(T t) {
+        queue.add(t);
+        drain();
+    }
+
+    private void drain() {
+        if (DRAINS_IN_PROGRESS.getAndIncrement(this) != 0) {
+            return;
+        }
+
+        int missed = 1;
+        do {
+            while (!queue.isEmpty()) {
+                drain.accept(queue.remove());
+            }
+            missed = DRAINS_IN_PROGRESS.addAndGet(this, -missed);
+        } while (missed != 0);
+    }
+}

--- a/core/src/test/java/io/atleon/core/DrainableQueueTest.java
+++ b/core/src/test/java/io/atleon/core/DrainableQueueTest.java
@@ -1,0 +1,62 @@
+package io.atleon.core;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Sinks;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DrainableQueueTest {
+
+    private final ExecutorService executorService = Executors.newCachedThreadPool();
+
+    @Test
+    public void addingAndDrainingDoesNotBlockConcurrentThreads() throws Exception {
+        Sinks.Many<Long> sink = Sinks.many().unicast().onBackpressureError();
+        DrainableQueue<Long> queue = DrainableQueue.onEmitNext(sink);
+
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch permitToProceed = new CountDownLatch(1);
+        AtomicInteger finished = new AtomicInteger();
+
+        sink.asFlux()
+            .doOnNext(next -> {
+                started.countDown();
+                try {
+                    permitToProceed.await();
+                    finished.incrementAndGet();
+                } catch (Exception e) {
+                    throw new IllegalStateException("Permit was not awaited properly", e);
+                }
+            })
+            .subscribe();
+
+        // Add and drain an item from the queue
+        Future<?> future = executorService.submit(() -> queue.addAndDrain(System.currentTimeMillis()));
+
+        // Wait for the Executor to be emitting in to the Flux and its thread to be blocked
+        assertTrue(started.await(10, TimeUnit.SECONDS));
+
+        // Add and drain another item from the queue, which should not block since previous thread is emitting
+        executorService.submit(() -> queue.addAndDrain(System.currentTimeMillis()))
+            .get(10, TimeUnit.SECONDS);
+
+        // Nothing should be finished yet
+        assertEquals(0, finished.get());
+
+        // Allow the blocked thread to proceed
+        permitToProceed.countDown();
+
+        // Wait for the blocked thread to finish
+        future.get(10, TimeUnit.SECONDS);
+
+        assertEquals(2, finished.get());
+    }
+}


### PR DESCRIPTION
### :pencil: Description
Use Reactor's drain-miss pattern to implement a work-stealing queue for serializing emissions. Apply to SQS message deletion

### :link: Related Issues
#57 
