### PR TITLE
#86: Add Opentracing integration

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -64,6 +64,16 @@
             </dependency>
             <dependency>
                 <groupId>io.atleon</groupId>
+                <artifactId>atleon-opentracing</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.atleon</groupId>
+                <artifactId>atleon-opentracing-auto</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.atleon</groupId>
                 <artifactId>atleon-polling</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/core/src/main/java/io/atleon/core/AbstractDecoratingAlo.java
+++ b/core/src/main/java/io/atleon/core/AbstractDecoratingAlo.java
@@ -1,0 +1,26 @@
+package io.atleon.core;
+
+import java.util.function.Function;
+
+/**
+ * Base implementation for a {@link DelegatingAlo} that decorates the delegation of invocations
+ * to another {@link Alo}.
+ *
+ * @param <T> The type of data item exposed by the decorated {@link Alo}
+ */
+public abstract class AbstractDecoratingAlo<T> extends AbstractDelegatingAlo<T, T> {
+
+    protected AbstractDecoratingAlo(Alo<T> delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public <R> Alo<R> map(Function<? super T, ? extends R> mapper) {
+        return delegate.map(mapper);
+    }
+
+    @Override
+    public T get() {
+        return delegate.get();
+    }
+}

--- a/core/src/test/java/io/atleon/core/AloDecoratorConfigTest.java
+++ b/core/src/test/java/io/atleon/core/AloDecoratorConfigTest.java
@@ -1,0 +1,19 @@
+package io.atleon.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AloDecoratorConfigTest {
+
+    @Test
+    public void decoratorsAreAutoLoadedIfNotSpecifiedDirectly() {
+        Optional<AloDecorator<Object>> decorator = AloDecoratorConfig.load(AloDecorator.class, Collections.emptyMap(), "");
+
+        assertTrue(decorator.isPresent());
+        assertTrue(decorator.get() instanceof TestAloDecorator);
+    }
+}

--- a/core/src/test/java/io/atleon/core/TestAloDecorator.java
+++ b/core/src/test/java/io/atleon/core/TestAloDecorator.java
@@ -1,0 +1,8 @@
+package io.atleon.core;
+
+public class TestAloDecorator<T> implements AloDecorator<T> {
+    @Override
+    public Alo<T> decorate(Alo<T> alo) {
+        return alo;
+    }
+}

--- a/core/src/test/resources/META-INF/services/io.atleon.core.AloDecorator
+++ b/core/src/test/resources/META-INF/services/io.atleon.core.AloDecorator
@@ -1,0 +1,1 @@
+io.atleon.core.TestAloDecorator

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,10 @@ The following Kafka [End to End to End](core/src/main/java/io/atleon/examples/en
 [Kafka Deduplication](core/src/main/java/io/atleon/examples/deduplication/KafkaDeduplication.java) shows how to add deduplication to the processing of a Kafka topic. This example maintains the incorporation of [Acknowledgement](../core/src/main/java/io/atleon/core/Alo.java) propagation such as to maintain at-least-once processing guarantee
 
 ## Metrics
-[Kafka Metrics](core/src/main/java/io/atleon/examples/metrics/KafkaMetrics.java) shows how Atleon integrates with Micrometer to provide Metrics from native Kafka Reporting and from available Metric transformation in streaming processes
+[Kafka Micrometer](core/src/main/java/io/atleon/examples/metrics/KafkaMicrometer.java) shows how Atleon integrates with Micrometer to provide Metrics from native Kafka Reporting and from available Metric transformation in streaming processes
+
+## Tracing
+[Kafka Opentracing](core/src/main/java/io/atleon/examples/tracing/KafkaOpentracing.java) shows how Atleon integrates with Opentracing to provide traces in reactive pipelines
 
 ## Spring
 [Example Kafka Application](spring/src/main/java/io/atleon/examples/spring/kafka/ExampleKafkaApplication.java) demonstrates general intended usage of Atleon in Spring (Boot) applications

--- a/examples/core/pom.xml
+++ b/examples/core/pom.xml
@@ -47,6 +47,14 @@
             <artifactId>micrometer-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
         </dependency>
@@ -57,6 +65,13 @@
         <dependency>
             <groupId>org.reactivestreams</groupId>
             <artifactId>reactive-streams</artifactId>
+        </dependency>
+
+        <!-- Project Runtime Dependencies -->
+        <dependency>
+            <groupId>io.atleon</groupId>
+            <artifactId>atleon-opentracing-auto</artifactId>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 </project>

--- a/examples/core/src/main/java/io/atleon/examples/tracing/KafkaOpentracing.java
+++ b/examples/core/src/main/java/io/atleon/examples/tracing/KafkaOpentracing.java
@@ -1,0 +1,114 @@
+package io.atleon.examples.tracing;
+
+import io.atleon.core.Alo;
+import io.atleon.kafka.AloKafkaReceiver;
+import io.atleon.kafka.AloKafkaSender;
+import io.atleon.kafka.KafkaConfigSource;
+import io.atleon.kafka.embedded.EmbeddedKafka;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.GlobalTracer;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import reactor.core.publisher.Flux;
+
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class KafkaOpentracing {
+
+    private static final String BOOTSTRAP_SERVERS = EmbeddedKafka.startAndGetBootstrapServersConnect();
+
+    private static final String TOPIC_1 = "TOPIC_1";
+
+    private static final String TOPIC_2 = "TOPIC_2";
+
+    public static void main(String[] args) {
+        //Step 1) Create Kafka Config for Producer that backs Sender
+        KafkaConfigSource kafkaSenderConfig = KafkaConfigSource.useClientIdAsName()
+            .with(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
+            .with(CommonClientConfigs.CLIENT_ID_CONFIG, KafkaOpentracing.class.getSimpleName())
+            .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
+            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
+            .with(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1)
+            .with(ProducerConfig.ACKS_CONFIG, "all");
+
+        //Step 2) Create Kafka Config for Consumer that backs Receiver
+        KafkaConfigSource kafkaReceiverConfig = KafkaConfigSource.useClientIdAsName()
+            .with(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
+            .with(CommonClientConfigs.CLIENT_ID_CONFIG, KafkaOpentracing.class.getSimpleName())
+            .with(ConsumerConfig.GROUP_ID_CONFIG, KafkaOpentracing.class.getSimpleName())
+            .with(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+            .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName())
+            .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+
+        //Step 3) Install a Tracer to the GlobalTracer registry. Note that tracing is automatically
+        // activated due to a dependency on atleon-opentracing-auto
+        MockTracer tracer = new MockTracer();
+        GlobalTracer.registerIfAbsent(tracer);
+
+        //Step 4) Create an AloKafkaSender with which we'll send records
+        AloKafkaSender<String, String> sender = AloKafkaSender.from(kafkaSenderConfig);
+
+        //Step 5) Produce records to our input topic
+        int numToEmit = 2;
+        Flux.range(1, numToEmit)
+            .map(index -> "test-" + index)
+            .transform(sender.sendValues(TOPIC_1, Function.identity()))
+            .then().block();
+
+        //Step 6) Process the records we produced to another topic
+        int numToCombine = 2;
+        AloKafkaReceiver.<String, String>from(kafkaReceiverConfig)
+            .receiveAloValues(TOPIC_1)
+            .bufferTimeout(numToCombine, Duration.ofNanos(Long.MAX_VALUE))
+            .map(strings -> String.join(" ", strings))
+            .transform(sender.sendAloValues(TOPIC_2, Function.identity()))
+            .consumeAloAndGet(Alo::acknowledge)
+            .take(numToEmit / numToCombine)
+            .collectList()
+            .doOnNext(results -> System.out.println("Sender Results: " + results))
+            .block();
+
+        //Before printing, sort the finished Spans by start time (then ID) such that they are
+        //easier to read below
+        List<MockSpan> sortedSpans = tracer.finishedSpans().stream()
+            .sorted(Comparator.comparing(MockSpan::startMicros).thenComparing(mockSpan -> mockSpan.context().spanId()))
+            .collect(Collectors.toList());
+
+        //This will print out all the spans
+        System.out.println("Number of Spans: " + sortedSpans.size());
+        for (int i = 0; i < sortedSpans.size(); i++) {
+            System.out.printf("================ Span #%d ================%n", i + 1);
+            System.out.println("Trace ID: " + sortedSpans.get(i).context().traceId());
+            System.out.println("Span ID: " + sortedSpans.get(i).context().spanId());
+            System.out.println("Parentage: " + extractParentage(sortedSpans.get(i)));
+            System.out.println("Operation Name: " + sortedSpans.get(i).operationName());
+
+            List<MockSpan.LogEntry> logEntries = sortedSpans.get(i).logEntries();
+            System.out.println("Number of Log Entries: " + logEntries.size());
+            for (int j = 0; j < logEntries.size(); j++) {
+                MockSpan.LogEntry entry = logEntries.get(j);
+                System.out.printf("Log Entry #%d: timestamp=%d fields=%s%n", j, entry.timestampMicros(), entry.fields());
+            }
+        }
+
+        System.exit(0);
+    }
+
+    private static String extractParentage(MockSpan mockSpan) {
+        if (mockSpan.references().isEmpty()) {
+            return "Root Span";
+        } else {
+            return mockSpan.references().stream()
+                .map(reference -> "{type:" + reference.getReferenceType() + ", id:" + reference.getContext().spanId() + "}")
+                .collect(Collectors.joining(", ", "[", "]"));
+        }
+    }
+}

--- a/examples/spring/pom.xml
+++ b/examples/spring/pom.xml
@@ -112,6 +112,13 @@
             <artifactId>sqs</artifactId>
         </dependency>
 
+        <!-- Project Runtime Dependencies -->
+        <dependency>
+            <groupId>io.atleon</groupId>
+            <artifactId>atleon-opentracing-auto</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Third Party Runtime Dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/opentracing-auto/pom.xml
+++ b/opentracing-auto/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.atleon</groupId>
+        <artifactId>atleon-parent</artifactId>
+        <version>0.9.2-SNAPSHOT</version>
+        <relativePath>../parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>atleon-opentracing-auto</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <!-- Project Runtime Dependencies -->
+        <dependency>
+            <groupId>io.atleon</groupId>
+            <artifactId>atleon-opentracing</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/opentracing-auto/src/main/resources/META-INF/services/io.atleon.aws.sqs.AloReceivedSqsMessageDecorator
+++ b/opentracing-auto/src/main/resources/META-INF/services/io.atleon.aws.sqs.AloReceivedSqsMessageDecorator
@@ -1,0 +1,1 @@
+io.atleon.opentracing.TracingAloReceivedSqsMessageDecorator

--- a/opentracing-auto/src/main/resources/META-INF/services/io.atleon.kafka.AloKafkaConsumerRecordDecorator
+++ b/opentracing-auto/src/main/resources/META-INF/services/io.atleon.kafka.AloKafkaConsumerRecordDecorator
@@ -1,0 +1,1 @@
+io.atleon.opentracing.TracingAloKafkaConsumerRecordDecorator

--- a/opentracing-auto/src/main/resources/META-INF/services/io.atleon.rabbitmq.AloRabbitMQMessageDecorator
+++ b/opentracing-auto/src/main/resources/META-INF/services/io.atleon.rabbitmq.AloRabbitMQMessageDecorator
@@ -1,0 +1,1 @@
+io.atleon.opentracing.TracingAloRabbitMQMessageDecorator

--- a/opentracing/pom.xml
+++ b/opentracing/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.atleon</groupId>
+        <artifactId>atleon-parent</artifactId>
+        <version>0.9.2-SNAPSHOT</version>
+        <relativePath>../parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>atleon-opentracing</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <!-- Third Party Compile Dependencies -->
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-util</artifactId>
+        </dependency>
+
+        <!-- Project Provided Dependencies -->
+        <dependency>
+            <groupId>io.atleon</groupId>
+            <artifactId>atleon-aws-sqs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.atleon</groupId>
+            <artifactId>atleon-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.atleon</groupId>
+            <artifactId>atleon-kafka</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.atleon</groupId>
+            <artifactId>atleon-rabbitmq</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.atleon</groupId>
+            <artifactId>atleon-util</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Third Party Provided Dependencies -->
+        <dependency>
+            <groupId>com.rabbitmq</groupId>
+            <artifactId>amqp-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sqs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Third Party Test Dependencies -->
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/opentracing/src/main/java/io/atleon/opentracing/ConsumerTracing.java
+++ b/opentracing/src/main/java/io/atleon/opentracing/ConsumerTracing.java
@@ -1,0 +1,29 @@
+package io.atleon.opentracing;
+
+import io.atleon.util.Configurable;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMapAdapter;
+import io.opentracing.tag.Tags;
+
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class ConsumerTracing implements Configurable {
+
+    private final TracerFacade tracerFacade = TracerFacade.global();
+
+    protected Tracer.SpanBuilder newSpanBuilder(String operationName) {
+        return tracerFacade.newSpanBuilder(operationName)
+            .withTag(Tags.SPAN_KIND, Tags.SPAN_KIND_CONSUMER);
+    }
+
+    protected Optional<SpanContext> extractSpanContext(Map<String, String> headerMap) {
+        return tracerFacade.extract(Format.Builtin.TEXT_MAP, new TextMapAdapter(headerMap));
+    }
+
+    protected TracerFacade tracerFacade() {
+        return tracerFacade;
+    }
+}

--- a/opentracing/src/main/java/io/atleon/opentracing/TracerFacade.java
+++ b/opentracing/src/main/java/io/atleon/opentracing/TracerFacade.java
@@ -1,0 +1,62 @@
+package io.atleon.opentracing;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracer;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Utility methods for consistently building resources from OpenTracing Tracers
+ */
+final class TracerFacade {
+
+    private final Tracer tracer;
+
+    private TracerFacade(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    public static TracerFacade global() {
+        return wrap(GlobalTracer.get());
+    }
+
+    public static TracerFacade wrap(Tracer tracer) {
+        return new TracerFacade(Objects.requireNonNull(tracer));
+    }
+
+    public Tracer.SpanBuilder newSpanBuilder(String operationName) {
+        return tracer.buildSpan(operationName)
+            .ignoreActiveSpan()
+            .withTag(Tags.COMPONENT, "atleon");
+    }
+
+    public <C> Optional<SpanContext> extract(Format<C> format, C carrier) {
+        return Optional.ofNullable(tracer.extract(format, carrier));
+    }
+
+    public void run(Span span, Runnable runnable) {
+        try (Scope ignored = tracer.activateSpan(span)) {
+            runnable.run();
+        }
+    }
+
+    public <T> T supply(Span span, Supplier<T> supplier) {
+        try (Scope ignored = tracer.activateSpan(span)) {
+            return supplier.get();
+        }
+    }
+
+    public <T, U, R> R map(Span span, Function<T, U> mapper, Function<Function<T, U>, R> finalizer) {
+        try (Scope ignored = tracer.activateSpan(span)) {
+            return finalizer.apply(mapper);
+        }
+    }
+}

--- a/opentracing/src/main/java/io/atleon/opentracing/TracingAlo.java
+++ b/opentracing/src/main/java/io/atleon/opentracing/TracingAlo.java
@@ -1,0 +1,150 @@
+package io.atleon.opentracing;
+
+import io.atleon.core.AbstractDecoratingAlo;
+import io.atleon.core.Alo;
+import io.atleon.core.AloFactory;
+import io.atleon.core.DelegatingAlo;
+import io.opentracing.References;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.log.Fields;
+import io.opentracing.tag.Tags;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Decorates {@link Alo} elements with tracing
+ *
+ * @param <T> The type of data item exposed by the decorated {@link Alo}
+ */
+public class TracingAlo<T> extends AbstractDecoratingAlo<T> {
+
+    protected final TracerFacade tracerFacade;
+
+    protected final Span span;
+
+    private TracingAlo(Alo<T> delegate, TracerFacade tracerFacade, Span span) {
+        super(delegate);
+        this.tracerFacade = tracerFacade;
+        this.span = span;
+    }
+
+    public static <T> TracingAlo<T> start(Alo<T> delegate, TracerFacade tracerFacade, Tracer.SpanBuilder spanBuilder) {
+        return new TracingAlo<>(delegate, tracerFacade, spanBuilder.start());
+    }
+
+    @Override
+    public void runInContext(Runnable runnable) {
+        tracerFacade.run(span, runnable);
+    }
+
+    @Override
+    public <R> R supplyInContext(Supplier<R> supplier) {
+        return tracerFacade.supply(span, supplier);
+    }
+
+    @Override
+    public <R> Alo<R> map(Function<? super T, ? extends R> mapper) {
+        Alo<R> result = tracerFacade.map(span, mapper, delegate::map);
+        return new TracingAlo<>(result, tracerFacade, span);
+    }
+
+    @Override
+    public <R> AloFactory<List<R>> fanInPropagator(List<? extends Alo<?>> alos) {
+        Tracer.SpanBuilder spanBuilder = tracerFacade.newSpanBuilder("atleon.fan.in");
+        for (Alo<?> alo : alos) {
+            extractSpanContext(alo).ifPresent(it -> spanBuilder.addReference(References.CHILD_OF, it));
+        }
+        return delegate.<R>fanInPropagator(alos).withDecorator(alo -> start(alo, tracerFacade, spanBuilder));
+    }
+
+    @Override
+    public <R> AloFactory<R> propagator() {
+        return delegate.<R>propagator().withDecorator(alo -> new Propagated<>(alo, tracerFacade, span));
+    }
+
+    @Override
+    public Runnable getAcknowledger() {
+        return applySpanTermination(delegate.getAcknowledger(), span);
+    }
+
+    @Override
+    public Consumer<? super Throwable> getNacknowledger() {
+        return applySpanTermination(delegate.getNacknowledger(), span);
+    }
+
+    public SpanContext spanContext() {
+        return span.context();
+    }
+
+    private static Optional<SpanContext> extractSpanContext(Alo<?> alo) {
+        if (alo instanceof TracingAlo) {
+            return Optional.of(TracingAlo.class.cast(alo).spanContext());
+        } else if (alo instanceof DelegatingAlo) {
+            return extractSpanContext(DelegatingAlo.class.cast(alo).getDelegate());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private static Runnable applySpanTermination(Runnable acknowledger, Span span) {
+        return () -> {
+            try {
+                acknowledger.run();
+            } finally {
+                span.setTag(Tags.ERROR, false);
+                span.finish();
+            }
+        };
+    }
+
+    private static Consumer<Throwable> applySpanTermination(Consumer<? super Throwable> nacknowledger, Span span) {
+        return error -> {
+            try {
+                nacknowledger.accept(error);
+            } finally {
+                span.setTag(Tags.ERROR, true);
+                span.log(createErrorFields(error));
+                span.finish();
+            }
+        };
+    }
+
+    private static Map<String, Object> createErrorFields(Throwable error) {
+        Map<String, Object> fields = new HashMap<>();
+        fields.put(Fields.EVENT, "error");
+        fields.put(Fields.ERROR_KIND, error.getClass().getSimpleName());
+        fields.put(Fields.ERROR_OBJECT, error);
+        return fields;
+    }
+
+    private static final class Propagated<T> extends TracingAlo<T> {
+
+        public Propagated(Alo<T> delegate, TracerFacade tracerFacade, Span span) {
+            super(delegate, tracerFacade, span);
+        }
+
+        @Override
+        public <R> Alo<R> map(Function<? super T, ? extends R> mapper) {
+            Alo<R> result = tracerFacade.map(span, mapper, delegate::map);
+            return new Propagated<>(result, tracerFacade, span);
+        }
+
+        @Override
+        public Runnable getAcknowledger() {
+            return delegate.getAcknowledger();
+        }
+
+        @Override
+        public Consumer<? super Throwable> getNacknowledger() {
+            return delegate.getNacknowledger();
+        }
+    }
+}

--- a/opentracing/src/main/java/io/atleon/opentracing/TracingAloKafkaConsumerRecordDecorator.java
+++ b/opentracing/src/main/java/io/atleon/opentracing/TracingAloKafkaConsumerRecordDecorator.java
@@ -1,0 +1,55 @@
+package io.atleon.opentracing;
+
+import io.atleon.core.Alo;
+import io.atleon.kafka.AloKafkaConsumerRecordDecorator;
+import io.atleon.util.ConfigLoading;
+import io.opentracing.References;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * An {@link AloKafkaConsumerRecordDecorator} that decorates {@link Alo} elements with tracing
+ * context extracted from {@link ConsumerRecord}s
+ *
+ * @param <K> The types of keys in records decorated by this decorator
+ * @param <V> The types of values in records decorated by this decorator
+ */
+public class TracingAloKafkaConsumerRecordDecorator<K, V> extends ConsumerTracing implements AloKafkaConsumerRecordDecorator<K, V> {
+
+    private String groupId = null;
+
+    @Override
+    public void configure(Map<String, ?> properties) {
+        groupId = ConfigLoading.load(properties, ConsumerConfig.GROUP_ID_CONFIG, Function.identity(), groupId);
+    }
+
+    @Override
+    public Alo<ConsumerRecord<K, V>> decorate(Alo<ConsumerRecord<K, V>> alo) {
+        ConsumerRecord<K, V> consumerRecord = alo.get();
+        Tracer.SpanBuilder spanBuilder = newSpanBuilder("atleon.kafka.consume")
+            .withTag("group", groupId)
+            .withTag("topic", consumerRecord.topic())
+            .withTag("partition", consumerRecord.partition())
+            .withTag("offset", consumerRecord.offset());
+        extractSpanContext(consumerRecord)
+            .ifPresent(it -> spanBuilder.addReference(References.FOLLOWS_FROM, it));
+        return TracingAlo.start(alo, tracerFacade(), spanBuilder);
+    }
+
+    protected Optional<SpanContext> extractSpanContext(ConsumerRecord<?, ?> consumerRecord) {
+        Map<String, String> headerMap = new LinkedHashMap<>();
+        for (Header header : consumerRecord.headers()) {
+            headerMap.put(header.key(), new String(header.value(), StandardCharsets.UTF_8));
+        }
+        return extractSpanContext(headerMap);
+    }
+}

--- a/opentracing/src/main/java/io/atleon/opentracing/TracingAloRabbitMQMessageDecorator.java
+++ b/opentracing/src/main/java/io/atleon/opentracing/TracingAloRabbitMQMessageDecorator.java
@@ -1,0 +1,44 @@
+package io.atleon.opentracing;
+
+import com.rabbitmq.client.AMQP;
+import io.atleon.core.Alo;
+import io.atleon.rabbitmq.AloRabbitMQMessageDecorator;
+import io.atleon.rabbitmq.RabbitMQMessage;
+import io.opentracing.References;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * An {@link AloRabbitMQMessageDecorator} that decorates {@link Alo} elements with tracing
+ * context extracted from {@link RabbitMQMessage}s
+ *
+ * @param <T> The types of (deserialized) body payloads referenced by {@link RabbitMQMessage}s
+ */
+public class TracingAloRabbitMQMessageDecorator<T> extends ConsumerTracing implements AloRabbitMQMessageDecorator<T> {
+
+    @Override
+    public Alo<RabbitMQMessage<T>> decorate(Alo<RabbitMQMessage<T>> alo) {
+        RabbitMQMessage<T> rabbitMQMessage = alo.get();
+        Tracer.SpanBuilder spanBuilder = newSpanBuilder("atleon.rabbitmq.consume")
+            .withTag("exchange", rabbitMQMessage.getExchange())
+            .withTag("routingKey", rabbitMQMessage.getRoutingKey());
+        extractSpanContext(rabbitMQMessage)
+            .ifPresent(it -> spanBuilder.addReference(References.FOLLOWS_FROM, it));
+        return TracingAlo.start(alo, tracerFacade(), spanBuilder);
+    }
+
+    protected Optional<SpanContext> extractSpanContext(RabbitMQMessage<?> rabbitMQMessage) {
+        Map<String, Object> headers = Optional.ofNullable(rabbitMQMessage.getProperties())
+            .map(AMQP.BasicProperties::getHeaders)
+            .orElse(Collections.emptyMap());
+        Map<String, String> headerMap = headers.entrySet().stream()
+            .filter(entry -> entry.getValue() != null)
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toString()));
+        return extractSpanContext(headerMap);
+    }
+}

--- a/opentracing/src/main/java/io/atleon/opentracing/TracingAloReceivedSqsMessageDecorator.java
+++ b/opentracing/src/main/java/io/atleon/opentracing/TracingAloReceivedSqsMessageDecorator.java
@@ -1,0 +1,32 @@
+package io.atleon.opentracing;
+
+import io.atleon.aws.sqs.AloReceivedSqsMessageDecorator;
+import io.atleon.aws.sqs.ReceivedSqsMessage;
+import io.atleon.core.Alo;
+import io.opentracing.References;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class TracingAloReceivedSqsMessageDecorator<T> extends ConsumerTracing implements AloReceivedSqsMessageDecorator<T> {
+    @Override
+    public Alo<ReceivedSqsMessage<T>> decorate(Alo<ReceivedSqsMessage<T>> alo) {
+        ReceivedSqsMessage<T> receivedSqsMessage = alo.get();
+        Tracer.SpanBuilder spanBuilder = newSpanBuilder("atleon.aws.sqs.consume")
+            .withTag("receiptHandle", receivedSqsMessage.receiptHandle())
+            .withTag("messageId", receivedSqsMessage.messageId());
+        extractSpanContext(receivedSqsMessage)
+            .ifPresent(it -> spanBuilder.addReference(References.FOLLOWS_FROM, it));
+        return TracingAlo.start(alo, tracerFacade(), spanBuilder);
+    }
+
+    protected Optional<SpanContext> extractSpanContext(ReceivedSqsMessage<?> receivedSqsMessage) {
+        Map<String, String> headerMap = receivedSqsMessage.messageAttributes().entrySet().stream()
+            .filter(entry -> entry.getValue().stringValue() != null)
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().stringValue()));
+        return extractSpanContext(headerMap);
+    }
+}

--- a/opentracing/src/test/java/io/atleon/opentracing/TestAlo.java
+++ b/opentracing/src/test/java/io/atleon/opentracing/TestAlo.java
@@ -1,0 +1,63 @@
+package io.atleon.opentracing;
+
+import io.atleon.core.Alo;
+import io.atleon.core.AloFactory;
+import io.atleon.core.ComposedAlo;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public final class TestAlo implements Alo<String> {
+
+    private final String data;
+
+    private final AtomicInteger acknowledgerCount = new AtomicInteger();
+
+    private final AtomicInteger nacknowledgerCount = new AtomicInteger();
+
+    public TestAlo(String data) {
+        this.data = data;
+    }
+
+    @Override
+    public <R> Alo<R> map(Function<? super String, ? extends R> mapper) {
+        return Alo.super.map(mapper);
+    }
+
+    @Override
+    public <R> AloFactory<R> propagator() {
+        return ComposedAlo.factory();
+    }
+
+    @Override
+    public String get() {
+        return data;
+    }
+
+    @Override
+    public Runnable getAcknowledger() {
+        return acknowledgerCount::incrementAndGet;
+    }
+
+    @Override
+    public Consumer<? super Throwable> getNacknowledger() {
+        return error -> nacknowledgerCount.incrementAndGet();
+    }
+
+    public boolean isAcknowledged() {
+        return acknowledgerCount.get() > 0;
+    }
+
+    public int acknowledgeCount() {
+        return acknowledgerCount.get();
+    }
+
+    public boolean isNacknowledged() {
+        return nacknowledgerCount.get() > 0;
+    }
+
+    public int nacknowledgeCount() {
+        return nacknowledgerCount.get();
+    }
+}

--- a/opentracing/src/test/java/io/atleon/opentracing/TestTracer.java
+++ b/opentracing/src/test/java/io/atleon/opentracing/TestTracer.java
@@ -1,0 +1,300 @@
+package io.atleon.opentracing;
+
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+import io.opentracing.tag.Tag;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestTracer implements Tracer {
+
+    private final List<MockSpan> spans = new ArrayList<>();
+
+    @Override
+    public ScopeManager scopeManager() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Span activeSpan() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Scope activateSpan(Span span) {
+        return new MockScope(MockSpan.class.cast(span));
+    }
+
+    @Override
+    public SpanBuilder buildSpan(String operationName) {
+        return new MockSpanBuilder(operationName);
+    }
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() {
+        throw new UnsupportedOperationException();
+    }
+
+    public List<MockSpan> spans() {
+        return spans;
+    }
+
+    public final class MockSpanBuilder implements SpanBuilder {
+
+        private final String operationName;
+
+        private final List<ReferencedSpanContext> references = new ArrayList<>();
+
+        public MockSpanBuilder(String operationName) {
+            this.operationName = operationName;
+        }
+
+        @Override
+        public SpanBuilder asChildOf(SpanContext parent) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SpanBuilder asChildOf(Span parent) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SpanBuilder addReference(String referenceType, SpanContext referencedContext) {
+            references.add(new ReferencedSpanContext(referenceType, referencedContext));
+            return this;
+        }
+
+        @Override
+        public SpanBuilder ignoreActiveSpan() {
+            return this;
+        }
+
+        @Override
+        public SpanBuilder withTag(String key, String value) {
+            return this;
+        }
+
+        @Override
+        public SpanBuilder withTag(String key, boolean value) {
+            return this;
+        }
+
+        @Override
+        public SpanBuilder withTag(String key, Number value) {
+            return this;
+        }
+
+        @Override
+        public <T> SpanBuilder withTag(Tag<T> tag, T value) {
+            return this;
+        }
+
+        @Override
+        public SpanBuilder withStartTimestamp(long microseconds) {
+            return this;
+        }
+
+        @Override
+        public Span startManual() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Span start() {
+            MockSpan span = new MockSpan(references);
+            spans.add(span);
+            return span;
+        }
+
+        @Override
+        public Scope startActive(boolean finishSpanOnClose) {
+            throw new UnsupportedOperationException();
+        }
+
+        public String operationName() {
+            return operationName;
+        }
+    }
+
+    public static final class MockSpan implements Span {
+
+        private final UUID traceId = UUID.randomUUID();
+
+        private final UUID spanId = UUID.randomUUID();
+
+        private final List<ReferencedSpanContext> references;
+
+        private final AtomicInteger finishCount = new AtomicInteger(0);
+
+        public MockSpan(List<ReferencedSpanContext> references) {
+            this.references = references;
+        }
+
+        @Override
+        public SpanContext context() {
+            return new MockSpanContext(traceId, spanId);
+        }
+
+        @Override
+        public Span setTag(String key, String value) {
+            return this;
+        }
+
+        @Override
+        public Span setTag(String key, boolean value) {
+            return this;
+        }
+
+        @Override
+        public Span setTag(String key, Number value) {
+            return this;
+        }
+
+        @Override
+        public <T> Span setTag(Tag<T> tag, T value) {
+            return this;
+        }
+
+        @Override
+        public Span log(Map<String, ?> fields) {
+            return this;
+        }
+
+        @Override
+        public Span log(long timestampMicroseconds, Map<String, ?> fields) {
+            return this;
+        }
+
+        @Override
+        public Span log(String event) {
+            return this;
+        }
+
+        @Override
+        public Span log(long timestampMicroseconds, String event) {
+            return this;
+        }
+
+        @Override
+        public Span setBaggageItem(String key, String value) {
+            return this;
+        }
+
+        @Override
+        public String getBaggageItem(String key) {
+            return null;
+        }
+
+        @Override
+        public Span setOperationName(String operationName) {
+            return this;
+        }
+
+        @Override
+        public void finish() {
+            finishCount.incrementAndGet();
+        }
+
+        @Override
+        public void finish(long finishMicros) {
+            finish();
+        }
+
+        public List<ReferencedSpanContext> references() {
+            return references;
+        }
+
+        public int finishCount() {
+            return finishCount.get();
+        }
+    }
+
+    public static final class MockSpanContext implements SpanContext {
+
+        private final UUID traceId;
+
+        private final UUID spanId;
+
+        public MockSpanContext(UUID traceId, UUID spanId) {
+            this.traceId = traceId;
+            this.spanId = spanId;
+        }
+
+        @Override
+        public String toTraceId() {
+            return traceId.toString();
+        }
+
+        @Override
+        public String toSpanId() {
+            return spanId.toString();
+        }
+
+        @Override
+        public Iterable<Map.Entry<String, String>> baggageItems() {
+            return Collections.emptyList();
+        }
+    }
+
+    public static final class MockScope implements Scope {
+
+        private final MockSpan span;
+
+        private final AtomicBoolean closed = new AtomicBoolean(false);
+
+        public MockScope(MockSpan span) {
+            this.span = span;
+        }
+
+        @Override
+        public void close() {
+            closed.set(true);
+        }
+
+        @Override
+        public MockSpan span() {
+            return span;
+        }
+    }
+
+    private static final class ReferencedSpanContext {
+
+        private final String referenceType;
+
+        private final SpanContext spanContext;
+
+        private ReferencedSpanContext(String referenceType, SpanContext spanContext) {
+            this.referenceType = referenceType;
+            this.spanContext = spanContext;
+        }
+
+        public String referenceType() {
+            return referenceType;
+        }
+
+        public SpanContext spanContext() {
+            return spanContext;
+        }
+    }
+}

--- a/opentracing/src/test/java/io/atleon/opentracing/TracingAloTest.java
+++ b/opentracing/src/test/java/io/atleon/opentracing/TracingAloTest.java
@@ -1,0 +1,97 @@
+package io.atleon.opentracing;
+
+import io.atleon.core.Alo;
+import io.atleon.core.AloFlux;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TracingAloTest {
+
+    private final TestTracer tracer = new TestTracer();
+
+    private final TracerFacade tracerFacade = TracerFacade.wrap(tracer);
+
+    @Test
+    public void aloWrappedInTracingIsOnlyAcknowledgedOnceWhenMapped() {
+        TestAlo alo = new TestAlo("I said what what");
+        TracingAlo<String> tracingAlo = TracingAlo.start(alo, tracerFacade, tracerFacade.newSpanBuilder("test"));
+
+        AloFlux.wrap(Flux.just(tracingAlo))
+            .map(string -> string.substring(0, 11))
+            .map(String::toUpperCase)
+            .consumeAloAndGet(Alo::acknowledge)
+            .then()
+            .block();
+
+        assertEquals(1, alo.acknowledgeCount());
+        assertEquals(0, alo.nacknowledgeCount());
+        assertEquals(1, tracer.spans().size());
+        assertEquals(1, tracer.spans().get(0).finishCount());
+    }
+
+    @Test
+    public void aloWrappedInTracingIsOnlyAcknowledgedOnceWhenPublished() {
+        TestAlo alo = new TestAlo("I said what what");
+        TracingAlo<String> tracingAlo = TracingAlo.start(alo, tracerFacade, tracerFacade.newSpanBuilder("test"));
+
+        AloFlux.wrap(Flux.just(tracingAlo))
+            .concatMap(string -> Mono.just(string).map(it -> it.substring(0, 11)))
+            .concatMap(string -> Mono.just(string).map(String::toUpperCase))
+            .consumeAloAndGet(Alo::acknowledge)
+            .then()
+            .block();
+
+        assertEquals(1, alo.acknowledgeCount());
+        assertEquals(0, alo.nacknowledgeCount());
+        assertEquals(1, tracer.spans().size());
+        assertEquals(1, tracer.spans().get(0).finishCount());
+    }
+
+    @Test
+    public void aloWrappedInTracingIsOnlyAcknowledgedOnceWhenMappingAndPublishing() {
+        TestAlo alo = new TestAlo("I said what what");
+        TracingAlo<String> tracingAlo = TracingAlo.start(alo, tracerFacade, tracerFacade.newSpanBuilder("test"));
+
+        AloFlux.wrap(Flux.just(tracingAlo))
+            .concatMap(string -> Mono.just(string).map(it -> it.substring(0, 11)))
+            .map(String::toUpperCase)
+            .concatMap(string -> Mono.just(string).map(it -> it.substring(0, 6)))
+            .map(String::toLowerCase)
+            .consumeAloAndGet(Alo::acknowledge)
+            .then()
+            .block();
+
+        assertEquals(1, alo.acknowledgeCount());
+        assertEquals(0, alo.nacknowledgeCount());
+        assertEquals(1, tracer.spans().size());
+        assertEquals(1, tracer.spans().get(0).finishCount());
+    }
+
+    @Test
+    public void fannedInAlosResultInMergedSpan() {
+        TestAlo alo1 = new TestAlo("I said what what");
+        TestAlo alo2 = new TestAlo("in the you know where");
+
+        TracingAlo<String> tracingAlo1 = TracingAlo.start(alo1, tracerFacade, tracerFacade.newSpanBuilder("test"));
+        TracingAlo<String> tracingAlo2 = TracingAlo.start(alo2, tracerFacade, tracerFacade.newSpanBuilder("test"));
+
+        AloFlux.wrap(Flux.just(tracingAlo1, tracingAlo2))
+            .bufferTimeout(2, Duration.ofNanos(Long.MAX_VALUE))
+            .map(strings -> String.join(" ", strings))
+            .consumeAloAndGet(Alo::acknowledge)
+            .then()
+            .block();
+
+        assertEquals(1, alo1.acknowledgeCount());
+        assertEquals(0, alo1.nacknowledgeCount());
+        assertEquals(1, alo2.acknowledgeCount());
+        assertEquals(0, alo2.nacknowledgeCount());
+        assertEquals(3, tracer.spans().size());
+        assertEquals(2, tracer.spans().get(2).references().size());
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -21,6 +21,7 @@
         <javassist.version>3.27.0-GA</javassist.version>
         <junit-jupiter.version>5.6.3</junit-jupiter.version>
         <micrometer.version>1.0.7</micrometer.version>
+        <opentracing.verion>0.32.0</opentracing.verion>
         <rabbitmq-amqp-client.version>5.13.1</rabbitmq-amqp-client.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <reactor.version>3.4.12</reactor.version>
@@ -76,6 +77,16 @@
             <dependency>
                 <groupId>io.atleon</groupId>
                 <artifactId>atleon-kafka-embedded</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.atleon</groupId>
+                <artifactId>atleon-opentracing</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.atleon</groupId>
+                <artifactId>atleon-opentracing-auto</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -169,6 +180,21 @@
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-core</artifactId>
                 <version>${micrometer.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing</groupId>
+                <artifactId>opentracing-api</artifactId>
+                <version>${opentracing.verion}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing</groupId>
+                <artifactId>opentracing-mock</artifactId>
+                <version>${opentracing.verion}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing</groupId>
+                <artifactId>opentracing-util</artifactId>
+                <version>${opentracing.verion}</version>
             </dependency>
             <dependency>
                 <groupId>io.projectreactor</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,8 @@
         <module>kafka-avro</module>
         <module>kafka-embedded</module>
         <module>micrometer</module>
+        <module>opentracing</module>
+        <module>opentracing-auto</module>
         <module>parent</module>
         <module>polling</module>
         <module>rabbitmq</module>


### PR DESCRIPTION
### :pencil: Description
- Add `AloDecorator`s for Opentracing on available Receviers
- Include auto-decoration functionality through `ServiceLoader`

### :link: Related Issues
#86 