### PR TITLE
#91: Implement ability to differentiate fan-in from regular propagation

### DIFF
--- a/aws-sns/src/main/java/io/atleon/aws/sns/SnsSenderResult.java
+++ b/aws-sns/src/main/java/io/atleon/aws/sns/SnsSenderResult.java
@@ -54,6 +54,10 @@ public final class SnsSenderResult<C> implements SenderResult {
         return Optional.ofNullable(error);
     }
 
+    public <R> SnsSenderResult<R> replaceCorrelationMetadata(R newCorrelationMetadata) {
+        return new SnsSenderResult<>(requestId, successMetadata, error, newCorrelationMetadata);
+    }
+
     public <R> SnsSenderResult<R> mapCorrelationMetadata(Function<? super C, ? extends R> mapper) {
         return new SnsSenderResult<>(requestId, successMetadata, error, mapper.apply(correlationMetadata));
     }

--- a/aws-sqs/src/main/java/io/atleon/aws/sqs/SqsSenderResult.java
+++ b/aws-sqs/src/main/java/io/atleon/aws/sqs/SqsSenderResult.java
@@ -54,6 +54,10 @@ public final class SqsSenderResult<C> implements SenderResult {
         return Optional.ofNullable(error);
     }
 
+    public <R> SqsSenderResult<R> replaceCorrelationMetadata(R newCorrelationMetadata) {
+        return new SqsSenderResult<>(requestId, successMetadata, error, newCorrelationMetadata);
+    }
+
     public <R> SqsSenderResult<R> mapCorrelationMetadata(Function<? super C, ? extends R> mapper) {
         return new SqsSenderResult<>(requestId, successMetadata, error, mapper.apply(correlationMetadata));
     }

--- a/core/src/main/java/io/atleon/core/Alo.java
+++ b/core/src/main/java/io/atleon/core/Alo.java
@@ -1,6 +1,6 @@
 package io.atleon.core;
 
-import java.util.function.BinaryOperator;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -59,16 +59,14 @@ public interface Alo<T> extends Contextual {
     }
 
     /**
-     * Apply a reduction on this Alo with another, producing a reduced Alo
+     * Create an {@link AloFactory} that will be used to "fan in" the provided list of Alos which
+     * reference the same type of data item as this one. Defaults to {@link Alo#propagator()}.
      *
-     * @param reducer The reduction to apply
-     * @param other   The other Alo to apply reduction with
-     * @return a reduced Alo
+     * @param alos The list of Alos to be "fanned in"
+     * @return An AloFactory that will later be used to create a "fanned in" result
      */
-    default Alo<T> reduce(BinaryOperator<T> reducer, Alo<? extends T> other) {
-        Runnable acknowledger = AloOps.combineAcknowledgers(getAcknowledger(), other.getAcknowledger());
-        Consumer<Throwable> nacknowledger = AloOps.combineNacknowledgers(getNacknowledger(), other.getNacknowledger());
-        return this.<T>propagator().create(reducer.apply(get(), other.get()), acknowledger, nacknowledger);
+    default AloFactory<List<T>> fanInPropagator(List<Alo<T>> alos) {
+        return propagator();
     }
 
     /**

--- a/core/src/main/java/io/atleon/core/AloFactory.java
+++ b/core/src/main/java/io/atleon/core/AloFactory.java
@@ -1,8 +1,6 @@
 package io.atleon.core;
 
-import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 /**
  * Factory for creating implementations of {@link Alo}
@@ -11,17 +9,6 @@ import java.util.stream.Collectors;
  */
 @FunctionalInterface
 public interface AloFactory<T> {
-
-    static <T> Alo<List<T>> invertList(List<Alo<T>> list, AloFactory<List<T>> factory) {
-        List<T> values = list.stream().map(Alo::get).collect(Collectors.toList());
-        Runnable acknowledger = list.stream()
-            .map(Alo::getAcknowledger)
-            .collect(Collectors.collectingAndThen(Collectors.toList(), AloOps::combineAcknowledgers));
-        Consumer<? super Throwable> nacknowledger = list.stream()
-            .map(Alo::getNacknowledger)
-            .collect(Collectors.collectingAndThen(Collectors.toList(), AloOps::combineNacknowledgers));
-        return factory.create(values, acknowledger, nacknowledger);
-    }
 
     Alo<T> create(T t, Runnable acknowledger, Consumer<? super Throwable> nacknowedger);
 }

--- a/core/src/main/java/io/atleon/core/AloFlux.java
+++ b/core/src/main/java/io/atleon/core/AloFlux.java
@@ -198,47 +198,14 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
      * @see Flux#bufferTimeout(int, Duration)
      */
     public AloFlux<List<T>> bufferTimeout(int maxSize, Duration maxTime) {
-        return bufferTimeout(maxSize, maxTime, Schedulers.parallel(), buffer -> buffer.get(0).propagator());
+        return bufferTimeout(maxSize, maxTime, Schedulers.parallel());
     }
 
     /**
      * @see Flux#bufferTimeout(int, Duration, Scheduler)
      */
     public AloFlux<List<T>> bufferTimeout(int maxSize, Duration maxTime, Scheduler scheduler) {
-        return bufferTimeout(maxSize, maxTime, scheduler, buffer -> buffer.get(0).propagator());
-    }
-
-    /**
-     * Same {@link AloFlux#bufferTimeout(int, Duration, Scheduler, Function)} with default
-     * Scheduler of {@link Schedulers#parallel()}
-     */
-    public AloFlux<List<T>> bufferTimeout(
-        int maxSize,
-        Duration maxTime,
-        Function<? super List<Alo<T>>, AloFactory<List<T>>> bufferToAloFactory) {
-        return bufferTimeout(maxSize, maxTime, Schedulers.parallel(), bufferToAloFactory);
-    }
-
-    /**
-     * With the same semantics as {@link Flux#bufferTimeout(int, Duration, Scheduler)}, this
-     * operator causes items to be buffered in to Lists within bounded size and time. The one
-     * nuance to this method is the provided Function which produces an {@link AloFactory} which is
-     * used to create an implementation of Alo that wraps the buffered data items.
-     *
-     * @param maxSize            the max collected size
-     * @param maxTime            the timeout enforcing the release of a partial buffer
-     * @param scheduler          a time-capable Scheduler instance to run on
-     * @param bufferToAloFactory Function that provides an AloFactory to wrap list of items
-     * @return An AloFlux that buffers upstream elements in bounded size and time
-     */
-    public AloFlux<List<T>> bufferTimeout(
-        int maxSize,
-        Duration maxTime,
-        Scheduler scheduler,
-        Function<? super List<Alo<T>>, AloFactory<List<T>>> bufferToAloFactory) {
-        return wrapped.bufferTimeout(maxSize, maxTime, scheduler)
-            .map(buffer -> AloFactory.invertList(buffer, bufferToAloFactory.apply(buffer)))
-            .as(AloFlux::wrap);
+        return wrapped.bufferTimeout(maxSize, maxTime, scheduler).map(AloOps::fanIn).as(AloFlux::wrap);
     }
 
     /**

--- a/core/src/main/java/io/atleon/core/AloOps.java
+++ b/core/src/main/java/io/atleon/core/AloOps.java
@@ -5,13 +5,14 @@ import org.reactivestreams.Publisher;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.function.BinaryOperator;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
- * Common utility methods associated with operations on Alo and components
+ * Common utility methods associated with operations on Alo and related components
  */
 final class AloOps {
 
@@ -19,8 +20,10 @@ final class AloOps {
 
     }
 
-    public static <T, A extends Alo<T>> Predicate<A>
-    filtering(Predicate<? super T> predicate, Consumer<? super A> negativeConsumer) {
+    public static <T, A extends Alo<T>> Predicate<A> filtering(
+        Predicate<? super T> predicate,
+        Consumer<? super A> negativeConsumer
+    ) {
         return alo -> {
             try {
                 boolean result = predicate.test(alo.get());
@@ -46,8 +49,10 @@ final class AloOps {
         };
     }
 
-    public static <T, R> Function<Alo<T>, Collection<Alo<R>>>
-    mappingToMany(Function<? super T, ? extends Collection<R>> mapper, Consumer<? super Alo<T>> emptyMappingConsumer) {
+    public static <T, R> Function<Alo<T>, Collection<Alo<R>>> mappingToMany(
+        Function<? super T, ? extends Collection<R>> mapper,
+        Consumer<? super Alo<T>> emptyMappingConsumer
+    ) {
         return alo -> {
             try {
                 Alo<Collection<R>> result = alo.map(mapper);
@@ -64,8 +69,7 @@ final class AloOps {
         };
     }
 
-    public static <T, R> Function<Alo<T>, Publisher<Alo<R>>>
-    publishing(Function<? super T, ? extends Publisher<R>> mapper) {
+    public static <T, R> Function<Alo<T>, Publisher<Alo<R>>> publishing(Function<? super T, ? extends Publisher<R>> mapper) {
         return alo -> {
             try {
                 return AcknowledgingPublisher.fromAloPublisher(alo.map(mapper));
@@ -76,48 +80,26 @@ final class AloOps {
         };
     }
 
-    public static <T> BinaryOperator<Alo<T>> reducing(BinaryOperator<T> reducer) {
-        return (alo1, alo2) -> {
-            try {
-                return alo1.reduce(reducer, alo2);
-            } catch (Throwable error) {
-                Alo.nacknowledge(alo1, error);
-                Alo.nacknowledge(alo2, error);
-                throw Throwing.propagate(error);
-            }
-        };
+    public static <T> Alo<List<T>> fanIn(List<Alo<T>> alos) {
+        Alo<T> firstAlo = alos.get(0);
+        if (alos.size() == 1) {
+            return firstAlo.map(Collections::singletonList);
+        } else {
+            return firstAlo.fanInPropagator(alos).create(
+                alos.stream().map(Alo::get).collect(Collectors.toList()),
+                combineAcknowledgers(alos.stream().map(Alo::getAcknowledger).collect(Collectors.toList())),
+                combineNacknowledgers(alos.stream().map(Alo::getNacknowledger).collect(Collectors.toList()))
+            );
+        }
     }
 
-    public static Runnable combineAcknowledgers(Iterable<? extends Runnable> acknowledgers) {
+    private static Runnable combineAcknowledgers(Iterable<? extends Runnable> acknowledgers) {
         return () -> acknowledgers.forEach(Runnable::run);
     }
 
-    public static Consumer<? super Throwable>
-    combineNacknowledgers(Iterable<? extends Consumer<? super Throwable>> nacknowledgers) {
+    private static Consumer<? super Throwable> combineNacknowledgers(
+        Iterable<? extends Consumer<? super Throwable>> nacknowledgers
+    ) {
         return error -> nacknowledgers.forEach(nacknowledger -> nacknowledger.accept(error));
-    }
-
-    /**
-     * Convenience method for combining Acknowledgers. Acknowledgers will be run in the same order
-     * that they are provided
-     */
-    public static Runnable combineAcknowledgers(Runnable acknowledger1, Runnable acknowledger2) {
-        return () -> {
-            acknowledger1.run();
-            acknowledger2.run();
-        };
-    }
-
-    /**
-     * Convenience method for combining Nacknowledgers. Nacknowledgers will be run in the same
-     * order that they are provided
-     */
-    public static Consumer<Throwable> combineNacknowledgers(
-        Consumer<? super Throwable> nacknowledger1,
-        Consumer<? super Throwable> nacknowledger2) {
-        return error -> {
-            nacknowledger1.accept(error);
-            nacknowledger2.accept(error);
-        };
     }
 }

--- a/core/src/main/java/io/atleon/core/AloQueueingSubscriber.java
+++ b/core/src/main/java/io/atleon/core/AloQueueingSubscriber.java
@@ -64,7 +64,7 @@ final class AloQueueingSubscriber<T, A extends Alo<T>> implements Subscriber<A>,
 
     @Override
     public void onNext(A a) {
-        AcknowledgementQueue queue = queuesByGroup.computeIfAbsent(groupExtractor.apply(a.get()), group -> queueSupplier.get());
+        AcknowledgementQueue queue = queuesByGroup.computeIfAbsent(groupExtractor.apply(a.get()), __ -> queueSupplier.get());
 
         AcknowledgementQueue.InFlight inFlight = queue.add(a.getAcknowledger(), a.getNacknowledger());
 

--- a/core/src/main/java/io/atleon/core/Deduplication.java
+++ b/core/src/main/java/io/atleon/core/Deduplication.java
@@ -31,6 +31,10 @@ public interface Deduplication<T> {
 
     class Identity<T> implements Deduplication<T> {
 
+        private Identity() {
+
+        }
+
         @Override
         public Object extractKey(T t) {
             return t;


### PR DESCRIPTION
### :pencil: Description
`Alo` implementations will now have the ability to be aware of the fact that other `Alo`s are being "fanned in" vs. propagated to downstream results. This has resulted in several simplifications as well as future abilities:
1. Removed exposure of how to create Alo items from microbatches in `AloFlux`
2. No longer need to expose how to "invert" List of Alo to Alo of List. Relocated and simplified.
3. Future `Alo` implementations will be able to do interesting things, like link to multiple contexts, when data is fanned-in through operations like microbatching and deduplication

### :link: Related Issues
#91 