### PR TITLE
#138: Make metric naming and tagging consistent

### DIFF
--- a/core/src/main/java/io/atleon/core/AloFlux.java
+++ b/core/src/main/java/io/atleon/core/AloFlux.java
@@ -398,6 +398,7 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
      * {@link AloSignalListener} (i.e. from atleon-micrometer), or using auto-listening (see Atleon
      * documentation for details)
      */
+    @Deprecated
     public AloFlux<T> metrics(String name, Map<String, String> tags) {
         Flux<Alo<T>> toWrap = wrapped.name(name);
         for (Map.Entry<String, String> entry : tags.entrySet()) {

--- a/examples/core/src/main/java/io/atleon/examples/metrics/KafkaMicrometer.java
+++ b/examples/core/src/main/java/io/atleon/examples/metrics/KafkaMicrometer.java
@@ -74,10 +74,8 @@ public class KafkaMicrometer {
         //Step 6) Apply stream processing to the Kafka topic we produced records to
         AloKafkaReceiver.<String>forValues(kafkaReceiverConfig)
             .receiveAloValues(Collections.singletonList(TOPIC_1))
-            .metrics(KafkaMicrometer.class.getSimpleName(), "flow", "inbound")
             .map(String::toUpperCase)
             .transform(AloKafkaSender.<String, String>from(kafkaSenderConfig).sendAloValues(TOPIC_2, Function.identity()))
-            .metrics(KafkaMicrometer.class.getSimpleName(), "flow", "outbound")
             .consumeAloAndGet(Alo::acknowledge)
             .publish()
             .autoConnect(0)

--- a/micrometer/src/main/java/io/atleon/micrometer/MeterFacade.java
+++ b/micrometer/src/main/java/io/atleon/micrometer/MeterFacade.java
@@ -33,11 +33,19 @@ public final class MeterFacade {
     }
 
     public Counter counter(String name, Tags tags) {
-        return counters.computeIfAbsent(new MeterKey(name, tags), this::newCounter);
+        return counter(new MeterKey(name, tags));
+    }
+
+    public Counter counter(MeterKey meterKey) {
+        return counters.computeIfAbsent(meterKey, this::newCounter);
     }
 
     public Timer timer(String name, Tags tags) {
-        return timers.computeIfAbsent(new MeterKey(name, tags), this::newTimer);
+        return timer(new MeterKey(name, tags));
+    }
+
+    public Timer timer(MeterKey meterKey) {
+        return timers.computeIfAbsent(meterKey, this::newTimer);
     }
 
     private Counter newCounter(MeterKey meterKey) {

--- a/micrometer/src/main/java/io/atleon/micrometer/MeterKey.java
+++ b/micrometer/src/main/java/io/atleon/micrometer/MeterKey.java
@@ -26,6 +26,14 @@ public final class MeterKey {
         this.tags = tags;
     }
 
+    public MeterKey withNameQualifier(String qualifier) {
+        return new MeterKey(name + "." + qualifier, tags);
+    }
+
+    public MeterKey withNameQualifierAndTag(String qualifier, String tagKey, String tagValue) {
+        return new MeterKey(name + "." + qualifier, tags.and(tagKey, tagValue));
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/micrometer/src/main/java/io/atleon/micrometer/MeteringAlo.java
+++ b/micrometer/src/main/java/io/atleon/micrometer/MeteringAlo.java
@@ -2,7 +2,6 @@ package io.atleon.micrometer;
 
 import io.atleon.core.AbstractDecoratingAlo;
 import io.atleon.core.Alo;
-import io.micrometer.core.instrument.Tags;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -18,56 +17,64 @@ public class MeteringAlo<T> extends AbstractDecoratingAlo<T> {
 
     protected final MeterFacade meterFacade;
 
-    protected final Tags baseTags;
+    protected final MeterKey baseMeterKey;
 
     protected final Instant startedAt;
 
-    private MeteringAlo(Alo<T> delegate, MeterFacade meterFacade, Tags baseTags, Instant startedAt) {
+    private MeteringAlo(Alo<T> delegate, MeterFacade meterFacade, MeterKey baseMeterKey, Instant startedAt) {
         super(delegate);
         this.meterFacade = meterFacade;
-        this.baseTags = baseTags;
+        this.baseMeterKey = baseMeterKey;
         this.startedAt = startedAt;
     }
 
-    public static <T> MeteringAlo<T> start(Alo<T> delegate, MeterFacade meterFacade, Tags baseTags) {
-        meterFacade.counter("atleon.alo.start", baseTags).increment();
-        return new MeteringAlo<>(delegate, meterFacade, baseTags, Instant.now());
+    public static <T> MeteringAlo<T> start(Alo<T> delegate, MeterFacade meterFacade, MeterKey baseMeterKey) {
+        meterFacade.counter(baseMeterKey.withNameQualifier("start")).increment();
+        return new MeteringAlo<>(delegate, meterFacade, baseMeterKey, Instant.now());
     }
 
     @Override
     public <R> Alo<R> map(Function<? super T, ? extends R> mapper) {
-        return new MeteringAlo<>(delegate.map(mapper), meterFacade, baseTags, startedAt);
+        return new MeteringAlo<>(delegate.map(mapper), meterFacade, baseMeterKey, startedAt);
     }
 
     @Override
     public Runnable getAcknowledger() {
-        return applyMetering(delegate.getAcknowledger(), meterFacade, baseTags, startedAt);
+        return applyMetering(delegate.getAcknowledger(), meterFacade, baseMeterKey, startedAt);
     }
 
     @Override
     public Consumer<? super Throwable> getNacknowledger() {
-        return applyMetering(delegate.getNacknowledger(), meterFacade, baseTags, startedAt);
+        return applyMetering(delegate.getNacknowledger(), meterFacade, baseMeterKey, startedAt);
     }
 
-    private static Runnable
-    applyMetering(Runnable acknowledger, MeterFacade meterFacade, Tags baseTags, Instant startedAt) {
+    private static Runnable applyMetering(
+        Runnable acknowledger,
+        MeterFacade meterFacade,
+        MeterKey baseMeterKey,
+        Instant startedAt
+    ) {
         return () -> {
             try {
                 acknowledger.run();
             } finally {
-                meterFacade.timer("atleon.alo.duration", baseTags.and("result", "success"))
+                meterFacade.timer(baseMeterKey.withNameQualifierAndTag("duration", "result", "success"))
                     .record(Duration.between(startedAt, Instant.now()));
             }
         };
     }
 
-    private static Consumer<Throwable>
-    applyMetering(Consumer<? super Throwable> nacknowledger, MeterFacade meterFacade, Tags baseTags, Instant startedAt) {
+    private static Consumer<Throwable> applyMetering(
+        Consumer<? super Throwable> nacknowledger,
+        MeterFacade meterFacade,
+        MeterKey baseMeterKey,
+        Instant startedAt
+    ) {
         return error -> {
             try {
                 nacknowledger.accept(error);
             } finally {
-                meterFacade.timer("atleon.alo.duration", baseTags.and("result", "failure"))
+                meterFacade.timer(baseMeterKey.withNameQualifierAndTag("duration", "result", "failure"))
                     .record(Duration.between(startedAt, Instant.now()));
             }
         };

--- a/micrometer/src/main/java/io/atleon/micrometer/MeteringAloDecorator.java
+++ b/micrometer/src/main/java/io/atleon/micrometer/MeteringAloDecorator.java
@@ -2,6 +2,8 @@ package io.atleon.micrometer;
 
 import io.atleon.core.Alo;
 import io.atleon.core.AloDecorator;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tags;
 
 /**
@@ -11,12 +13,23 @@ import io.micrometer.core.instrument.Tags;
  */
 public abstract class MeteringAloDecorator<T> implements AloDecorator<T> {
 
-    private final MeterFacade meterFacade = MeterFacade.global();
+    private final MeterFacade meterFacade;
+
+    private final String name;
+
+    protected MeteringAloDecorator(String name) {
+        this(Metrics.globalRegistry, name);
+    }
+
+    protected MeteringAloDecorator(MeterRegistry meterRegistry, String name) {
+        this.meterFacade = MeterFacade.wrap(meterRegistry);
+        this.name = name;
+    }
 
     @Override
     public final Alo<T> decorate(Alo<T> alo) {
-        Tags tags = extractTags(alo.get());
-        return MeteringAlo.start(alo, meterFacade, tags);
+        MeterKey baseMeterKey = new MeterKey(name, extractTags(alo.get()));
+        return MeteringAlo.start(alo, meterFacade, baseMeterKey);
     }
 
     /**

--- a/micrometer/src/main/java/io/atleon/micrometer/MeteringAloKafkaConsumerRecordDecorator.java
+++ b/micrometer/src/main/java/io/atleon/micrometer/MeteringAloKafkaConsumerRecordDecorator.java
@@ -23,6 +23,10 @@ public class MeteringAloKafkaConsumerRecordDecorator<K, V>
 
     private String clientId = null;
 
+    public MeteringAloKafkaConsumerRecordDecorator() {
+        super("atleon.alo.kafka.receive");
+    }
+
     @Override
     public void configure(Map<String, ?> properties) {
         super.configure(properties);
@@ -32,7 +36,6 @@ public class MeteringAloKafkaConsumerRecordDecorator<K, V>
     @Override
     protected Tags extractTags(ConsumerRecord<K, V> consumerRecord) {
         return Tags.of(
-            Tag.of("type", "kafka"),
             Tag.of("client", Objects.toString(clientId)),
             Tag.of("topic", consumerRecord.topic())
         );

--- a/micrometer/src/main/java/io/atleon/micrometer/MeteringAloKafkaConsumerRecordSignalListener.java
+++ b/micrometer/src/main/java/io/atleon/micrometer/MeteringAloKafkaConsumerRecordSignalListener.java
@@ -6,7 +6,7 @@ import io.micrometer.core.instrument.Tag;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -24,6 +24,10 @@ public class MeteringAloKafkaConsumerRecordSignalListener<K, V>
 
     private String clientId = null;
 
+    public MeteringAloKafkaConsumerRecordSignalListener() {
+        super("atleon.alo.publisher.signal.kafka.receive");
+    }
+
     @Override
     public void configure(Map<String, ?> properties) {
         super.configure(properties);
@@ -32,9 +36,6 @@ public class MeteringAloKafkaConsumerRecordSignalListener<K, V>
 
     @Override
     protected Iterable<Tag> baseTags() {
-        return Arrays.asList(
-            Tag.of("type", "kafka-receive"),
-            Tag.of("client", Objects.toString(clientId))
-        );
+        return Collections.singleton(Tag.of("client", Objects.toString(clientId)));
     }
 }

--- a/micrometer/src/main/java/io/atleon/micrometer/MeteringAloReceivedRabbitMQMessageDecorator.java
+++ b/micrometer/src/main/java/io/atleon/micrometer/MeteringAloReceivedRabbitMQMessageDecorator.java
@@ -4,7 +4,6 @@ import io.atleon.core.Alo;
 import io.atleon.rabbitmq.AloReceivedRabbitMQMessageDecorator;
 import io.atleon.rabbitmq.ReceivedRabbitMQMessage;
 import io.atleon.util.ConfigLoading;
-import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 
 import java.util.Map;
@@ -21,6 +20,10 @@ public class MeteringAloReceivedRabbitMQMessageDecorator<T>
 
     private String queue = null;
 
+    public MeteringAloReceivedRabbitMQMessageDecorator() {
+        super("atleon.alo.rabbitmq.receive");
+    }
+
     @Override
     public void configure(Map<String, ?> properties) {
         super.configure(properties);
@@ -29,9 +32,6 @@ public class MeteringAloReceivedRabbitMQMessageDecorator<T>
 
     @Override
     protected Tags extractTags(ReceivedRabbitMQMessage<T> receivedRabbitMQMessage) {
-        return Tags.of(
-            Tag.of("type", "rabbitmq"),
-            Tag.of("queue", Objects.toString(queue))
-        );
+        return Tags.of("queue", Objects.toString(queue));
     }
 }

--- a/micrometer/src/main/java/io/atleon/micrometer/MeteringAloReceivedRabbitMQMessageSignalListener.java
+++ b/micrometer/src/main/java/io/atleon/micrometer/MeteringAloReceivedRabbitMQMessageSignalListener.java
@@ -5,7 +5,7 @@ import io.atleon.rabbitmq.ReceivedRabbitMQMessage;
 import io.atleon.util.ConfigLoading;
 import io.micrometer.core.instrument.Tag;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -22,6 +22,10 @@ public class MeteringAloReceivedRabbitMQMessageSignalListener<T>
 
     private String queue = null;
 
+    public MeteringAloReceivedRabbitMQMessageSignalListener() {
+        super("atleon.alo.publisher.signal.rabbitmq.receive");
+    }
+
     @Override
     public void configure(Map<String, ?> properties) {
         super.configure(properties);
@@ -30,9 +34,6 @@ public class MeteringAloReceivedRabbitMQMessageSignalListener<T>
 
     @Override
     protected Iterable<Tag> baseTags() {
-        return Arrays.asList(
-            Tag.of("type", "rabbitmq-receive"),
-            Tag.of("queue", Objects.toString(queue))
-        );
+        return Collections.singletonList(Tag.of("queue", Objects.toString(queue)));
     }
 }

--- a/micrometer/src/main/java/io/atleon/micrometer/MeteringAloReceivedSqsMessageDecorator.java
+++ b/micrometer/src/main/java/io/atleon/micrometer/MeteringAloReceivedSqsMessageDecorator.java
@@ -4,7 +4,6 @@ import io.atleon.aws.sqs.AloReceivedSqsMessageDecorator;
 import io.atleon.aws.sqs.ReceivedSqsMessage;
 import io.atleon.core.Alo;
 import io.atleon.util.ConfigLoading;
-import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 
 import java.util.Map;
@@ -21,6 +20,10 @@ public class MeteringAloReceivedSqsMessageDecorator<T>
 
     private String queueUrl = null;
 
+    public MeteringAloReceivedSqsMessageDecorator() {
+        super("atleon.alo.sqs.receive");
+    }
+
     @Override
     public void configure(Map<String, ?> properties) {
         super.configure(properties);
@@ -29,9 +32,6 @@ public class MeteringAloReceivedSqsMessageDecorator<T>
 
     @Override
     protected Tags extractTags(ReceivedSqsMessage<T> receivedSqsMessage) {
-        return Tags.of(
-            Tag.of("type", "sqs"),
-            Tag.of("queue_url", Objects.toString(queueUrl))
-        );
+        return Tags.of("queue_url", Objects.toString(queueUrl));
     }
 }

--- a/micrometer/src/main/java/io/atleon/micrometer/MeteringAloReceivedSqsMessageSignalListener.java
+++ b/micrometer/src/main/java/io/atleon/micrometer/MeteringAloReceivedSqsMessageSignalListener.java
@@ -5,7 +5,7 @@ import io.atleon.aws.sqs.ReceivedSqsMessage;
 import io.atleon.util.ConfigLoading;
 import io.micrometer.core.instrument.Tag;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -22,6 +22,10 @@ public class MeteringAloReceivedSqsMessageSignalListener<T>
 
     private String queueUrl = null;
 
+    public MeteringAloReceivedSqsMessageSignalListener() {
+        super("atleon.alo.publisher.signal.sqs.receive");
+    }
+
     @Override
     public void configure(Map<String, ?> properties) {
         super.configure(properties);
@@ -30,9 +34,6 @@ public class MeteringAloReceivedSqsMessageSignalListener<T>
 
     @Override
     protected Iterable<Tag> baseTags() {
-        return Arrays.asList(
-            Tag.of("type", "sqs-receive"),
-            Tag.of("queue_url", Objects.toString(queueUrl))
-        );
+        return Collections.singletonList(Tag.of("queue_url", Objects.toString(queueUrl)));
     }
 }

--- a/micrometer/src/main/java/io/atleon/micrometer/MeteringAloSignalListener.java
+++ b/micrometer/src/main/java/io/atleon/micrometer/MeteringAloSignalListener.java
@@ -23,10 +23,6 @@ public abstract class MeteringAloSignalListener<T> implements AloSignalListener<
 
     private final String name;
 
-    protected MeteringAloSignalListener() {
-        this("atleon.alo.publisher.signal");
-    }
-
     protected MeteringAloSignalListener(String name) {
         this(Metrics.globalRegistry, name);
     }


### PR DESCRIPTION
### :pencil: Description

For any given metric name, ensure same tags are always provided

### :link: Related Issues

#138 
