### PR TITLE
#109: Smarter Config Loading

### DIFF
--- a/aws-sns/src/main/java/io/atleon/aws/sns/AloSnsSender.java
+++ b/aws-sns/src/main/java/io/atleon/aws/sns/AloSnsSender.java
@@ -159,12 +159,15 @@ public class AloSnsSender<T> implements Closeable {
 
         public static <T> Resources<T> fromConfig(SnsConfig config) {
             SnsSenderOptions options = SnsSenderOptions.newBuilder(config::buildClient)
-                .batchSize(config.loadInt(BATCH_SIZE_CONFIG, SnsSenderOptions.DEFAULT_BATCH_SIZE))
-                .batchDuration(config.loadDuration(BATCH_DURATION_CONFIG, SnsSenderOptions.DEFAULT_BATCH_DURATION))
-                .batchPrefetch(config.loadInt(BATCH_PREFETCH_CONFIG, SnsSenderOptions.DEFAULT_BATCH_PREFETCH))
-                .maxRequestsInFlight(config.loadInt(MAX_REQUESTS_IN_FLIGHT_CONFIG, SnsSenderOptions.DEFAULT_MAX_REQUESTS_IN_FLIGHT))
+                .batchSize(config.loadInt(BATCH_SIZE_CONFIG).orElse(SnsSenderOptions.DEFAULT_BATCH_SIZE))
+                .batchDuration(config.loadDuration(BATCH_DURATION_CONFIG).orElse(SnsSenderOptions.DEFAULT_BATCH_DURATION))
+                .batchPrefetch(config.loadInt(BATCH_PREFETCH_CONFIG).orElse(SnsSenderOptions.DEFAULT_BATCH_PREFETCH))
+                .maxRequestsInFlight(config.loadInt(MAX_REQUESTS_IN_FLIGHT_CONFIG).orElse(SnsSenderOptions.DEFAULT_MAX_REQUESTS_IN_FLIGHT))
                 .build();
-            return new Resources<>(SnsSender.create(options), config.loadConfiguredOrThrow(BODY_SERIALIZER_CONFIG));
+            return new Resources<T>(
+                SnsSender.create(options),
+                config.loadConfiguredOrThrow(BODY_SERIALIZER_CONFIG, BodySerializer.class)
+            );
         }
 
         public Mono<SnsSenderResult<SnsMessage<T>>> send(SnsMessage<T> message, SnsAddress address) {

--- a/aws-sns/src/main/java/io/atleon/aws/sns/SnsConfig.java
+++ b/aws-sns/src/main/java/io/atleon/aws/sns/SnsConfig.java
@@ -5,11 +5,11 @@ import io.atleon.util.ConfigLoading;
 import io.atleon.util.Configurable;
 import software.amazon.awssdk.services.sns.SnsAsyncClient;
 
-import java.net.URI;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Config used by SNS Resources to build Clients and load typed configuration values.
@@ -30,21 +30,21 @@ public final class SnsConfig {
 
     public SnsAsyncClient buildClient() {
         return SnsAsyncClient.builder()
-            .endpointOverride(ConfigLoading.load(properties, ENDPOINT_OVERRIDE_CONFIG, URI::create).orElse(null))
+            .endpointOverride(ConfigLoading.loadUri(properties, ENDPOINT_OVERRIDE_CONFIG).orElse(null))
             .credentialsProvider(AwsConfig.loadCredentialsProvider(properties))
             .region(AwsConfig.loadRegion(properties).orElse(null))
             .build();
     }
 
-    public <T extends Configurable> T loadConfiguredOrThrow(String property) {
-        return ConfigLoading.loadConfiguredOrThrow(properties, property);
+    public <T extends Configurable> T loadConfiguredOrThrow(String property, Class<? extends T> type) {
+        return ConfigLoading.loadConfiguredOrThrow(properties, property, type);
     }
 
-    public Duration loadDuration(String key, Duration defaultValue) {
-        return ConfigLoading.load(properties, key, Duration::parse, defaultValue);
+    public Optional<Duration> loadDuration(String key) {
+        return ConfigLoading.loadDuration(properties, key);
     }
 
-    public int loadInt(String key, int defaultValue) {
-        return ConfigLoading.load(properties, key, Integer::parseInt, defaultValue);
+    public Optional<Integer> loadInt(String key) {
+        return ConfigLoading.loadInt(properties, key);
     }
 }

--- a/aws-sqs/src/main/java/io/atleon/aws/sqs/AloSqsSender.java
+++ b/aws-sqs/src/main/java/io/atleon/aws/sqs/AloSqsSender.java
@@ -152,12 +152,15 @@ public class AloSqsSender<T> implements Closeable {
 
         public static <T> Resources<T> fromConfig(SqsConfig config) {
             SqsSenderOptions options = SqsSenderOptions.newBuilder(config::buildClient)
-                .batchSize(config.loadInt(BATCH_SIZE_CONFIG, SqsSenderOptions.DEFAULT_BATCH_SIZE))
-                .batchDuration(config.loadDuration(BATCH_DURATION_CONFIG, SqsSenderOptions.DEFAULT_BATCH_DURATION))
-                .batchPrefetch(config.loadInt(BATCH_PREFETCH_CONFIG, SqsSenderOptions.DEFAULT_BATCH_PREFETCH))
-                .maxRequestsInFlight(config.loadInt(MAX_REQUESTS_IN_FLIGHT_CONFIG, SqsSenderOptions.DEFAULT_MAX_REQUESTS_IN_FLIGHT))
+                .batchSize(config.loadInt(BATCH_SIZE_CONFIG).orElse(SqsSenderOptions.DEFAULT_BATCH_SIZE))
+                .batchDuration(config.loadDuration(BATCH_DURATION_CONFIG).orElse(SqsSenderOptions.DEFAULT_BATCH_DURATION))
+                .batchPrefetch(config.loadInt(BATCH_PREFETCH_CONFIG).orElse(SqsSenderOptions.DEFAULT_BATCH_PREFETCH))
+                .maxRequestsInFlight(config.loadInt(MAX_REQUESTS_IN_FLIGHT_CONFIG).orElse(SqsSenderOptions.DEFAULT_MAX_REQUESTS_IN_FLIGHT))
                 .build();
-            return new Resources<>(SqsSender.create(options), config.loadConfiguredOrThrow(BODY_SERIALIZER_CONFIG));
+            return new Resources<T>(
+                SqsSender.create(options),
+                config.loadConfiguredOrThrow(BODY_SERIALIZER_CONFIG, BodySerializer.class)
+            );
         }
 
         public Mono<SqsSenderResult<SqsMessage<T>>> send(SqsMessage<T> message, String queueUrl) {

--- a/aws-sqs/src/main/java/io/atleon/aws/sqs/NacknowledgerFactory.java
+++ b/aws-sqs/src/main/java/io/atleon/aws/sqs/NacknowledgerFactory.java
@@ -1,5 +1,6 @@
 package io.atleon.aws.sqs;
 
+import io.atleon.util.ConfigLoading;
 import io.atleon.util.Configurable;
 import org.slf4j.Logger;
 
@@ -15,6 +16,17 @@ import java.util.function.Consumer;
  */
 public interface NacknowledgerFactory<T> extends Configurable {
 
+    /**
+     * When using {@link VisibilityReset} this configures the number of seconds that a
+     * nacknowledged message has its visibility reset by.
+     */
+    String VISIBILITY_RESET_SECONDS_CONFIG = "sqs.nacknowledger.visibility.reset.seconds";
+
+    @Override
+    default void configure(Map<String, ?> properties) {
+
+    }
+
     Consumer<Throwable> create(
         ReceivedSqsMessage<T> message,
         Runnable deleter,
@@ -25,11 +37,6 @@ public interface NacknowledgerFactory<T> extends Configurable {
     final class Emit<T> implements NacknowledgerFactory<T> {
 
         Emit() {
-
-        }
-
-        @Override
-        public void configure(Map<String, ?> properties) {
 
         }
 
@@ -48,16 +55,15 @@ public interface NacknowledgerFactory<T> extends Configurable {
 
         private final Logger logger;
 
-        private final int seconds;
+        private int seconds = 0;
 
-        VisibilityReset(Logger logger, int seconds) {
+        VisibilityReset(Logger logger) {
             this.logger = logger;
-            this.seconds = seconds;
         }
 
         @Override
         public void configure(Map<String, ?> properties) {
-
+            this.seconds = ConfigLoading.loadInt(properties, VISIBILITY_RESET_SECONDS_CONFIG).orElse(seconds);
         }
 
         @Override

--- a/aws-util/src/main/java/io/atleon/aws/util/AwsConfig.java
+++ b/aws-util/src/main/java/io/atleon/aws/util/AwsConfig.java
@@ -11,7 +11,6 @@ import software.amazon.awssdk.regions.Region;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * Utility class used to build AWS resources from property-based configs
@@ -72,7 +71,8 @@ public final class AwsConfig {
     }
 
     public static AwsCredentialsProvider loadCredentialsProvider(Map<String, ?> configs) {
-        String type = ConfigLoading.load(configs, CREDENTIALS_PROVIDER_TYPE_CONFIG, Function.identity(), CREDENTIALS_PROVIDER_TYPE_DEFAULT);
+        String type = ConfigLoading.loadString(configs, CREDENTIALS_PROVIDER_TYPE_CONFIG)
+            .orElse(CREDENTIALS_PROVIDER_TYPE_DEFAULT);
         switch (type) {
             case CREDENTIALS_PROVIDER_TYPE_DEFAULT:
                 return DefaultCredentialsProvider.create();
@@ -84,18 +84,18 @@ public final class AwsConfig {
     }
 
     public static AwsCredentials loadAwsCredentials(Map<String, ?> configs) {
-        String type = ConfigLoading.load(configs, CREDENTIALS_TYPE_CONFIG, Function.identity(), CREDENTIALS_TYPE_BASIC);
+        String type = ConfigLoading.loadString(configs, CREDENTIALS_TYPE_CONFIG).orElse(CREDENTIALS_TYPE_BASIC);
         switch (type) {
             case CREDENTIALS_TYPE_BASIC:
                 return AwsBasicCredentials.create(
-                    ConfigLoading.loadOrThrow(configs, CREDENTIALS_ACCESS_KEY_ID_CONFIG, Function.identity()),
-                    ConfigLoading.loadOrThrow(configs, CREDENTIALS_SECRET_ACCESS_KEY_CONFIG, Function.identity())
+                    ConfigLoading.loadStringOrThrow(configs, CREDENTIALS_ACCESS_KEY_ID_CONFIG),
+                    ConfigLoading.loadStringOrThrow(configs, CREDENTIALS_SECRET_ACCESS_KEY_CONFIG)
                 );
             case CREDENTIALS_TYPE_SESSION:
                 return AwsSessionCredentials.create(
-                    ConfigLoading.loadOrThrow(configs, CREDENTIALS_ACCESS_KEY_ID_CONFIG, Function.identity()),
-                    ConfigLoading.loadOrThrow(configs, CREDENTIALS_SECRET_ACCESS_KEY_CONFIG, Function.identity()),
-                    ConfigLoading.loadOrThrow(configs, CREDENTIALS_SESSION_TOKEN_CONFIG, Function.identity())
+                    ConfigLoading.loadStringOrThrow(configs, CREDENTIALS_ACCESS_KEY_ID_CONFIG),
+                    ConfigLoading.loadStringOrThrow(configs, CREDENTIALS_SECRET_ACCESS_KEY_CONFIG),
+                    ConfigLoading.loadStringOrThrow(configs, CREDENTIALS_SESSION_TOKEN_CONFIG)
                 );
             default:
                 throw new IllegalArgumentException("Cannot create AwsCredentials for type=" + type);
@@ -103,6 +103,6 @@ public final class AwsConfig {
     }
 
     public static Optional<Region> loadRegion(Map<String, ?> configs) {
-        return ConfigLoading.load(configs, REGION_CONFIG, Region::of);
+        return ConfigLoading.loadParseable(configs, REGION_CONFIG, Region.class, Region::of);
     }
 }

--- a/core/src/main/java/io/atleon/core/AloDecorator.java
+++ b/core/src/main/java/io/atleon/core/AloDecorator.java
@@ -33,6 +33,11 @@ public interface AloDecorator<T> extends Configurable {
         }
 
         @Override
+        public void configure(Map<String, ?> properties) {
+            decorators.forEach(decorator -> decorator.configure(properties));
+        }
+
+        @Override
         public Alo<T> decorate(Alo<T> alo) {
             for (AloDecorator<T> decorator : decorators) {
                 alo = decorator.decorate(alo);

--- a/core/src/main/java/io/atleon/core/ConfigSource.java
+++ b/core/src/main/java/io/atleon/core/ConfigSource.java
@@ -1,7 +1,6 @@
 package io.atleon.core;
 
 import io.atleon.util.ConfigLoading;
-import io.atleon.util.Instantiation;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -69,7 +68,7 @@ public abstract class ConfigSource<T, S extends ConfigSource<T, S>> extends Conf
         List<ConfigProcessor> processors = defaultInterceptors().stream()
             .map(ConfigInterceptor::asProcessor)
             .collect(Collectors.toList());
-        processors.addAll(ConfigLoading.loadListOrEmpty(properties, PROCESSORS_PROPERTY, Instantiation::one));
+        processors.addAll(ConfigLoading.loadListOfInstancesOrEmpty(properties, PROCESSORS_PROPERTY, ConfigProcessor.class));
         return processors;
     }
 

--- a/core/src/test/java/io/atleon/core/AloDecoratorConfigTest.java
+++ b/core/src/test/java/io/atleon/core/AloDecoratorConfigTest.java
@@ -2,18 +2,76 @@ package io.atleon.core;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AloDecoratorConfigTest {
 
     @Test
     public void decoratorsAreAutoLoadedIfNotSpecifiedDirectly() {
-        Optional<AloDecorator<Object>> decorator = AloDecoratorConfig.load(Collections.emptyMap(), AloDecorator.class);
+        Optional<AloDecorator<Object>> loadedDecorator = AloDecoratorConfig.load(Collections.emptyMap(), AloDecorator.class);
 
-        assertTrue(decorator.isPresent());
-        assertTrue(decorator.get() instanceof TestAloDecorator);
+        assertTrue(loadedDecorator.isPresent());
+        assertTrue(loadedDecorator.get() instanceof TestAloDecorator);
+    }
+
+    @Test
+    public void decoratorsArePassedThroughIfExplicitlySpecified() {
+        AloDecorator<Object> aloDecorator = new ExplicitAloDecorator<>();
+
+        Map<String, ?> properties = Collections.singletonMap(AloDecoratorConfig.ALO_DECORATOR_TYPES_CONFIG, aloDecorator);
+
+        Optional<AloDecorator<Object>> loadedDecorator = AloDecoratorConfig.load(properties, AloDecorator.class);
+
+        assertSame(aloDecorator, loadedDecorator.orElse(null));
+    }
+
+    @Test
+    public void decoratorsAreInstantiatedFromClassWhenExplicitlySpecified() {
+        Map<String, ?> properties = Collections.singletonMap(
+            AloDecoratorConfig.ALO_DECORATOR_TYPES_CONFIG,
+            ExplicitAloDecorator.class
+        );
+
+        Optional<AloDecorator<Object>> loadedDecorator = AloDecoratorConfig.load(properties, AloDecorator.class);
+
+        assertTrue(loadedDecorator.map(ExplicitAloDecorator.class::isInstance).orElse(false));
+    }
+
+    @Test
+    public void decoratorsAreInstantiatedFromClassNameWhenExplicitlySpecified() {
+        Map<String, ?> properties = Collections.singletonMap(
+            AloDecoratorConfig.ALO_DECORATOR_TYPES_CONFIG,
+            ExplicitAloDecorator.class.getName()
+        );
+
+        Optional<AloDecorator<Object>> loadedDecorator = AloDecoratorConfig.load(properties, AloDecorator.class);
+
+        assertTrue(loadedDecorator.map(ExplicitAloDecorator.class::isInstance).orElse(false));
+    }
+
+    @Test
+    public void decoratorsAreLoadedWithAutoDecoratorsWhenExplicitlySpecified() {
+        Map<String, ?> properties = Collections.singletonMap(
+            AloDecoratorConfig.ALO_DECORATOR_TYPES_CONFIG,
+            Arrays.asList(ExplicitAloDecorator.class, AloDecoratorConfig.DECORATOR_TYPE_AUTO)
+        );
+
+        Optional<AloDecorator<Object>> loadedDecorator = AloDecoratorConfig.load(properties, AloDecorator.class);
+
+        assertTrue(loadedDecorator.map(AloDecorator.Composite.class::isInstance).orElse(false));
+    }
+
+    public static final class ExplicitAloDecorator<T> implements AloDecorator<T> {
+
+        @Override
+        public Alo<T> decorate(Alo<T> alo) {
+            return alo;
+        }
     }
 }

--- a/kafka-avro/src/main/java/io/atleon/kafka/avro/AvroSchemas.java
+++ b/kafka-avro/src/main/java/io/atleon/kafka/avro/AvroSchemas.java
@@ -26,8 +26,9 @@ public final class AvroSchemas {
 
     public static Schema getOrSupply(Object data, Supplier<Schema> schemaSupplier) {
         try {
-            return data instanceof GenericContainer ? GenericContainer.class.cast(data).getSchema() :
-                SpecificData.get().getSchema(TypeResolution.safelyGetClass(data));
+            return data instanceof GenericContainer
+                ? GenericContainer.class.cast(data).getSchema()
+                : SpecificData.get().getSchema(TypeResolution.safelyGetClass(data));
         } catch (AvroRuntimeException e) {
             return schemaSupplier.get();
         }

--- a/kafka-avro/src/main/java/io/atleon/kafka/avro/LoadingAvroDeserializer.java
+++ b/kafka-avro/src/main/java/io/atleon/kafka/avro/LoadingAvroDeserializer.java
@@ -56,9 +56,12 @@ public abstract class LoadingAvroDeserializer<T> extends LoadingAvroSerDe implem
     @Override
     public void configure(Map<String, ?> configs, boolean isKey) {
         this.configureClientProperties(new KafkaAvroDeserializerConfig(configs), new AvroSchemaProvider());
-        this.readNullOnFailure = ConfigLoading.load(configs, READ_NULL_ON_FAILURE_PROPERTY, Boolean::valueOf, readNullOnFailure);
-        this.readerSchemaLoading = ConfigLoading.load(configs, READER_SCHEMA_LOADING_PROPERTY, Boolean::valueOf, readerSchemaLoading);
-        this.readerReferenceSchemaGeneration = ConfigLoading.load(configs, READER_REFERENCE_SCHEMA_GENERATION_PROPERTY, Boolean::valueOf, readerReferenceSchemaGeneration);
+        this.readNullOnFailure = ConfigLoading.loadBoolean(configs, READ_NULL_ON_FAILURE_PROPERTY)
+            .orElse(readNullOnFailure);
+        this.readerSchemaLoading = ConfigLoading.loadBoolean(configs, READER_SCHEMA_LOADING_PROPERTY)
+            .orElse(readerSchemaLoading);
+        this.readerReferenceSchemaGeneration = ConfigLoading.loadBoolean(configs, READER_REFERENCE_SCHEMA_GENERATION_PROPERTY)
+            .orElse(readerReferenceSchemaGeneration);
     }
 
     @Override

--- a/kafka-avro/src/main/java/io/atleon/kafka/avro/LoadingAvroSerializer.java
+++ b/kafka-avro/src/main/java/io/atleon/kafka/avro/LoadingAvroSerializer.java
@@ -51,8 +51,10 @@ public abstract class LoadingAvroSerializer<T> extends LoadingAvroSerDe implemen
     @Override
     public void configure(Map<String, ?> configs, boolean isKey) {
         this.configureClientProperties(new KafkaAvroSerializerConfig(configs), new AvroSchemaProvider());
-        this.writerSchemaCaching = ConfigLoading.load(configs, WRITER_SCHEMA_CACHING_PROPERTY, Boolean::valueOf, writerSchemaCaching);
-        this.writerSchemaGeneration = ConfigLoading.load(configs, WRITER_SCHEMA_GENERATION_PROPERTY, Boolean::valueOf, writerSchemaGeneration);
+        this.writerSchemaCaching = ConfigLoading.loadBoolean(configs, WRITER_SCHEMA_CACHING_PROPERTY)
+            .orElse(writerSchemaCaching);
+        this.writerSchemaGeneration = ConfigLoading.loadBoolean(configs, WRITER_SCHEMA_GENERATION_PROPERTY)
+            .orElse(writerSchemaGeneration);
         this.isKey = isKey;
     }
 

--- a/kafka-avro/src/main/java/io/atleon/kafka/avro/ReflectDecoderAvroDeserializer.java
+++ b/kafka-avro/src/main/java/io/atleon/kafka/avro/ReflectDecoderAvroDeserializer.java
@@ -28,7 +28,7 @@ public class ReflectDecoderAvroDeserializer<T> extends LoadingAvroDeserializer<T
     @Override
     public void configure(Map<String, ?> configs, boolean isKey) {
         super.configure(configs, isKey);
-        this.reflectAllowNull = ConfigLoading.load(configs, REFLECT_ALLOW_NULL_PROPERTY, Boolean::valueOf, reflectAllowNull);
+        this.reflectAllowNull = ConfigLoading.loadBoolean(configs, REFLECT_ALLOW_NULL_PROPERTY).orElse(reflectAllowNull);
     }
 
     @Override

--- a/kafka-avro/src/main/java/io/atleon/kafka/avro/ReflectEncoderAvroSerializer.java
+++ b/kafka-avro/src/main/java/io/atleon/kafka/avro/ReflectEncoderAvroSerializer.java
@@ -20,7 +20,7 @@ public class ReflectEncoderAvroSerializer<T> extends LoadingAvroSerializer<T> {
     @Override
     public void configure(Map<String, ?> configs, boolean isKey) {
         super.configure(configs, isKey);
-        this.reflectAllowNull = ConfigLoading.load(configs, REFLECT_ALLOW_NULL_PROPERTY, Boolean::valueOf, reflectAllowNull);
+        this.reflectAllowNull = ConfigLoading.loadBoolean(configs, REFLECT_ALLOW_NULL_PROPERTY).orElse(reflectAllowNull);
     }
 
     @Override

--- a/kafka/src/main/java/io/atleon/kafka/AloKafkaSender.java
+++ b/kafka/src/main/java/io/atleon/kafka/AloKafkaSender.java
@@ -367,14 +367,14 @@ public class AloKafkaSender<K, V> implements Closeable {
             // 2) Note Client ID and, if enabled, increment client ID in consumer config
             Map<String, Object> producerConfig = new HashMap<>(config);
             options.keySet().forEach(producerConfig::remove);
-            String clientId = ConfigLoading.loadOrThrow(config, CommonClientConfigs.CLIENT_ID_CONFIG, Object::toString);
-            if (ConfigLoading.loadOrThrow(options, AUTO_INCREMENT_CLIENT_ID_CONFIG, Boolean::valueOf)) {
+            String clientId = ConfigLoading.loadStringOrThrow(config, CommonClientConfigs.CLIENT_ID_CONFIG);
+            if (ConfigLoading.loadBooleanOrThrow(options, AUTO_INCREMENT_CLIENT_ID_CONFIG)) {
                 producerConfig.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId + "-" + nextClientIdCount(clientId));
             }
 
             return SenderOptions.<K, V>create(producerConfig)
-                .maxInFlight(ConfigLoading.loadOrThrow(options, MAX_IN_FLIGHT_PER_SEND_CONFIG, Integer::valueOf))
-                .stopOnError(ConfigLoading.loadOrThrow(options, STOP_ON_ERROR_CONFIG, Boolean::valueOf));
+                .maxInFlight(ConfigLoading.loadIntOrThrow(options, MAX_IN_FLIGHT_PER_SEND_CONFIG))
+                .stopOnError(ConfigLoading.loadBooleanOrThrow(options, STOP_ON_ERROR_CONFIG));
         }
 
         private static long nextClientIdCount(String clientId) {

--- a/kafka/src/main/java/io/atleon/kafka/KafkaConfigSource.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaConfigSource.java
@@ -32,8 +32,7 @@ public class KafkaConfigSource extends ConfigSource<Map<String, Object>, KafkaCo
     }
 
     public static KafkaConfigSource useClientIdAsName() {
-        return new KafkaConfigSource(properties ->
-            ConfigLoading.load(properties, CommonClientConfigs.CLIENT_ID_CONFIG, Object::toString));
+        return new KafkaConfigSource(map -> ConfigLoading.loadString(map, CommonClientConfigs.CLIENT_ID_CONFIG));
     }
 
     public KafkaConfigSource withClientId(String clientId) {

--- a/opentracing/src/main/java/io/atleon/opentracing/TracingAloKafkaConsumerRecordDecorator.java
+++ b/opentracing/src/main/java/io/atleon/opentracing/TracingAloKafkaConsumerRecordDecorator.java
@@ -11,7 +11,6 @@ import org.apache.kafka.common.header.Header;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 /**
  * An {@link AloKafkaConsumerRecordDecorator} that decorates {@link Alo} elements with tracing
@@ -29,7 +28,7 @@ public class TracingAloKafkaConsumerRecordDecorator<K, V>
     @Override
     public void configure(Map<String, ?> properties) {
         super.configure(properties);
-        groupId = ConfigLoading.load(properties, ConsumerConfig.GROUP_ID_CONFIG, Function.identity(), groupId);
+        groupId = ConfigLoading.loadString(properties, ConsumerConfig.GROUP_ID_CONFIG).orElse(groupId);
     }
 
     @Override

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQReceiver.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQReceiver.java
@@ -139,9 +139,9 @@ public class AloRabbitMQReceiver<T> {
         public static <T> ReceiveResources<T> fromConfig(RabbitMQConfig config) {
             return new ReceiveResources<T>(
                 config.getConnectionFactory(),
-                config.load(QOS_CONFIG, Integer::parseInt).orElse(Defaults.PREFETCH),
-                config.loadConfiguredOrThrow(BODY_DESERIALIZER_CONFIG),
-                config.load(NACK_STRATEGY_CONFIG, NackStrategy::valueOf).orElse(NackStrategy.EMIT),
+                config.loadInt(QOS_CONFIG).orElse(Defaults.PREFETCH),
+                config.loadConfiguredOrThrow(BODY_DESERIALIZER_CONFIG, BodyDeserializer.class),
+                config.loadParseable(NACK_STRATEGY_CONFIG, NackStrategy.class, NackStrategy::valueOf).orElse(NackStrategy.EMIT),
                 config.loadAloFactory()
             );
         }

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQSender.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQSender.java
@@ -210,9 +210,9 @@ public class AloRabbitMQSender<T> implements Closeable {
             SenderOptions senderOptions = new SenderOptions()
                 .connectionFactory(config.getConnectionFactory());
 
-            return new SendResources<>(
+            return new SendResources<T>(
                 new Sender(senderOptions),
-                config.loadConfiguredOrThrow(BODY_SERIALIZER_CONFIG)
+                config.loadConfiguredOrThrow(BODY_SERIALIZER_CONFIG, BodySerializer.class)
             );
         }
 

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQConfig.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQConfig.java
@@ -29,11 +29,15 @@ public class RabbitMQConfig {
         return AloFactoryConfig.loadDecorated(properties, AloRabbitMQMessageDecorator.class);
     }
 
-    public <T extends Configurable> T loadConfiguredOrThrow(String property) {
-        return ConfigLoading.loadConfiguredOrThrow(properties, property);
+    public <T extends Configurable> T loadConfiguredOrThrow(String property, Class<? extends T> type) {
+        return ConfigLoading.loadConfiguredOrThrow(properties, property, type);
     }
 
-    public <T> Optional<T> load(String property, Function<? super String, T> parser) {
-        return ConfigLoading.load(properties, property, parser);
+    public Optional<Integer> loadInt(String property) {
+        return ConfigLoading.loadInt(properties, property);
+    }
+
+    public <T> Optional<T> loadParseable(String property, Class<T> type, Function<? super String, T> parser) {
+        return ConfigLoading.loadParseable(properties, property, type, parser);
     }
 }

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -11,4 +11,17 @@
     <artifactId>atleon-util</artifactId>
     <packaging>jar</packaging>
 
+    <dependencies>
+        <!-- Third Party Test Dependencies -->
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/util/src/main/java/io/atleon/util/ConfigLoading.java
+++ b/util/src/main/java/io/atleon/util/ConfigLoading.java
@@ -1,5 +1,7 @@
 package io.atleon.util;
 
+import java.net.URI;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -8,11 +10,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Convenience methods for loading configurations from arbitrary String-value mappings
@@ -23,60 +27,123 @@ public final class ConfigLoading {
 
     }
 
-    public static <T extends Configurable> Optional<T> loadConfigured(Map<String, ?> configs, String property) {
-        return ConfigLoading.<Class<? extends T>>load(configs, property, TypeResolution::classForQualifiedName)
-            .map(clazz -> Instantiation.oneConfigured(clazz, configs));
+    public static <T extends Configurable> T
+    loadConfiguredOrThrow(Map<String, ?> configs, String property, Class<? extends T> type) {
+        return loadConfiguredWithPredefinedTypes(configs, property, type, typeName -> Optional.empty())
+            .orElseThrow(supplyMissingConfigPropertyException(property));
     }
 
-    public static <T extends Configurable> T loadConfiguredOrThrow(Map<String, ?> configs, String property) {
-        return Instantiation.oneConfigured(loadOrThrow(configs, property, TypeResolution::classForQualifiedName), configs);
+    public static Duration loadDurationOrThrow(Map<String, ?> configs, String property) {
+        return loadDuration(configs, property).orElseThrow(supplyMissingConfigPropertyException(property));
     }
 
-    public static <T extends Configurable> List<T> loadListOfConfigured(Map<String, ?> configs, String property) {
-        List<Class<? extends T>> clazzes = loadListOrEmpty(configs, property, TypeResolution::classForQualifiedName);
-        return Instantiation.manyConfigured(clazzes, configs);
+    public static boolean loadBooleanOrThrow(Map<String, ?> configs, String property) {
+        return loadBoolean(configs, property).orElseThrow(supplyMissingConfigPropertyException(property));
     }
 
-    public static <T> T load(Map<String, ?> configs, String property, Function<? super String, T> parser, T defaultValue) {
-        return load(configs, property, parser).orElse(defaultValue);
+    public static int loadIntOrThrow(Map<String, ?> configs, String property) {
+        return loadInt(configs, property).orElseThrow(supplyMissingConfigPropertyException(property));
     }
 
-    public static <T> T loadOrThrow(Map<String, ?> configs, String property, Function<? super String, T> parser) {
-        return load(configs, property, parser).orElseThrow(supplyMissingConfigPropertyException(property));
+    public static long loadLongOrThrow(Map<String, ?> configs, String property) {
+        return loadLong(configs, property).orElseThrow(supplyMissingConfigPropertyException(property));
     }
 
-    public static <T> Optional<T> load(Map<String, ?> configs, String property, Function<? super String, T> parser) {
-        return Optional.ofNullable(configs.get(property)).map(Object::toString).map(parser);
+    public static String loadStringOrThrow(Map<String, ?> configs, String property) {
+        return loadString(configs, property).orElseThrow(supplyMissingConfigPropertyException(property));
     }
 
-    public static <T> List<T> loadListOrEmpty(Map<String, ?> configs, String property, Function<? super String, T> parser) {
-        return loadCollection(configs, property, parser, Collectors.toList()).orElse(Collections.emptyList());
-    }
-
-    public static <T> Set<T> loadSetOrEmpty(Map<String, ?> configs, String property, Function<? super String, T> parser) {
-        return loadSet(configs, property, parser).orElse(Collections.emptySet());
-    }
-
-    public static <T> Optional<Set<T>> loadSet(Map<String, ?> configs, String property, Function<? super String, T> parser) {
-        return loadCollection(configs, property, parser, Collectors.<T, Set<T>>toCollection(LinkedHashSet::new));
-    }
-
-    public static <T, R> Optional<R> loadCollection(
+    public static <T extends Configurable> Optional<T> loadConfiguredWithPredefinedTypes(
         Map<String, ?> configs,
         String property,
-        Function<? super String, T> parser,
-        Collector<? super T, ?, R> collector) {
-        return Optional.ofNullable(configs.get(property))
-            .map(ConfigLoading::convertToCollection)
-            .map(collection -> collection.stream().map(Objects::toString).map(parser).collect(collector));
+        Class<? extends T> type,
+        Function<String, Optional<T>> predefinedTypeInstantiator
+    ) {
+        Function<String, T> instantiator = newInstantiatorWithPredefinedTypes(type, predefinedTypeInstantiator);
+        Optional<T> result = load(configs, property, value -> coerce(type, value, instantiator));
+        result.ifPresent(configurable -> configurable.configure(configs));
+        return result;
+    }
+
+    public static Optional<URI> loadUri(Map<String, ?> configs, String property) {
+        return loadParseable(configs, property, URI.class, URI::create);
+    }
+
+    public static Optional<Duration> loadDuration(Map<String, ?> configs, String property) {
+        return loadParseable(configs, property, Duration.class, Duration::parse);
+    }
+
+    public static Optional<Boolean> loadBoolean(Map<String, ?> configs, String property) {
+        return loadParseable(configs, property, Boolean.class, Boolean::parseBoolean);
+    }
+
+    public static Optional<Integer> loadInt(Map<String, ?> configs, String property) {
+        return loadParseable(configs, property, Number.class, Integer::parseInt).map(Number::intValue);
+    }
+
+    public static Optional<Long> loadLong(Map<String, ?> configs, String property) {
+        return loadParseable(configs, property, Number.class, Long::parseLong).map(Number::longValue);
+    }
+
+    public static Optional<String> loadString(Map<String, ?> configs, String property) {
+        return loadParseable(configs, property, String.class, Function.identity());
+    }
+
+    public static <T> Optional<T>
+    loadParseable(Map<String, ?> configs, String property, Class<T> type, Function<? super String, T> parser) {
+        return load(configs, property, value -> coerce(type, value, parser));
+    }
+
+    public static <T extends Configurable> List<T>
+    loadListOfConfiguredServices(Class<? extends T> type, Map<String, ?> configs) {
+        ServiceLoader<? extends T> serviceLoader = ServiceLoader.load(type);
+        return StreamSupport.stream(serviceLoader.spliterator(), false)
+            .peek(configurable -> configurable.configure(configs))
+            .collect(Collectors.toList());
+    }
+
+    public static <T> List<T> loadListOfInstancesOrEmpty(Map<String, ?> configs, String property, Class<T> type) {
+        return loadListOfInstances(configs, property, type).orElse(Collections.emptyList());
+    }
+
+    public static Set<String> loadSetOfStringOrEmpty(Map<String, ?> configs, String property) {
+        return loadSetOfString(configs, property).orElse(Collections.emptySet());
+    }
+
+    public static <T extends Configurable> Optional<List<T>> loadListOfConfiguredWithPredefinedTypes(
+        Map<String, ?> configs,
+        String property,
+        Class<? extends T> type,
+        Function<String, Optional<T>> predefinedTypeInstantiator
+    ) {
+        Optional<List<T>> result =
+            loadListOfInstancesWithPredefinedTypes(configs, property, type, predefinedTypeInstantiator);
+        result.ifPresent(configurables -> configurables.forEach(configurable -> configurable.configure(configs)));
+        return result;
+    }
+
+    public static <T> Optional<List<T>> loadListOfInstances(Map<String, ?> configs, String property, Class<T> type) {
+        return loadListOfInstancesWithPredefinedTypes(configs, property, type, typeName -> Optional.empty());
+    }
+
+    public static <T> Optional<List<T>> loadListOfInstancesWithPredefinedTypes(
+        Map<String, ?> configs,
+        String property,
+        Class<? extends T> type,
+        Function<String, Optional<T>> predefinedTypeInstantiator
+    ) {
+        Function<String, T> instantiator = newInstantiatorWithPredefinedTypes(type, predefinedTypeInstantiator);
+        return ConfigLoading.loadStream(configs, property, value -> coerce(type, value, instantiator))
+            .map(stream -> stream.collect(Collectors.toList()));
+    }
+
+    public static Optional<Set<String>> loadSetOfString(Map<String, ?> configs, String property) {
+        return loadStream(configs, property, Objects::toString)
+            .map(stream -> stream.collect(Collectors.toCollection(LinkedHashSet::new)));
     }
 
     public static Map<String, Object> loadPrefixedEnvironmentalProperties(String prefix) {
         return loadPrefixed(Arrays.asList(System.getenv(), System.getProperties()), prefix);
-    }
-
-    public static Map<String, Object> loadPrefixed(Map<String, ?> configs, String prefix) {
-        return loadPrefixed(Collections.singletonList(configs), prefix);
     }
 
     private static Map<String, Object> loadPrefixed(List<Map<?, ?>> configsList, String prefix) {
@@ -90,13 +157,39 @@ public final class ConfigLoading {
             ));
     }
 
-    private static Collection<?> convertToCollection(Object config) {
-        if (config instanceof Collection) {
-            return Collection.class.cast(config);
-        } else if (config instanceof CharSequence) {
-            return Arrays.asList(config.toString().split(","));
+    private static <T> Optional<T> load(Map<String, ?> configs, String property, Function<Object, T> coercer) {
+        return Optional.ofNullable(configs.get(property)).map(coercer);
+    }
+
+    private static <T> Optional<Stream<T>> loadStream(Map<String, ?> configs, String property, Function<Object, T> coercer) {
+        return Optional.ofNullable(configs.get(property))
+            .map(value -> convertToStream(value).map(coercer));
+    }
+
+    private static Stream<?> convertToStream(Object value) {
+        if (value instanceof Collection) {
+            return Collection.class.cast(value).stream();
+        } else if (value instanceof CharSequence) {
+            return Stream.of(value.toString().split(",")).map(String::trim);
         } else {
-            return Collections.singletonList(config);
+            return Stream.of(value);
+        }
+    }
+
+    private static <T> Function<String, T>
+    newInstantiatorWithPredefinedTypes(Class<? extends T> type, Function<String, Optional<T>> predefinedTypeInstantiator) {
+        return typeName -> predefinedTypeInstantiator.apply(typeName).orElseGet(() -> Instantiation.oneTyped(type, typeName));
+    }
+
+    private static <T> T coerce(Class<? extends T> toType, Object value, Function<? super String, T> parser) {
+        if (toType.isInstance(value)) {
+            return toType.cast(value);
+        } else if (value instanceof Class) {
+            return Instantiation.oneTyped(toType, Class.class.cast(value));
+        } else if (value instanceof CharSequence) {
+            return parser.apply(value.toString());
+        } else {
+            throw new UnsupportedOperationException("Cannot coerce value=" + value + " to object of type=" + toType);
         }
     }
 

--- a/util/src/main/java/io/atleon/util/TypeResolution.java
+++ b/util/src/main/java/io/atleon/util/TypeResolution.java
@@ -16,16 +16,8 @@ public final class TypeResolution {
 
     }
 
-    public static String extractSimpleName(Object object) {
-        return safelyGetClass(object).getSimpleName();
-    }
-
-    public static Class safelyGetClass(Object object) {
+    public static Class<?> safelyGetClass(Object object) {
         return object == null ? Void.class : object.getClass();
-    }
-
-    public static <T> Class<T> classForPackageAndClass(String pkg, String name) {
-        return classForQualifiedName(pkg + "." + name);
     }
 
     public static <T> Class<T> classForQualifiedName(String qualifiedName) {
@@ -36,23 +28,23 @@ public final class TypeResolution {
         }
     }
 
-    public static boolean isGenericClass(Class clazz) {
+    public static boolean isGenericClass(Class<?> clazz) {
         return clazz.getTypeParameters().length > 0;
     }
 
-    public static boolean isDataStructure(Class clazz) {
+    public static boolean isDataStructure(Class<?> clazz) {
         return Collection.class.isAssignableFrom(clazz) || Map.class.isAssignableFrom(clazz);
     }
 
-    public static Set<Type> getAllTypeParameters(Class clazz) {
+    public static Set<Type> getAllTypeParameters(Class<?> clazz) {
         return withSuperClasses(clazz).stream()
-            .<TypeVariable[]>map(Class::getTypeParameters)
+            .<TypeVariable<?>[]>map(Class::getTypeParameters)
             .flatMap(Arrays::stream)
             .collect(Collectors.toSet());
     }
 
-    private static List<Class> withSuperClasses(Class clazz) {
-        List<Class> classes = new ArrayList<>();
+    private static List<Class<?>> withSuperClasses(Class<?> clazz) {
+        List<Class<?>> classes = new ArrayList<>();
         classes.add(clazz);
         while ((clazz = clazz.getSuperclass()) != null) {
             classes.add(clazz);


### PR DESCRIPTION
### :pencil: Description
- Pass through loaded config values if they are already the correct type
- Make `ConfigLoading` responsible for all instantiation of config values
- Make `ConfigLoading` responsible for configuring `Configurable` objects

### :link: Related Issues
#109 