### PR TITLE
#78: Add Contextual interface and have Alo extend it

### DIFF
--- a/aws-sns/src/main/java/io/atleon/aws/sns/AloSnsSender.java
+++ b/aws-sns/src/main/java/io/atleon/aws/sns/AloSnsSender.java
@@ -185,7 +185,7 @@ public class AloSnsSender<T> implements Closeable {
             String topicArn
         ) {
             return AloFlux.toFlux(alos)
-                .map(alo -> toSenderMessage(alo, messageCreator.compose(Alo::get)))
+                .map(alo -> alo.supplyInContext(() -> toSenderMessage(alo, messageCreator.compose(Alo::get))))
                 .transform(senderMessages -> sender.send(senderMessages, topicArn))
                 .map(this::toAloOfMessageResult);
         }

--- a/aws-sqs/src/main/java/io/atleon/aws/sqs/AloSqsSender.java
+++ b/aws-sqs/src/main/java/io/atleon/aws/sqs/AloSqsSender.java
@@ -178,7 +178,7 @@ public class AloSqsSender<T> implements Closeable {
             String queueUrl
         ) {
             return AloFlux.toFlux(alos)
-                .map(alo -> toSenderMessage(alo, messageCreator.compose(Alo::get)))
+                .map(alo -> alo.supplyInContext(() -> toSenderMessage(alo, messageCreator.compose(Alo::get))))
                 .transform(senderMessages -> sender.send(senderMessages, queueUrl))
                 .map(this::toAloOfMessageResult);
         }

--- a/core/src/main/java/io/atleon/core/Alo.java
+++ b/core/src/main/java/io/atleon/core/Alo.java
@@ -17,15 +17,15 @@ import java.util.function.Function;
  * other words, execution of either the acknowledger or nacknowledger must be threadsafe, and once
  * either is executed, further executions of either should result in no-ops. Implementations are
  * responsible for implementing how to propagate enough information with which to eventually
- * execute acknowledgement. Note that implementations may propagate more than just
- * acknowledgement resources.
+ * execute acknowledgement. Note that Alo extends {@link Contextual}, and implementations may
+ * therefore propagate contextual information in addition to acknowledgement resources.
  *
  * <p>Acknowledgers and Nacknowledgers referenced by Alo implementations must be
  * <strong>safe</strong>. They <i>must not throw Exceptions.</i>
  *
  * @param <T> The type of data item contained in this Alo
  */
-public interface Alo<T> {
+public interface Alo<T> extends Contextual {
 
     /**
      * Convenience method for executing an Alo's acknowledger. This is typically useful as a method

--- a/core/src/main/java/io/atleon/core/Contextual.java
+++ b/core/src/main/java/io/atleon/core/Contextual.java
@@ -1,0 +1,20 @@
+package io.atleon.core;
+
+import java.util.function.Supplier;
+
+/**
+ * An object that may have some context associated with it.
+ */
+public interface Contextual {
+
+    /**
+     * Invoke the given {@link Supplier} while managing context around its invocation.
+     *
+     * @param supplier A {@link Supplier} to run
+     * @param <R>      The type of result produced by the {@link Supplier}
+     * @return The value resulting from invoking the {@link Supplier}
+     */
+    default <R> R supplyInContext(Supplier<R> supplier) {
+        return supplier.get();
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/AloKafkaSender.java
+++ b/kafka/src/main/java/io/atleon/kafka/AloKafkaSender.java
@@ -348,7 +348,7 @@ public class AloKafkaSender<K, V> implements Closeable {
             Function<T, ProducerRecord<K, V>> recordCreator
         ) {
             return AloFlux.toFlux(alos)
-                .map(alo -> SenderRecord.create(recordCreator.apply(alo.get()), alo))
+                .map(alo -> alo.supplyInContext(() -> SenderRecord.create(recordCreator.apply(alo.get()), alo)))
                 .transform(sender::send)
                 .map(KafkaSenderResult::fromSenderResultOfAlo);
         }

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQSender.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQSender.java
@@ -245,7 +245,7 @@ public class AloRabbitMQSender<T> implements Closeable {
             Function<R, RabbitMQMessage<T>> messageCreator
         ) {
             return AloFlux.toFlux(alos)
-                .map(alo -> toCorrelableOutboundMessage(alo, messageCreator.compose(Alo::get)))
+                .map(alo -> alo.supplyInContext(() -> toCorrelableOutboundMessage(alo, messageCreator.compose(Alo::get))))
                 .transform(outboundMessages -> sender.sendWithTypedPublishConfirms(outboundMessages, ALO_SEND_OPTIONS))
                 .map(RabbitMQSenderResult::fromMessageResultOfAlo);
         }


### PR DESCRIPTION
- Will allow the activation context, i.e. for Tracing

### :pencil: Description
In order to enable full APM tracing from sent items to downstream consumers, Alo items need a way to activate their tracing context when those natively sendable items are generated. This is typically done without going through `Alo.map`, so this adds a context-aware method to allow Alo items to activate their context on arbitrary invocations of methods that supply results

### :link: Related Issues
#78 
