### PR TITLE
#112: Move environmental property loading to `EnvironmentalConfigs`

### DIFF
--- a/core/src/main/java/io/atleon/core/EnvironmentalConfigs.java
+++ b/core/src/main/java/io/atleon/core/EnvironmentalConfigs.java
@@ -1,9 +1,9 @@
 package io.atleon.core;
 
-import io.atleon.util.ConfigLoading;
-
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 public final class EnvironmentalConfigs implements ConfigInterceptor {
 
@@ -13,12 +13,33 @@ public final class EnvironmentalConfigs implements ConfigInterceptor {
     public Map<String, Object> intercept(String name, Map<String, Object> configs) {
         String prefix = String.format("%s%s.", PREFIX, name);
         Map<String, Object> result = new HashMap<>(configs);
-        result.putAll(ConfigLoading.loadPrefixedEnvironmentalProperties(prefix));
+        result.putAll(loadPrefixedEnvironmentalProperties(prefix));
         return result;
     }
 
     @Override
     public Map<String, Object> intercept(Map<String, Object> configs) {
         return configs;
+    }
+
+    private static Map<String, Object> loadPrefixedEnvironmentalProperties(String prefix) {
+        Map<String, Object> properties = new HashMap<>();
+        consumePrefixed(System.getenv(), key -> key.replaceAll("_", ".").toLowerCase(), prefix, properties::put);
+        consumePrefixed(System.getProperties(), Object::toString, prefix, properties::put);
+        return properties;
+    }
+
+    private static <K> void consumePrefixed(
+        Map<K, ?> source,
+        Function<K, String> keyToPropertyKey,
+        String prefix,
+        BiConsumer<String, Object> consumer
+    ) {
+        source.forEach((key, value) -> {
+            String propertyKey = keyToPropertyKey.apply(key);
+            if (propertyKey.startsWith(prefix)) {
+                consumer.accept(propertyKey.substring(prefix.length()), value);
+            }
+        });
     }
 }

--- a/util/src/main/java/io/atleon/util/ConfigLoading.java
+++ b/util/src/main/java/io/atleon/util/ConfigLoading.java
@@ -2,7 +2,6 @@ package io.atleon.util;
 
 import java.net.URI;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -140,21 +139,6 @@ public final class ConfigLoading {
     public static Optional<Set<String>> loadSetOfString(Map<String, ?> configs, String property) {
         return loadStream(configs, property, Objects::toString)
             .map(stream -> stream.collect(Collectors.toCollection(LinkedHashSet::new)));
-    }
-
-    public static Map<String, Object> loadPrefixedEnvironmentalProperties(String prefix) {
-        return loadPrefixed(Arrays.asList(System.getenv(), System.getProperties()), prefix);
-    }
-
-    private static Map<String, Object> loadPrefixed(List<Map<?, ?>> configsList, String prefix) {
-        return configsList.stream()
-            .flatMap(configs -> configs.entrySet().stream())
-            .filter(entry -> entry.getKey().toString().startsWith(prefix))
-            .collect(Collectors.toMap(
-                entry -> entry.getKey().toString().substring(prefix.length()),
-                Map.Entry::getValue,
-                (firstValue, secondValue) -> secondValue
-            ));
     }
 
     private static <T> Optional<T> load(Map<String, ?> configs, String property, Function<Object, T> coercer) {


### PR DESCRIPTION
### :pencil: Description
- Make `EnvironmentalConfigs` own the loading of environment properties (the only place this is used)
- Properly convert environment variables to properties

### :link: Related Issues
#112 
