### PR TITLE
#73: Implement base interface for all Sender Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Atleon dependencies are available in Maven Central under the following coordinat
 The typical entry points in to Atleon are through Receiver and Sender implementations. The following example shows how to create a reactive Kafka stream:
 
 ```java
+import io.atleon.core.DefaultAloSenderResultSubscriber;
 import io.atleon.kafka.AloKafkaReceiver;
 import io.atleon.kafka.AloKafkaSender;
-import io.atleon.kafka.DefaultAloKafkaSenderResultSubscriber;
 import io.atleon.kafka.KafkaConfigSource;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -92,7 +92,7 @@ public class GettingStarted {
             .map(String::toUpperCase)
             .map(string -> new ProducerRecord("topic2", string, string))
             .transform(AloKafkaSender.<String, String>from(kafkaSenderConfig)::sendAloRecords)
-            .subscribe(new DefaultAloKafkaSenderResultSubscriber<>());
+            .subscribe(new DefaultAloSenderResultSubscriber<>());
         
         // ... Do more things while the above stream process is running ...
     }

--- a/aws-sns/src/main/java/io/atleon/aws/sns/AloSnsSender.java
+++ b/aws-sns/src/main/java/io/atleon/aws/sns/AloSnsSender.java
@@ -209,9 +209,8 @@ public class AloSnsSender<T> implements Closeable {
 
         private <R> Alo<SnsSenderResult<R>> toAloOfMessageResult(SnsSenderResult<Alo<R>> messageResultOfAlo) {
             Alo<R> alo = messageResultOfAlo.correlationMetadata();
-            SnsSenderResult<R> messageResult = messageResultOfAlo.replaceCorrelationMetadata(alo.get());
             return alo.<SnsSenderResult<R>>propagator()
-                .create(messageResult, alo.getAcknowledger(), alo.getNacknowledger());
+                .create(messageResultOfAlo.mapCorrelationMetadata(Alo::get), alo.getAcknowledger(), alo.getNacknowledger());
         }
     }
 }

--- a/aws-sns/src/main/java/io/atleon/aws/sns/DefaultAloSnsSenderResultSubscriber.java
+++ b/aws-sns/src/main/java/io/atleon/aws/sns/DefaultAloSnsSenderResultSubscriber.java
@@ -1,17 +1,11 @@
 package io.atleon.aws.sns;
 
-import io.atleon.core.Alo;
-import reactor.core.publisher.BaseSubscriber;
+import io.atleon.core.DefaultAloSenderResultSubscriber;
 
-public class DefaultAloSnsSenderResultSubscriber<C> extends BaseSubscriber<Alo<SnsSenderResult<C>>> {
+/**
+ * Deprecated - Use {@link DefaultAloSenderResultSubscriber}
+ */
+@Deprecated
+public class DefaultAloSnsSenderResultSubscriber<C> extends DefaultAloSenderResultSubscriber<SnsSenderResult<C>> {
 
-    @Override
-    protected void hookOnNext(Alo<SnsSenderResult<C>> value) {
-        SnsSenderResult<C> result = value.get();
-        if (result.isFailure()) {
-            Alo.nacknowledge(value, result.error());
-        } else {
-            Alo.acknowledge(value);
-        }
-    }
 }

--- a/aws-sqs/src/main/java/io/atleon/aws/sqs/AloSqsSender.java
+++ b/aws-sqs/src/main/java/io/atleon/aws/sqs/AloSqsSender.java
@@ -202,9 +202,8 @@ public class AloSqsSender<T> implements Closeable {
 
         private <R> Alo<SqsSenderResult<R>> toAloOfMessageResult(SqsSenderResult<Alo<R>> messageResultOfAlo) {
             Alo<R> alo = messageResultOfAlo.correlationMetadata();
-            SqsSenderResult<R> messageResult = messageResultOfAlo.replaceCorrelationMetadata(alo.get());
             return alo.<SqsSenderResult<R>>propagator()
-                .create(messageResult, alo.getAcknowledger(), alo.getNacknowledger());
+                .create(messageResultOfAlo.mapCorrelationMetadata(Alo::get), alo.getAcknowledger(), alo.getNacknowledger());
         }
     }
 }

--- a/aws-sqs/src/main/java/io/atleon/aws/sqs/DefaultAloSqsSenderResultSubscriber.java
+++ b/aws-sqs/src/main/java/io/atleon/aws/sqs/DefaultAloSqsSenderResultSubscriber.java
@@ -1,17 +1,11 @@
 package io.atleon.aws.sqs;
 
-import io.atleon.core.Alo;
-import reactor.core.publisher.BaseSubscriber;
+import io.atleon.core.DefaultAloSenderResultSubscriber;
 
-public class DefaultAloSqsSenderResultSubscriber<C> extends BaseSubscriber<Alo<SqsSenderResult<C>>> {
+/**
+ * Deprecated - Use {@link DefaultAloSenderResultSubscriber}
+ */
+@Deprecated
+public class DefaultAloSqsSenderResultSubscriber<C> extends DefaultAloSenderResultSubscriber<SqsSenderResult<C>> {
 
-    @Override
-    protected void hookOnNext(Alo<SqsSenderResult<C>> value) {
-        SqsSenderResult<C> result = value.get();
-        if (result.isFailure()) {
-            Alo.nacknowledge(value, result.error());
-        } else {
-            Alo.acknowledge(value);
-        }
-    }
 }

--- a/aws-sqs/src/main/java/io/atleon/aws/sqs/SqsSenderResult.java
+++ b/aws-sqs/src/main/java/io/atleon/aws/sqs/SqsSenderResult.java
@@ -1,7 +1,10 @@
 package io.atleon.aws.sqs;
 
+import io.atleon.core.SenderResult;
+
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * The result of sending an {@link SqsSenderMessage}. Will either contain {@link SuccessMetadata}
@@ -10,7 +13,7 @@ import java.util.Optional;
  *
  * @param <C> The type of correlated metadata that is propagated from the originating request
  */
-public final class SqsSenderResult<C> {
+public final class SqsSenderResult<C> implements SenderResult {
 
     private final String requestId;
 
@@ -46,24 +49,21 @@ public final class SqsSenderResult<C> {
         return new SqsSenderResult<>(requestId, null, Objects.requireNonNull(error), correlationMetadata);
     }
 
-    public <R> SqsSenderResult<R> replaceCorrelationMetadata(R newCorrelationMetadata) {
-        return new SqsSenderResult<>(requestId, successMetadata, error, newCorrelationMetadata);
+    @Override
+    public Optional<Throwable> failureCause() {
+        return Optional.ofNullable(error);
+    }
+
+    public <R> SqsSenderResult<R> mapCorrelationMetadata(Function<? super C, ? extends R> mapper) {
+        return new SqsSenderResult<>(requestId, successMetadata, error, mapper.apply(correlationMetadata));
     }
 
     public String requestId() {
         return requestId;
     }
 
-    public boolean isFailure() {
-        return error != null;
-    }
-
-    public SuccessMetadata successMetadata() {
-        return Objects.requireNonNull(successMetadata, "Should not query successMetadata unless successful");
-    }
-
-    public Throwable error() {
-        return Objects.requireNonNull(error, "Should not query error unless failed");
+    public Optional<SuccessMetadata> successMetadata() {
+        return Optional.ofNullable(successMetadata);
     }
 
     public C correlationMetadata() {

--- a/core/src/main/java/io/atleon/core/DefaultAloSenderResultSubscriber.java
+++ b/core/src/main/java/io/atleon/core/DefaultAloSenderResultSubscriber.java
@@ -1,0 +1,24 @@
+package io.atleon.core;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.BaseSubscriber;
+
+import java.util.Optional;
+
+public class DefaultAloSenderResultSubscriber<T extends SenderResult> extends BaseSubscriber<Alo<T>> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAloSenderResultSubscriber.class);
+
+    @Override
+    protected void hookOnNext(Alo<T> value) {
+        T senderResult = value.get();
+        Optional<Throwable> failure = senderResult.failureCause();
+        if (failure.isPresent()) {
+            LOGGER.warn("SenderResult type={} has failure={}", senderResult.getClass().getSimpleName(), failure.get());
+            Alo.nacknowledge(value, failure.get());
+        } else {
+            Alo.acknowledge(value);
+        }
+    }
+}

--- a/core/src/main/java/io/atleon/core/SenderResult.java
+++ b/core/src/main/java/io/atleon/core/SenderResult.java
@@ -1,0 +1,11 @@
+package io.atleon.core;
+
+import java.util.Optional;
+
+/**
+ * Base interface representing the result of sending a message
+ */
+public interface SenderResult {
+
+    Optional<Throwable> failureCause();
+}

--- a/examples/core/src/main/java/io/atleon/examples/errorhandling/KafkaErrorHandling.java
+++ b/examples/core/src/main/java/io/atleon/examples/errorhandling/KafkaErrorHandling.java
@@ -1,8 +1,8 @@
 package io.atleon.examples.errorhandling;
 
+import io.atleon.core.DefaultAloSenderResultSubscriber;
 import io.atleon.kafka.AloKafkaReceiver;
 import io.atleon.kafka.AloKafkaSender;
-import io.atleon.kafka.DefaultAloKafkaSenderResultSubscriber;
 import io.atleon.kafka.KafkaConfigSource;
 import io.atleon.kafka.embedded.EmbeddedKafka;
 import io.atleon.util.Defaults;
@@ -107,11 +107,11 @@ public class KafkaErrorHandling {
                 .transform(sender.sendAloValues(TOPIC_2, Function.identity()))
                 .doOnNext(next -> latch.countDown())
                 .doOnNext(senderResult -> {
-                    if (!senderResult.exception().isPresent()) {
+                    if (!senderResult.failureCause().isPresent()) {
                         successfullyProcessed.add(senderResult.correlationMetadata());
                     }
                 })
-                .subscribe(new DefaultAloKafkaSenderResultSubscriber<>()));
+                .subscribe(new DefaultAloSenderResultSubscriber<>()));
 
         //Step 5) Produce the records to be consumed above. Note that we are using the same record
         // key for each data item, which will cause these items to show up in the order we emit

--- a/kafka/src/main/java/io/atleon/kafka/DefaultAloKafkaSenderResultSubscriber.java
+++ b/kafka/src/main/java/io/atleon/kafka/DefaultAloKafkaSenderResultSubscriber.java
@@ -1,25 +1,11 @@
 package io.atleon.kafka;
 
-import io.atleon.core.Alo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import reactor.core.publisher.BaseSubscriber;
+import io.atleon.core.DefaultAloSenderResultSubscriber;
 
-import java.util.Optional;
+/**
+ * Deprecated - Use {@link DefaultAloSenderResultSubscriber}
+ */
+@Deprecated
+public class DefaultAloKafkaSenderResultSubscriber<T> extends DefaultAloSenderResultSubscriber<KafkaSenderResult<T>> {
 
-public class DefaultAloKafkaSenderResultSubscriber<T> extends BaseSubscriber<Alo<KafkaSenderResult<T>>> {
-
-    protected static final Logger LOGGER = LoggerFactory.getLogger(DefaultAloKafkaSenderResultSubscriber.class);
-
-    @Override
-    protected void hookOnNext(Alo<KafkaSenderResult<T>> aloResult) {
-        KafkaSenderResult<T> result = aloResult.get();
-        Optional<Exception> error = result.exception();
-        if (error.isPresent()) {
-            LOGGER.warn("Alo Kafka Sender Result has Error: result={}", result);
-            Alo.nacknowledge(aloResult, error.get());
-        } else {
-            Alo.acknowledge(aloResult);
-        }
-    }
 }

--- a/kafka/src/main/java/io/atleon/kafka/KafkaSenderResult.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaSenderResult.java
@@ -1,12 +1,12 @@
 package io.atleon.kafka;
 
 import io.atleon.core.Alo;
+import io.atleon.core.SenderResult;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import reactor.kafka.sender.SenderResult;
 
 import java.util.Optional;
 
-public class KafkaSenderResult<T> {
+public class KafkaSenderResult<T> implements SenderResult {
 
     private final RecordMetadata recordMetadata;
 
@@ -20,13 +20,18 @@ public class KafkaSenderResult<T> {
         this.correlationMetadata = correlationMetadata;
     }
 
-    static <T> KafkaSenderResult<T> fromSenderResult(SenderResult<T> senderResult) {
+    static <T> KafkaSenderResult<T> fromSenderResult(reactor.kafka.sender.SenderResult<T> senderResult) {
         return new KafkaSenderResult<>(senderResult.recordMetadata(), senderResult.exception(), senderResult.correlationMetadata());
     }
 
-    static <T> Alo<KafkaSenderResult<T>> fromSenderResultOfAlo(SenderResult<Alo<T>> senderResult) {
+    static <T> Alo<KafkaSenderResult<T>> fromSenderResultOfAlo(reactor.kafka.sender.SenderResult<Alo<T>> senderResult) {
         return senderResult.correlationMetadata().map(correlationMetadata ->
             new KafkaSenderResult<>(senderResult.recordMetadata(), senderResult.exception(), correlationMetadata));
+    }
+
+    @Override
+    public Optional<Throwable> failureCause() {
+        return Optional.ofNullable(exception);
     }
 
     @Override
@@ -42,6 +47,10 @@ public class KafkaSenderResult<T> {
         return Optional.ofNullable(recordMetadata);
     }
 
+    /**
+     * Deprecated - use {@link KafkaSenderResult#failureCause()}
+     */
+    @Deprecated
     public Optional<Exception> exception() {
         return Optional.ofNullable(exception);
     }

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/DefaultAloRabbitMQSenderResultSubscriber.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/DefaultAloRabbitMQSenderResultSubscriber.java
@@ -1,26 +1,11 @@
 package io.atleon.rabbitmq;
 
-import io.atleon.core.Alo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import reactor.core.publisher.BaseSubscriber;
+import io.atleon.core.DefaultAloSenderResultSubscriber;
 
-public class DefaultAloRabbitMQSenderResultSubscriber<T> extends BaseSubscriber<Alo<RabbitMQSenderResult<T>>> {
+/**
+ * Deprecated - Use {@link DefaultAloSenderResultSubscriber}
+ */
+@Deprecated
+public class DefaultAloRabbitMQSenderResultSubscriber<T> extends DefaultAloSenderResultSubscriber<RabbitMQSenderResult<T>> {
 
-    protected static final Logger LOGGER = LoggerFactory.getLogger(DefaultAloRabbitMQSenderResultSubscriber.class);
-
-    @Override
-    protected void hookOnNext(Alo<RabbitMQSenderResult<T>> aloResult) {
-        RabbitMQSenderResult<T> result = aloResult.get();
-        if (result.isAck()) {
-            Alo.acknowledge(aloResult);
-        } else {
-            LOGGER.warn("RabbitMQ Sender Result is not an ack: result={}", result);
-            Alo.nacknowledge(aloResult, new UnackedRabbitMQSenderResultException());
-        }
-    }
-
-    private static final class UnackedRabbitMQSenderResultException extends Exception {
-
-    }
 }

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQSenderResult.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQSenderResult.java
@@ -2,10 +2,13 @@ package io.atleon.rabbitmq;
 
 import com.rabbitmq.client.AMQP;
 import io.atleon.core.Alo;
+import io.atleon.core.SenderResult;
 import reactor.rabbitmq.CorrelableOutboundMessage;
 import reactor.rabbitmq.OutboundMessageResult;
 
-public class RabbitMQSenderResult<T> {
+import java.util.Optional;
+
+public class RabbitMQSenderResult<T> implements SenderResult {
 
     private final String exchange;
 
@@ -49,6 +52,11 @@ public class RabbitMQSenderResult<T> {
                 messageResult.getOutboundMessage().getProperties(),
                 correlationMetadata,
                 messageResult.isAck()));
+    }
+
+    @Override
+    public Optional<Throwable> failureCause() {
+        return ack ? Optional.empty() : Optional.of(new UnackedRabbitMQMessageException());
     }
 
     @Override

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/UnackedRabbitMQMessageException.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/UnackedRabbitMQMessageException.java
@@ -1,0 +1,8 @@
+package io.atleon.rabbitmq;
+
+/**
+ * Error indicating that a sent {@link RabbitMQMessage} was not ack'd
+ */
+public class UnackedRabbitMQMessageException extends RuntimeException {
+
+}


### PR DESCRIPTION
### :pencil: Description

All Sender Results now implement same base interface

### :link: Related Issues

#73 