### PR TITLE
#136: Implement `Signal` listening on `Alo` pipelines

### DIFF
--- a/aws-sqs/src/main/java/io/atleon/aws/sqs/AloReceivedSqsMessageSignalListener.java
+++ b/aws-sqs/src/main/java/io/atleon/aws/sqs/AloReceivedSqsMessageSignalListener.java
@@ -1,0 +1,24 @@
+package io.atleon.aws.sqs;
+
+import io.atleon.core.AloSignalListener;
+
+/**
+ * Interface through which side effects on {@link reactor.core.publisher.Signal}s emitted from
+ * Reactor Publishers of {@link io.atleon.core.Alo}s referencing {@link ReceivedSqsMessage}s can be
+ * implemented.
+ * <p>
+ * In order to have implementations automatically applied, you can use the
+ * {@link java.util.ServiceLoader} SPI and add the class names to
+ * {@code META-INF/services/io.atleon.aws.sqs.AloReceivedSqsMessageSignalListener} in your
+ * project's resource directory.
+ *
+ * @param <T> The types of (deserialized) body payloads referenced by {@link ReceivedSqsMessage}s
+ */
+public interface AloReceivedSqsMessageSignalListener<T> extends AloSignalListener<ReceivedSqsMessage<T>> {
+
+    /**
+     * This parameter will be populated during configuration to let the decorator know what the URL
+     * is of the queue being consumed from.
+     */
+    String QUEUE_URL_CONFIG = "alo.signal.listener.sqs.queue.url";
+}

--- a/core/src/main/java/io/atleon/core/AloFlux.java
+++ b/core/src/main/java/io/atleon/core/AloFlux.java
@@ -4,6 +4,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Signal;
 import reactor.core.publisher.SignalType;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -67,6 +68,15 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
      */
     public AloFlux<T> doOnCancel(Runnable onCancel) {
         return new AloFlux<>(wrapped.doOnCancel(onCancel));
+    }
+
+    /**
+     * Add side effect behavior on each underlying emitted {@link Alo} item
+     *
+     * @see Flux#doOnEach(Consumer)
+     */
+    public AloFlux<T> doOnEachAlo(Consumer<? super Signal<Alo<T>>> signalConsumer) {
+        return new AloFlux<>(wrapped.doOnEach(signalConsumer));
     }
 
     /**
@@ -361,7 +371,12 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
      *
      * @param name The name to be assigned to this sequence and used for Meter names
      * @param tags Tuples of tags used to create Meters
+     * @deprecated The backing method for this call is being deprecated by Reactor. It can be
+     * replaced with explicit listening using {@link #doOnEachAlo(Consumer)} and an
+     * {@link AloSignalListener} (i.e. from atleon-micrometer), or using auto-listening (see Atleon
+     * documentation for details)
      */
+    @Deprecated
     public AloFlux<T> metrics(String name, String... tags) {
         if (tags.length % 2 != 0) {
             throw new IllegalArgumentException("Tags must be key-value tuples");
@@ -378,6 +393,10 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
      *
      * @param name The name to be assigned to this sequence and used for Meter names
      * @param tags Tags used during metric identification and creation
+     * @deprecated The backing method for this call is being deprecated by Reactor. It can be
+     * replaced with explicit listening using {@link #doOnEachAlo(Consumer)} and an
+     * {@link AloSignalListener} (i.e. from atleon-micrometer), or using auto-listening (see Atleon
+     * documentation for details)
      */
     public AloFlux<T> metrics(String name, Map<String, String> tags) {
         Flux<Alo<T>> toWrap = wrapped.name(name);

--- a/core/src/main/java/io/atleon/core/AloSignalListener.java
+++ b/core/src/main/java/io/atleon/core/AloSignalListener.java
@@ -1,0 +1,46 @@
+package io.atleon.core;
+
+import io.atleon.util.Configurable;
+import reactor.core.publisher.Signal;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Interface for adding side-effects to the transmission of {@link Signal}s in Reactor
+ * pipelines of {@link Alo} items. This implementations of this interface can be used in
+ * {@code doOnEach} operators of Alo Publisher pipelines (like {@link AloFlux#doOnEachAlo(Consumer)}}
+ *
+ * @param <T> The type of data exposed by Alo values in emitted Signals
+ */
+public interface AloSignalListener<T> extends Configurable, Consumer<Signal<Alo<T>>> {
+
+    static <T> AloSignalListener<T> combine(List<AloSignalListener<T>> decorators) {
+        return decorators.size() == 1 ? decorators.get(0) : new Composite<>(decorators);
+    }
+
+    @Override
+    default void configure(Map<String, ?> properties) {
+
+    }
+
+    class Composite<T> implements AloSignalListener<T> {
+
+        private final List<AloSignalListener<T>> decorators;
+
+        private Composite(List<AloSignalListener<T>> decorators) {
+            this.decorators = decorators;
+        }
+
+        @Override
+        public void configure(Map<String, ?> properties) {
+            decorators.forEach(decorator -> decorator.configure(properties));
+        }
+
+        @Override
+        public void accept(Signal<Alo<T>> signal) {
+            decorators.forEach(decorator -> decorator.accept(signal));
+        }
+    }
+}

--- a/core/src/main/java/io/atleon/core/AloSignalListenerConfig.java
+++ b/core/src/main/java/io/atleon/core/AloSignalListenerConfig.java
@@ -1,0 +1,70 @@
+package io.atleon.core;
+
+import io.atleon.util.ConfigLoading;
+import reactor.core.publisher.Signal;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Utility for loading {@link AloSignalListener}s
+ */
+public final class AloSignalListenerConfig {
+
+    /**
+     * Optional comma-separated list of {@link AloSignalListener} types. Each type is either a
+     * predefined type defined in this class or a fully qualified name of a class that implements
+     * {@link AloSignalListener}. Defaults to  {@link #SIGNAL_LISTENER_TYPE_AUTO}, which results in
+     * automatic loading of decorators through the {@link java.util.ServiceLoader} SPI.
+     */
+    public static final String ALO_SIGNAL_LISTENER_TYPES_CONFIG = "alo.signal.listener.types";
+
+    /**
+     * Type name used to activate automatic loading of {@link AloSignalListener}s through
+     * {@link java.util.ServiceLoader ServiceLoader} SPI
+     */
+    public static final String SIGNAL_LISTENER_TYPE_AUTO = "auto";
+
+    private AloSignalListenerConfig() {
+
+    }
+
+    public static <T, D extends AloSignalListener<T>> Optional<AloSignalListener<T>>
+    load(Map<String, ?> properties, Class<D> superType) {
+        List<AloSignalListener<T>> decorators = loadExplicit(properties, superType)
+            .orElseGet(() -> ConfigLoading.loadListOfConfiguredServices(superType, properties));
+        return decorators.isEmpty() ? Optional.empty() : Optional.of(AloSignalListener.combine(decorators));
+    }
+
+    private static <T, D extends AloSignalListener<T>> Optional<List<AloSignalListener<T>>>
+    loadExplicit(Map<String, ?> properties, Class<D> superType) {
+        return ConfigLoading.loadListOfConfiguredWithPredefinedTypes(
+            properties,
+            ALO_SIGNAL_LISTENER_TYPES_CONFIG,
+            superType,
+            typeName -> instantiatePredefined(properties, superType, typeName)
+        );
+    }
+
+    private static <T> Optional<AloSignalListener<T>> instantiatePredefined(
+        Map<String, ?> properties,
+        Class<? extends AloSignalListener<T>> superType,
+        String typeName
+    ) {
+        if (typeName.equalsIgnoreCase(SIGNAL_LISTENER_TYPE_AUTO)) {
+            List<AloSignalListener<T>> listeners = ConfigLoading.loadListOfConfiguredServices(superType, properties);
+            return Optional.of(listeners.isEmpty() ? new NoOp<>() : AloSignalListener.combine(listeners));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private static final class NoOp<T> implements AloSignalListener<T> {
+
+        @Override
+        public void accept(Signal<Alo<T>> signal) {
+
+        }
+    }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,7 @@ The following Kafka [End to End to End](core/src/main/java/io/atleon/examples/en
 [Kafka Deduplication](core/src/main/java/io/atleon/examples/deduplication/KafkaDeduplication.java) shows how to add deduplication to the processing of a Kafka topic. This example maintains the incorporation of [Acknowledgement](../core/src/main/java/io/atleon/core/Alo.java) propagation such as to maintain at-least-once processing guarantee
 
 ## Metrics
-[Kafka Micrometer](core/src/main/java/io/atleon/examples/metrics/KafkaMicrometer.java) shows how Atleon integrates with Micrometer to provide Metrics from native Kafka Reporting and from available Metric transformation in streaming processes
+[Kafka Micrometer](core/src/main/java/io/atleon/examples/metrics/KafkaMicrometer.java) shows how Atleon integrates with Micrometer to provide Metrics from Atleon streams, as well as bridging native Kafka metrics to Micrometer
 
 ## Tracing
 [Kafka Opentracing](core/src/main/java/io/atleon/examples/tracing/KafkaOpentracing.java) shows how Atleon integrates with Opentracing to provide traces in reactive pipelines

--- a/examples/core/src/main/java/io/atleon/examples/metrics/KafkaMicrometer.java
+++ b/examples/core/src/main/java/io/atleon/examples/metrics/KafkaMicrometer.java
@@ -25,10 +25,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * This example shows Atleon's integration with Micrometer. Under the hood, Project Reactor
- * provides most of the desirable metrics on Fluxes concerning subscription, requests, and data
- * emissions. This example includes Atleon's Kafka-specific integration with Micrometer in order to
- * surface metrics such as consumer lag, fetch, and request metrics.
+ * This example shows Atleon's integration with Micrometer. Atleon implements automatic meter
+ * instrumentation for Alo items as well as receiver streams. In addition, Atleon provides a bridge
+ * for native Kafka metrics to Micrometer such that metrics like lag, request rate, and throughput
+ * are exported alongside Atleon metrics.
  */
 public class KafkaMicrometer {
 

--- a/kafka/src/main/java/io/atleon/kafka/AloKafkaConsumerRecordSignalListener.java
+++ b/kafka/src/main/java/io/atleon/kafka/AloKafkaConsumerRecordSignalListener.java
@@ -1,0 +1,21 @@
+package io.atleon.kafka;
+
+import io.atleon.core.AloSignalListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+/**
+ * Interface through which side effects on {@link reactor.core.publisher.Signal}s emitted from
+ * Reactor Publishers of {@link io.atleon.core.Alo}s referencing {@link ConsumerRecord}s can be
+ * implemented.
+ * <p>
+ * In order to have implementations automatically applied, you can use the
+ * {@link java.util.ServiceLoader} SPI and add the class names to
+ * {@code META-INF/services/io.atleon.aws.sqs.AloKafkaConsumerRecordSignalListener} in your
+ * project's resources directory.
+ *
+ * @param <K> The types of keys in records consumed by this listener
+ * @param <V> The types of values in records consumed by this listener
+ */
+public interface AloKafkaConsumerRecordSignalListener<K, V> extends AloSignalListener<ConsumerRecord<K, V>> {
+
+}

--- a/micrometer-auto/src/main/resources/META-INF/services/io.atleon.aws.sqs.AloReceivedSqsMessageSignalListener
+++ b/micrometer-auto/src/main/resources/META-INF/services/io.atleon.aws.sqs.AloReceivedSqsMessageSignalListener
@@ -1,0 +1,1 @@
+io.atleon.micrometer.MeteringAloReceivedSqsMessageSignalListener

--- a/micrometer-auto/src/main/resources/META-INF/services/io.atleon.kafka.AloKafkaConsumerRecordSignalListener
+++ b/micrometer-auto/src/main/resources/META-INF/services/io.atleon.kafka.AloKafkaConsumerRecordSignalListener
@@ -1,0 +1,1 @@
+io.atleon.micrometer.MeteringAloKafkaConsumerRecordSignalListener

--- a/micrometer-auto/src/main/resources/META-INF/services/io.atleon.rabbitmq.AloReceivedRabbitMQSignalListener
+++ b/micrometer-auto/src/main/resources/META-INF/services/io.atleon.rabbitmq.AloReceivedRabbitMQSignalListener
@@ -1,0 +1,1 @@
+io.atleon.micrometer.MeteringAloReceivedRabbitMQMessageSignalListener

--- a/micrometer/pom.xml
+++ b/micrometer/pom.xml
@@ -48,6 +48,11 @@
 
         <!-- Third Party Provided Dependencies -->
         <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <scope>provided</scope>

--- a/micrometer/src/main/java/io/atleon/micrometer/MeteringAloKafkaConsumerRecordSignalListener.java
+++ b/micrometer/src/main/java/io/atleon/micrometer/MeteringAloKafkaConsumerRecordSignalListener.java
@@ -1,0 +1,40 @@
+package io.atleon.micrometer;
+
+import io.atleon.kafka.AloKafkaConsumerRecordSignalListener;
+import io.atleon.util.ConfigLoading;
+import io.micrometer.core.instrument.Tag;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * An {@link AloKafkaConsumerRecordSignalListener} that applies metering to emitted
+ * {@link reactor.core.publisher.Signal}s referencing {@link io.atleon.core.Alo} of Kafka
+ * {@link ConsumerRecord}.
+ *
+ * @param <K> The types of keys in records consumed by this listener
+ * @param <V> The types of values in records consumed by this listener
+ */
+public class MeteringAloKafkaConsumerRecordSignalListener<K, V>
+    extends MeteringAloSignalListener<ConsumerRecord<K, V>>
+    implements AloKafkaConsumerRecordSignalListener<K, V> {
+
+    private String clientId = null;
+
+    @Override
+    public void configure(Map<String, ?> properties) {
+        super.configure(properties);
+        clientId = ConfigLoading.loadString(properties, CommonClientConfigs.CLIENT_ID_CONFIG).orElse(clientId);
+    }
+
+    @Override
+    protected Iterable<Tag> baseTags() {
+        return Arrays.asList(
+            Tag.of("source", "kafka-receive"),
+            Tag.of("client", Objects.toString(clientId))
+        );
+    }
+}

--- a/micrometer/src/main/java/io/atleon/micrometer/MeteringAloReceivedRabbitMQMessageSignalListener.java
+++ b/micrometer/src/main/java/io/atleon/micrometer/MeteringAloReceivedRabbitMQMessageSignalListener.java
@@ -1,0 +1,38 @@
+package io.atleon.micrometer;
+
+import io.atleon.rabbitmq.AloReceivedRabbitMQMessageSignalListener;
+import io.atleon.rabbitmq.ReceivedRabbitMQMessage;
+import io.atleon.util.ConfigLoading;
+import io.micrometer.core.instrument.Tag;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * An {@link AloReceivedRabbitMQMessageSignalListener} that applies metering to emitted
+ * {@link reactor.core.publisher.Signal}s referencing {@link io.atleon.core.Alo} of
+ * {@link ReceivedRabbitMQMessage}.
+ *
+ * @param <T> The types of (deserialized) body payloads referenced by {@link ReceivedRabbitMQMessage}s
+ */
+public class MeteringAloReceivedRabbitMQMessageSignalListener<T>
+    extends MeteringAloSignalListener<ReceivedRabbitMQMessage<T>>
+    implements AloReceivedRabbitMQMessageSignalListener<T> {
+
+    private String queue = null;
+
+    @Override
+    public void configure(Map<String, ?> properties) {
+        super.configure(properties);
+        this.queue = ConfigLoading.loadString(properties, QUEUE_CONFIG).orElse(queue);
+    }
+
+    @Override
+    protected Iterable<Tag> baseTags() {
+        return Arrays.asList(
+            Tag.of("source", "rabbitmq-receive"),
+            Tag.of("queue", Objects.toString(queue))
+        );
+    }
+}

--- a/micrometer/src/main/java/io/atleon/micrometer/MeteringAloReceivedSqsMessageSignalListener.java
+++ b/micrometer/src/main/java/io/atleon/micrometer/MeteringAloReceivedSqsMessageSignalListener.java
@@ -1,0 +1,38 @@
+package io.atleon.micrometer;
+
+import io.atleon.aws.sqs.AloReceivedSqsMessageSignalListener;
+import io.atleon.aws.sqs.ReceivedSqsMessage;
+import io.atleon.util.ConfigLoading;
+import io.micrometer.core.instrument.Tag;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * An {@link AloReceivedSqsMessageSignalListener} that applies metering to emitted
+ * {@link reactor.core.publisher.Signal}s referencing {@link io.atleon.core.Alo} of
+ * {@link ReceivedSqsMessage}.
+ *
+ * @param <T> The types of (deserialized) body payloads referenced by {@link ReceivedSqsMessage}s
+ */
+public class MeteringAloReceivedSqsMessageSignalListener<T>
+    extends MeteringAloSignalListener<ReceivedSqsMessage<T>>
+    implements AloReceivedSqsMessageSignalListener<T> {
+
+    private String queueUrl = null;
+
+    @Override
+    public void configure(Map<String, ?> properties) {
+        super.configure(properties);
+        this.queueUrl = ConfigLoading.loadString(properties, QUEUE_URL_CONFIG).orElse(queueUrl);
+    }
+
+    @Override
+    protected Iterable<Tag> baseTags() {
+        return Arrays.asList(
+            Tag.of("source", "sqs-receive"),
+            Tag.of("queueUrl", Objects.toString(queueUrl))
+        );
+    }
+}

--- a/micrometer/src/main/java/io/atleon/micrometer/MeteringAloSignalListener.java
+++ b/micrometer/src/main/java/io/atleon/micrometer/MeteringAloSignalListener.java
@@ -1,0 +1,96 @@
+package io.atleon.micrometer;
+
+import io.atleon.core.Alo;
+import io.atleon.core.AloSignalListener;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import reactor.core.publisher.Signal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Templated implementation of metering on {@link Signal}s referencing {@link Alo} values
+ *
+ * @param <T> The type of data exposed by Alo items in emitted Signal values
+ */
+public abstract class MeteringAloSignalListener<T> implements AloSignalListener<T> {
+
+    private final MeterFacade meterFacade;
+
+    private final String name;
+
+    protected MeteringAloSignalListener() {
+        this("atleon.alo.publisher.signal");
+    }
+
+    protected MeteringAloSignalListener(String name) {
+        this(Metrics.globalRegistry, name);
+    }
+
+    protected MeteringAloSignalListener(MeterRegistry meterRegistry, String name) {
+        this.meterFacade = MeterFacade.wrap(meterRegistry);
+        this.name = name;
+    }
+
+    public static <T> AloSignalListener<T> composed(String name, String... tagKeyValues) {
+        return new Composed<>(name, Tags.of(tagKeyValues), value -> Tags.empty());
+    }
+
+    public static <T> AloSignalListener<T>
+    composed(String name, Iterable<Tag> baseTags, Function<? super T, Iterable<Tag>> valueTagsExtractor) {
+        return new Composed<>(name, Tags.of(baseTags), valueTagsExtractor);
+    }
+
+    @Override
+    public void accept(Signal<Alo<T>> signal) {
+        switch (signal.getType()) {
+            case CANCEL:
+            case ON_NEXT:
+            case ON_ERROR:
+                meterFacade.counter(name, extractTags(signal)).increment();
+        }
+    }
+
+    protected final Tags extractTags(Signal<Alo<T>> signal) {
+        List<Tag> tags = new ArrayList<>();
+        baseTags().forEach(tags::add);
+        if (signal.hasValue()) {
+            extractValueTags(signal.get().get()).forEach(tags::add);
+        }
+        tags.add(Tag.of("signalType", signal.getType().name()));
+        return Tags.of(tags);
+    }
+
+    protected abstract Iterable<Tag> baseTags();
+
+    protected Iterable<Tag> extractValueTags(T value) {
+        return Tags.empty();
+    }
+
+    private static final class Composed<T> extends MeteringAloSignalListener<T> {
+
+        private final Tags baseTags;
+
+        private final Function<? super T, Iterable<Tag>> valueTagsExtractor;
+
+        public Composed(String name, Tags baseTags, Function<? super T, Iterable<Tag>> valueTagsExtractor) {
+            super(name);
+            this.baseTags = baseTags;
+            this.valueTagsExtractor = valueTagsExtractor;
+        }
+
+        @Override
+        protected Iterable<Tag> baseTags() {
+            return baseTags;
+        }
+
+        @Override
+        protected Iterable<Tag> extractValueTags(T value) {
+            return valueTagsExtractor.apply(value);
+        }
+    }
+}

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/AloReceivedRabbitMQMessageSignalListener.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/AloReceivedRabbitMQMessageSignalListener.java
@@ -1,0 +1,24 @@
+package io.atleon.rabbitmq;
+
+import io.atleon.core.AloSignalListener;
+
+/**
+ * Interface through which side effects on {@link reactor.core.publisher.Signal}s emitted from
+ * Reactor Publishers of {@link io.atleon.core.Alo}s referencing {@link ReceivedRabbitMQMessage}s
+ * can be implemented.
+ * <p>
+ * In order to have implementations automatically applied, you can use the
+ * {@link java.util.ServiceLoader} SPI and add the class names to
+ * {@code META-INF/services/io.atleon.rabbitmq.AloReceivedRabbitMQMessageSignalListener} in your
+ * project's resource directory.
+ *
+ * @param <T> The types of (deserialized) body payloads referenced by {@link ReceivedRabbitMQMessage}s
+ */
+public interface AloReceivedRabbitMQMessageSignalListener<T> extends AloSignalListener<ReceivedRabbitMQMessage<T>> {
+
+    /**
+     * This parameter will be populated during configuration to let the decorator know the name of
+     * the queue that is being consumed from.
+     */
+    String QUEUE_CONFIG = "alo.signal.listener.rabbitmq.queue";
+}


### PR DESCRIPTION
### :pencil: Description
- Add `AloSignalListener` to be plugged in to reactive `Alo` pipelines
- Copy `auto` functionality from `AloDecorator`
- Implement Micrometer listeners and add to `auto` listeners files
- Deprecate AloFlux#metrics in favor of `doOnEach`

### :link: Related Issues
#136 