### PR TITLE
#59: Add single-message send methods to Kafka and RabbitMQ Alo Senders

### DIFF
--- a/core/src/main/java/io/atleon/core/Batcher.java
+++ b/core/src/main/java/io/atleon/core/Batcher.java
@@ -1,0 +1,52 @@
+package io.atleon.core;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Convenience class for applying size and time bounded batching to {@link Publisher}s
+ */
+public final class Batcher {
+
+    private final int maxSize;
+
+    private final Duration maxDuration;
+
+    private final int prefetch;
+
+    private Batcher(int maxSize, Duration maxDuration, int prefetch) {
+        this.maxSize = maxSize;
+        this.maxDuration = maxDuration;
+        this.prefetch = prefetch;
+    }
+
+    public static Batcher create(int maxSize, Duration maxDuration, int prefetch) {
+        return new Batcher(maxSize, maxDuration, prefetch);
+    }
+
+    public <T, R> Flux<R> applyMapping(
+        Publisher<T> publisher,
+        Function<? super List<T>, ? extends Publisher<? extends R>> mapper,
+        int maxConcurrency
+    ) {
+        return maxConcurrency <= 1
+            ? toBatches(publisher).concatMap(mapper, prefetch)
+            : toBatches(publisher).publishOn(Schedulers.immediate(), prefetch).flatMap(mapper, maxConcurrency);
+    }
+
+    private <T> Flux<List<T>> toBatches(Publisher<T> publisher) {
+        if (maxSize <= 1) {
+            return Flux.from(publisher).map(Collections::singletonList);
+        } else if (maxDuration.isZero() || maxDuration.isNegative()) {
+            throw new IllegalArgumentException("Batching is enabled, but batch duration is not positive");
+        } else {
+            return Flux.from(publisher).bufferTimeout(maxSize, maxDuration);
+        }
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/AloKafkaSender.java
+++ b/kafka/src/main/java/io/atleon/kafka/AloKafkaSender.java
@@ -125,6 +125,10 @@ public class AloKafkaSender<K, V> implements Closeable {
             .flatMapMany(sender -> sendValues(sender, values, valueToTopic, valueToKey));
     }
 
+    public Mono<KafkaSenderResult<ProducerRecord<K, V>>> sendRecord(ProducerRecord<K, V> record) {
+        return sendRecords(Flux.just(record)).next();
+    }
+
     public Flux<KafkaSenderResult<ProducerRecord<K, V>>> sendRecords(Publisher<ProducerRecord<K, V>> records) {
         return futureKafkaSender.flatMapMany(sender -> sendRecords(sender, records));
     }

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQSender.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQSender.java
@@ -72,13 +72,15 @@ public class AloRabbitMQSender<T> implements Closeable {
     }
 
     public Flux<RabbitMQSenderResult<T>> sendBodies(Publisher<T> bodies, RabbitMQMessageCreator<T> messageCreator) {
-        return futureResources
-            .flatMapMany(resources -> resources.send(bodies, messageCreator));
+        return futureResources.flatMapMany(resources -> resources.send(bodies, messageCreator));
+    }
+
+    public Mono<RabbitMQSenderResult<RabbitMQMessage<T>>> sendMessage(RabbitMQMessage<T> message) {
+        return sendMessages(Flux.just(message)).next();
     }
 
     public Flux<RabbitMQSenderResult<RabbitMQMessage<T>>> sendMessages(Publisher<RabbitMQMessage<T>> messages) {
-        return futureResources
-            .flatMapMany(resources -> resources.send(messages, Function.identity()));
+        return futureResources.flatMapMany(resources -> resources.send(messages, Function.identity()));
     }
 
     public Function<Publisher<Alo<T>>, AloFlux<RabbitMQSenderResult<T>>> sendAloBodies(
@@ -91,9 +93,7 @@ public class AloRabbitMQSender<T> implements Closeable {
         Publisher<Alo<T>> aloBodies,
         RabbitMQMessageCreator<T> messageCreator
     ) {
-        return futureResources
-            .flatMapMany(resources -> resources.sendAlos(aloBodies, messageCreator))
-            .as(AloFlux::wrap);
+        return futureResources.flatMapMany(resources -> resources.sendAlos(aloBodies, messageCreator)).as(AloFlux::wrap);
     }
 
     public AloFlux<RabbitMQSenderResult<RabbitMQMessage<T>>> sendAloMessages(


### PR DESCRIPTION
- Include a little bit of refactoring on SQS and SNS Senders

