### PR TITLE
#76: Replace and deprecate `AloExtendedFlux` with `GroupFlux`

### DIFF
--- a/core/src/main/java/io/atleon/core/AloExtendedFlux.java
+++ b/core/src/main/java/io/atleon/core/AloExtendedFlux.java
@@ -9,94 +9,116 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
- * An {@link Alo}-aware wrapper of a {@link Flux}. All {@code *Extended} methods are delegated to
- * Flux and return {@link AloExtendedFlux}. All {@code *Alo} methods also delegate to Flux, but
- * map to result types that allow them to be wrapped as {@link AloFlux} and are wrapped as such.
+ * An {@link Alo}-aware wrapper of a {@link Flux}. All methods delegate to wrapped Flux, and all
+ * {@code *Alo} methods map to result types that allow them to be wrapped as {@link AloFlux} and
+ * are wrapped as such.
+ *
+ * @deprecated All past operations resulting AloExtendedFlux now result in {@link GroupFlux}, which
+ * should be used directly
  */
-public class AloExtendedFlux<T> implements Publisher<T> {
+@Deprecated
+public interface AloExtendedFlux<T> extends Publisher<T> {
 
-    private final Flux<? extends T> wrapped;
-
-    AloExtendedFlux(Flux<? extends T> wrapped) {
-        this.wrapped = wrapped;
+    /**
+     * @deprecated Create Publisher/Flux of Alo and use {@link AloFlux#wrap(Publisher)}
+     */
+    @Deprecated
+    static <T> AloExtendedFlux<T> wrap(Publisher<? extends T> publisher) {
+        return publisher instanceof GroupFlux
+            ? GroupFlux.class.cast(publisher)
+            : new GroupFlux<>(Flux.from(publisher), Integer.MAX_VALUE);
     }
 
     /**
-     * Wraps a Publisher as an Alo-aware Flux
+     * @deprecated Use {@link AloExtendedFlux#map(Function)}
      */
-    public static <T> AloExtendedFlux<T> wrap(Publisher<? extends T> publisher) {
-        return publisher instanceof AloExtendedFlux
-            ? AloExtendedFlux.class.cast(publisher)
-            : new AloExtendedFlux<>(Flux.from(publisher));
+    @Deprecated
+    default <V> AloExtendedFlux<V> mapExtended(Function<? super T, ? extends V> mapper) {
+        return map(mapper);
+    }
+
+    /**
+     * @deprecated Reference {@link GroupFlux} and use {@link GroupFlux#flatMapAlo(Function)}
+     */
+    @Deprecated
+    default <V> AloFlux<V> flatMapAlo(Function<? super T, ? extends Publisher<Alo<V>>> mapper, int concurrency) {
+        return unwrap().flatMap(mapper, concurrency).as(AloFlux::wrap);
+    }
+
+    /**
+     * @deprecated Reference {@link GroupFlux} and use {@link GroupFlux#flatMapAlo(Function)}
+     */
+    @Deprecated
+    default <V> AloFlux<V>
+    flatMapAlo(Function<? super T, ? extends Publisher<Alo<V>>> mapper, int concurrency, int prefetch) {
+        return unwrap().flatMap(mapper, concurrency, prefetch).as(AloFlux::wrap);
+    }
+
+    /**
+     * @deprecated Reference {@link GroupFlux} and use {@link GroupFlux#flatMapAlo(Function)}
+     */
+    @Deprecated
+    default <V> AloFlux<V> transformAlo(Function<? super AloExtendedFlux<T>, ? extends Publisher<Alo<V>>> transformer) {
+        return AloFlux.wrap(transformer.apply(this));
+    }
+
+    /**
+     * @deprecated It is not intended for users to subscribe directly to this Flux
+     */
+    @Deprecated
+    default Disposable subscribe(Consumer<? super T> consumer) {
+        return unwrap().subscribe(consumer);
+    }
+
+    /**
+     * @deprecated It is not intended for users to subscribe directly to this Flux
+     */
+    @Deprecated
+    default Disposable subscribe(Consumer<? super T> consumer, Consumer<? super Throwable> errorConsumer) {
+        return unwrap().subscribe(consumer, errorConsumer);
+    }
+
+    /**
+     * @deprecated It is not intended for users to subscribe directly to this Flux
+     */
+    @Override
+    default void subscribe(Subscriber<? super T> s) {
+        unwrap().subscribe(s);
+    }
+
+    /**
+     * @deprecated It is not intended for users to subscribe directly to this Flux
+     */
+    @Deprecated
+    default <E extends Subscriber<? super T>> E subscribeWith(E subscriber) {
+        return unwrap().subscribeWith(subscriber);
     }
 
     /**
      * Return the underlying Flux backing this AloExtendedFlux
      */
-    public Flux<? extends T> unwrap() {
-        return wrapped;
-    }
+    Flux<? extends T> unwrap();
 
     /**
-     * See {@link Flux#map(Function)}
+     * Transform the items emitted by this {@link AloExtendedFlux} by applying a synchronous
+     * function to each item.
+     *
+     * @param mapper the synchronous transforming {@link Function}
+     * @param <V>    the transformed type
+     * @return a transformed {@link AloExtendedFlux}
+     * @see Flux#map(Function)
      */
-    public final <V> AloExtendedFlux<V> mapExtended(Function<? super T, ? extends V> mapper) {
-        return new AloExtendedFlux<>(wrapped.map(mapper));
-    }
+    <V> AloExtendedFlux<V> map(Function<? super T, ? extends V> mapper);
 
     /**
-     * See {@link Flux#flatMap(Function)}
+     * Transform the elements emitted by this {@link AloExtendedFlux} asynchronously into
+     * Publishers of {@link Alo}, then flatten these inner Publishers in to a single
+     * {@link AloFlux}, which allows them to interleave
+     *
+     * @param mapper {@link Function} to transform each emission into {@link Publisher} of {@link Alo}
+     * @param <V>    the type referenced by each resulting {@link Alo}
+     * @return a new {@link AloFlux} of the merged results
+     * @see Flux#flatMap(Function)
      */
-    public final <V> AloFlux<V> flatMapAlo(Function<? super T, ? extends Publisher<Alo<V>>> mapper) {
-        return wrapped.flatMap(mapper).as(AloFlux::wrap);
-    }
-
-    /**
-     * See {@link Flux#flatMap(Function, int)}
-     */
-    public final <V> AloFlux<V> flatMapAlo(Function<? super T, ? extends Publisher<Alo<V>>> mapper, int concurrency) {
-        return wrapped.flatMap(mapper, concurrency).as(AloFlux::wrap);
-    }
-
-    /**
-     * See {@link Flux#flatMap(Function, int, int)}
-     */
-    public final <V> AloFlux<V>
-    flatMapAlo(Function<? super T, ? extends Publisher<Alo<V>>> mapper, int concurrency, int prefetch) {
-        return wrapped.flatMap(mapper, concurrency, prefetch).as(AloFlux::wrap);
-    }
-
-    /**
-     * See {@link Flux#transform(Function)}
-     */
-    public final <V> AloFlux<V>
-    transformAlo(Function<? super AloExtendedFlux<T>, ? extends Publisher<Alo<V>>> transformer) {
-        return AloFlux.wrap(transformer.apply(this));
-    }
-
-    /**
-     * See {@link Flux#subscribe(Consumer)}
-     */
-    public Disposable subscribe(Consumer<? super T> consumer) {
-        return wrapped.subscribe(consumer);
-    }
-
-    /**
-     * See {@link Flux#subscribe(Consumer, Consumer)}
-     */
-    public Disposable subscribe(Consumer<? super T> consumer, Consumer<? super Throwable> errorConsumer) {
-        return wrapped.subscribe(consumer, errorConsumer);
-    }
-
-    /**
-     * See {@link Flux#subscribe(Subscriber)}
-     */
-    @Override
-    public void subscribe(Subscriber<? super T> s) {
-        wrapped.subscribe(s);
-    }
-
-    public <E extends Subscriber<? super T>> E subscribeWith(E subscriber) {
-        return wrapped.subscribeWith(subscriber);
-    }
+    <V> AloFlux<V> flatMapAlo(Function<? super T, ? extends Publisher<Alo<V>>> mapper);
 }

--- a/core/src/main/java/io/atleon/core/AloFlux.java
+++ b/core/src/main/java/io/atleon/core/AloFlux.java
@@ -56,56 +56,56 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
     }
 
     /**
-     * See {@link Flux#doFirst(Runnable)}
+     * @see Flux#doFirst(Runnable)
      */
     public AloFlux<T> doFirst(Runnable onFirst) {
         return new AloFlux<>(wrapped.doFirst(onFirst));
     }
 
     /**
-     * See {@link Flux#doOnCancel(Runnable)}
+     * @see Flux#doOnCancel(Runnable)
      */
     public AloFlux<T> doOnCancel(Runnable onCancel) {
         return new AloFlux<>(wrapped.doOnCancel(onCancel));
     }
 
     /**
-     * See {@link Flux#doOnNext(Consumer)}
+     * @see Flux#doOnNext(Consumer)
      */
     public AloFlux<T> doOnNext(Consumer<? super T> onNext) {
         return new AloFlux<>(wrapped.doOnNext(alo -> onNext.accept(alo.get())));
     }
 
     /**
-     * See {@link Flux#doOnError(Consumer)}
+     * @see Flux#doOnError(Consumer)
      */
     public AloFlux<T> doOnError(Consumer<? super Throwable> onError) {
         return new AloFlux<>(wrapped.doOnError(onError));
     }
 
     /**
-     * See {@link Flux#doFinally(Consumer)}
+     * @see Flux#doFinally(Consumer)
      */
     public AloFlux<T> doFinally(Consumer<SignalType> onFinally) {
         return new AloFlux<>(wrapped.doFinally(onFinally));
     }
 
     /**
-     * See {@link Flux#filter(Predicate)}
+     * @see Flux#filter(Predicate)
      */
     public AloFlux<T> filter(Predicate<? super T> predicate) {
         return new AloFlux<>(wrapped.filter(AloOps.filtering(predicate, Alo::acknowledge)));
     }
 
     /**
-     * Alias for .map(clazz::cast)
+     * Alias for {@code .map(clazz::cast)}
      */
     public <V> AloFlux<V> cast(Class<V> clazz) {
         return map(clazz::cast);
     }
 
     /**
-     * See {@link Flux#map(Function)}
+     * @see Flux#map(Function)
      */
     public <V> AloFlux<V> map(Function<? super T, ? extends V> mapper) {
         return new AloFlux<>(wrapped.map(AloOps.mapping(mapper)));
@@ -118,9 +118,9 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
      * {@link Optional} and only emitting present values. This effectively results in two
      * {@link Alo#map(Function)} invocations for non-null values.
      *
-     * @param mapper - the synchronous transforming {@link Function}
-     * @param <V>    - the transformed type
-     * @return - a transformed {@link AloFlux}
+     * @param mapper the synchronous transforming {@link Function}
+     * @param <V>    the transformed type
+     * @return a transformed {@link AloFlux}
      */
     public <V> AloFlux<V> mapNotNull(Function<? super T, ? extends V> mapper) {
         return mapPresent(mapper.andThen(Optional::ofNullable));
@@ -132,9 +132,9 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
      * emitted. This effectively results in two  {@link Alo#map(Function)} invocations for present
      * values.
      *
-     * @param mapper - the synchronous transforming {@link Function}
-     * @param <V>    - the transformed type
-     * @return - a transformed {@link AloFlux}
+     * @param mapper the synchronous transforming {@link Function}
+     * @param <V>    the transformed type
+     * @return a transformed {@link AloFlux}
      */
     public <V> AloFlux<V> mapPresent(Function<? super T, Optional<? extends V>> mapper) {
         return new AloFlux<>(wrapped.handle((alo, sink) -> {
@@ -148,35 +148,35 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
     }
 
     /**
-     * See {@link Flux#concatMap(Function)}
+     * @see Flux#concatMap(Function)
      */
     public <V> AloFlux<V> concatMap(Function<? super T, ? extends Publisher<V>> mapper) {
         return new AloFlux<>(wrapped.concatMap(AloOps.publishing(mapper)));
     }
 
     /**
-     * See {@link Flux#concatMap(Function, int)}
+     * @see Flux#concatMap(Function, int)
      */
     public <V> AloFlux<V> concatMap(Function<? super T, ? extends Publisher<V>> mapper, int prefetch) {
         return new AloFlux<>(wrapped.concatMap(AloOps.publishing(mapper), prefetch));
     }
 
     /**
-     * See {@link Flux#flatMap(Function)}
+     * @see Flux#flatMap(Function)
      */
     public <V> AloFlux<V> flatMap(Function<? super T, ? extends Publisher<V>> mapper) {
         return new AloFlux<>(wrapped.flatMap(AloOps.publishing(mapper)));
     }
 
     /**
-     * See {@link Flux#flatMap(Function, int)}
+     * @see Flux#flatMap(Function, int)
      */
     public <V> AloFlux<V> flatMap(Function<? super T, ? extends Publisher<V>> mapper, int concurrency) {
         return new AloFlux<>(wrapped.flatMap(AloOps.publishing(mapper), concurrency));
     }
 
     /**
-     * See {@link Flux#flatMap(Function, int, int)}
+     * @see Flux#flatMap(Function, int, int)
      */
     public <V> AloFlux<V> flatMap(Function<? super T, ? extends Publisher<V>> mapper, int concurrency, int prefetch) {
         return new AloFlux<>(wrapped.flatMap(AloOps.publishing(mapper), concurrency, prefetch));
@@ -194,14 +194,14 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
     }
 
     /**
-     * See {@link Flux#bufferTimeout(int, Duration)}
+     * @see Flux#bufferTimeout(int, Duration)
      */
     public AloFlux<List<T>> bufferTimeout(int maxSize, Duration maxTime) {
         return bufferTimeout(maxSize, maxTime, Schedulers.parallel(), buffer -> buffer.get(0).propagator());
     }
 
     /**
-     * See {@link Flux#bufferTimeout(int, Duration, Scheduler)}
+     * @see Flux#bufferTimeout(int, Duration, Scheduler)
      */
     public AloFlux<List<T>> bufferTimeout(int maxSize, Duration maxTime, Scheduler scheduler) {
         return bufferTimeout(maxSize, maxTime, scheduler, buffer -> buffer.get(0).propagator());
@@ -224,10 +224,10 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
      * nuance to this method is the provided Function which produces an {@link AloFactory} which is
      * used to create an implementation of Alo that wraps the buffered data items.
      *
-     * @param maxSize            – the max collected size
-     * @param maxTime            – the timeout enforcing the release of a partial buffer
-     * @param scheduler          – a time-capable Scheduler instance to run on
-     * @param bufferToAloFactory - Function that provides an AloFactory to wrap list of items
+     * @param maxSize            the max collected size
+     * @param maxTime            the timeout enforcing the release of a partial buffer
+     * @param scheduler          a time-capable Scheduler instance to run on
+     * @param bufferToAloFactory Function that provides an AloFactory to wrap list of items
      * @return An AloFlux that buffers upstream elements in bounded size and time
      */
     public AloFlux<List<T>> bufferTimeout(
@@ -241,7 +241,7 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
     }
 
     /**
-     * See {@link Flux#delayUntil(Function)}
+     * @see Flux#delayUntil(Function)
      */
     public AloFlux<T> delayUntil(Function<? super T, ? extends Publisher<?>> triggerProvider) {
         return new AloFlux<>(wrapped.delayUntil(alo -> triggerProvider.apply(alo.get())));
@@ -283,7 +283,7 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
      * @param numGroups       How many groups to divide the source sequence in to
      * @return A Flux of grouped AloFluxes
      */
-    public AloExtendedFlux<AloGroupedFlux<Integer, T>>
+    public GroupFlux<AloGroupedFlux<Integer, T>>
     groupByNumberHash(Function<? super T, ? extends Number> numberExtractor, int numGroups) {
         return groupBy(NumberHashGroupExtractor.composed(numberExtractor, numGroups));
     }
@@ -297,7 +297,7 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
      * @param numGroups       How many groups to divide the source sequence in to
      * @return A Flux of grouped AloFluxes
      */
-    public <V> AloExtendedFlux<AloGroupedFlux<Integer, V>> groupByNumberHash(
+    public <V> GroupFlux<AloGroupedFlux<Integer, V>> groupByNumberHash(
         Function<? super T, ? extends Number> numberExtractor,
         int numGroups,
         Function<? super T, V> valueMapper) {
@@ -313,9 +313,9 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
      * @param numGroups       How many groups to divide the source sequence in to
      * @return A Flux of grouped AloFluxes
      */
-    public AloExtendedFlux<AloGroupedFlux<Integer, T>>
+    public GroupFlux<AloGroupedFlux<Integer, T>>
     groupByStringHash(Function<? super T, String> stringExtractor, int numGroups) {
-        return groupBy(StringHashGroupExtractor.composed(stringExtractor, numGroups));
+        return groupBy(StringHashGroupExtractor.composed(stringExtractor, numGroups), numGroups);
     }
 
     /**
@@ -327,46 +327,62 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
      * @param numGroups       How many groups to divide the source sequence in to
      * @return A Flux of grouped AloFluxes
      */
-    public <V> AloExtendedFlux<AloGroupedFlux<Integer, V>>
+    public <V> GroupFlux<AloGroupedFlux<Integer, V>>
     groupByStringHash(Function<? super T, String> stringExtractor, int numGroups, Function<? super T, V> valueMapper) {
-        return groupBy(StringHashGroupExtractor.composed(stringExtractor, numGroups), valueMapper);
+        return groupBy(StringHashGroupExtractor.composed(stringExtractor, numGroups), numGroups, valueMapper);
     }
 
     /**
-     * See {@link Flux#groupBy(Function)}
+     * @see Flux#groupBy(Function)
      */
-    public <K> AloExtendedFlux<AloGroupedFlux<K, T>> groupBy(Function<? super T, ? extends K> groupExtractor) {
+    public <K> GroupFlux<AloGroupedFlux<K, T>> groupBy(Function<? super T, ? extends K> groupExtractor) {
+        return groupBy(groupExtractor, Integer.MAX_VALUE);
+    }
+
+    /**
+     * @see Flux#groupBy(Function)
+     */
+    public <K, V> GroupFlux<AloGroupedFlux<K, V>>
+    groupBy(Function<? super T, ? extends K> groupExtractor, Function<? super T, V> valueMapper) {
+        return groupBy(groupExtractor, Integer.MAX_VALUE, valueMapper);
+    }
+
+    /**
+     * @see Flux#groupBy(Function)
+     */
+    public <K> GroupFlux<AloGroupedFlux<K, T>>
+    groupBy(Function<? super T, ? extends K> groupExtractor, int cardinality) {
         return wrapped.groupBy(alo -> groupExtractor.apply(alo.get()))
             .<AloGroupedFlux<K, T>>map(AloGroupedFlux::new)
-            .as(AloExtendedFlux::new);
+            .as(flux -> new GroupFlux<>(flux, cardinality));
     }
 
     /**
-     * See {@link Flux#groupBy(Function)}
+     * @see Flux#groupBy(Function)
      */
-    public <K, V> AloExtendedFlux<AloGroupedFlux<K, V>>
-    groupBy(Function<? super T, ? extends K> groupExtractor, Function<? super T, V> valueMapper) {
+    public <K, V> GroupFlux<AloGroupedFlux<K, V>>
+    groupBy(Function<? super T, ? extends K> groupExtractor, int cardinality, Function<? super T, V> valueMapper) {
         return wrapped.groupBy(alo -> groupExtractor.apply(alo.get()), AloOps.mapping(valueMapper))
             .<AloGroupedFlux<K, V>>map(AloGroupedFlux::new)
-            .as(AloExtendedFlux::new);
+            .as(flux -> new GroupFlux<>(flux, cardinality));
     }
 
     /**
-     * See {@link Flux#publishOn(Scheduler)}
+     * @see Flux#publishOn(Scheduler)
      */
     public AloFlux<T> publishOn(Scheduler scheduler) {
         return new AloFlux<>(wrapped.publishOn(scheduler));
     }
 
     /**
-     * See {@link Flux#publishOn(Scheduler, int)}
+     * @see Flux#publishOn(Scheduler, int)
      */
     public AloFlux<T> publishOn(Scheduler scheduler, int prefetch) {
         return new AloFlux<>(wrapped.publishOn(scheduler, prefetch));
     }
 
     /**
-     * See {@link Flux#subscribeOn(Scheduler)}
+     * @see Flux#subscribeOn(Scheduler)
      */
     public AloFlux<T> subscribeOn(Scheduler scheduler) {
         return new AloFlux<>(wrapped.subscribeOn(scheduler));
@@ -416,14 +432,14 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
     }
 
     /**
-     * See {@link AloFlux#resubscribeOnError(ResubscriptionConfig)}
+     * @see AloFlux#resubscribeOnError(ResubscriptionConfig)
      */
     public AloFlux<T> resubscribeOnError(String name) {
         return resubscribeOnError(new ResubscriptionConfig(name));
     }
 
     /**
-     * See {@link AloFlux#resubscribeOnError(ResubscriptionConfig)}
+     * @see AloFlux#resubscribeOnError(ResubscriptionConfig)
      */
     public AloFlux<T> resubscribeOnError(String name, Duration delay) {
         return resubscribeOnError(new ResubscriptionConfig(name, delay));
@@ -437,7 +453,7 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
     }
 
     /**
-     * See {@link AloFlux#limitPerSecond(RateLimitingConfig)}
+     * @see AloFlux#limitPerSecond(RateLimitingConfig)
      */
     public AloFlux<T> limitPerSecond(double limitPerSecond) {
         return limitPerSecond(new RateLimitingConfig(limitPerSecond));
@@ -500,21 +516,21 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
     }
 
     /**
-     * See {@link Flux#subscribe(Consumer)}
+     * @see Flux#subscribe(Consumer)
      */
     public Disposable subscribe(Consumer<? super Alo<T>> consumer) {
         return wrapped.subscribe(consumer);
     }
 
     /**
-     * See {@link Flux#subscribe(Consumer, Consumer)}
+     * @see Flux#subscribe(Consumer, Consumer)
      */
     public Disposable subscribe(Consumer<? super Alo<T>> consumer, Consumer<? super Throwable> errorConsumer) {
         return wrapped.subscribe(consumer, errorConsumer);
     }
 
     /**
-     * See {@link Publisher#subscribe(Subscriber)}
+     * @see Publisher#subscribe(Subscriber)
      */
     @Override
     public void subscribe(Subscriber<? super Alo<T>> subscriber) {
@@ -522,7 +538,7 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
     }
 
     /**
-     * See {@link Flux#subscribeWith(Subscriber)}
+     * @see Flux#subscribeWith(Subscriber)
      */
     public <E extends Subscriber<? super Alo<T>>> E subscribeWith(E subscriber) {
         return wrapped.subscribeWith(subscriber);

--- a/core/src/main/java/io/atleon/core/GroupFlux.java
+++ b/core/src/main/java/io/atleon/core/GroupFlux.java
@@ -1,0 +1,61 @@
+package io.atleon.core;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+
+import java.util.function.Function;
+
+/**
+ * An {@link Alo}-aware Flux that is known to be emitting some form of grouping of items. This
+ * grouping is typically some other {@link Publisher}.
+ *
+ * @param <T> the type of groups emitted by this {@link GroupFlux}
+ */
+public class GroupFlux<T> implements AloExtendedFlux<T> {
+
+    private final Flux<? extends T> wrapped;
+
+    private final int cardinality;
+
+    GroupFlux(Flux<? extends T> wrapped, int cardinality) {
+        this.wrapped = wrapped;
+        this.cardinality = cardinality;
+    }
+
+    /**
+     * Return the underlying Flux backing this GroupFlux
+     */
+    @Override
+    public Flux<? extends T> unwrap() {
+        return wrapped;
+    }
+
+    /**
+     * Transform the items emitted by this {@link GroupFlux} by applying a synchronous
+     * function to each item.
+     *
+     * @param mapper the synchronous transforming {@link Function}
+     * @param <V>    the transformed type
+     * @return a transformed {@link GroupFlux}
+     * @see Flux#map(Function)
+     */
+    @Override
+    public final <V> GroupFlux<V> map(Function<? super T, ? extends V> mapper) {
+        return new GroupFlux<>(wrapped.map(mapper), cardinality);
+    }
+
+    /**
+     * Transform the elements emitted by this {@link AloExtendedFlux} asynchronously into
+     * Publishers of {@link Alo}, then flatten these inner Publishers in to a single
+     * {@link AloFlux}, which allows them to interleave
+     *
+     * @param mapper {@link Function} to transform each emission into {@link Publisher} of {@link Alo}
+     * @param <V>    the type referenced by each resulting {@link Alo}
+     * @return a new {@link AloFlux} of the merged results
+     * @see Flux#flatMap(Function)
+     */
+    @Override
+    public final <V> AloFlux<V> flatMapAlo(Function<? super T, ? extends Publisher<Alo<V>>> mapper) {
+        return wrapped.flatMap(mapper, cardinality).as(AloFlux::wrap);
+    }
+}

--- a/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaArbitraryParallelism.java
+++ b/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaArbitraryParallelism.java
@@ -71,7 +71,7 @@ public class KafkaArbitraryParallelism {
         AloKafkaReceiver.<String>forValues(kafkaReceiverConfig)
             .receiveAloValues(Collections.singletonList(TOPIC))
             .groupByStringHash(Function.identity(), NUM_GROUPS)
-            .subscribe(groupFlux -> groupFlux
+            .flatMapAlo(groupedFluex -> groupedFluex
                 .publishOn(SCHEDULER)
                 .map(String::toUpperCase)
                 .doOnNext(next -> {
@@ -84,8 +84,9 @@ public class KafkaArbitraryParallelism {
                         System.err.println("Failed to sleep");
                     }
                 })
-                .consumeAloAndGet(Alo::acknowledge)
-                .subscribe(string -> latch.countDown()));
+            )
+            .consumeAloAndGet(Alo::acknowledge)
+            .subscribe(string -> latch.countDown());
 
         //Step 4) Produce random UUIDs to the topic we're processing above
         Flux.range(0, NUM_SAMPLES)

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -313,4 +313,34 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>oss-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <configuration>
+                            <source>8</source>
+                            <links>
+                                <link>https://www.reactive-streams.org/reactive-streams-${reactive-streams.version}-javadoc/org/reactivestreams</link>
+                                <link>https://projectreactor.io/docs/core/${reactor.version}/api</link>
+                            </links>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -229,22 +229,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.0.0</version>
-                        <configuration>
-                            <source>8</source>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
### :pencil: Description
- New `GroupFlux` is easier to use since concurrency does not need to be explicitly provided
- Take a pass at cleaning up Javadoc

### :link: Related Issues
#76 