### PR TITLE
#154: Provide terminal `consume` operator on `AloFlux`

### DIFF
--- a/core/src/main/java/io/atleon/core/AloFlux.java
+++ b/core/src/main/java/io/atleon/core/AloFlux.java
@@ -142,6 +142,17 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
     }
 
     /**
+     * Apply a terminal consumption to the pipeline, acknowledging the corresponding {@link Alo}
+     * upon successful consumer invocation. Resulting AloFlux will emit no values.
+     *
+     * @param consumer Terminal consumption to be applied to each {@link Alo}'s data item
+     * @return A new AloFlux that emits no values
+     */
+    public AloFlux<Void> consume(Consumer<? super T> consumer) {
+        return new AloFlux<>(wrapped.handle(AloOps.consumingHandler(consumer, Alo::acknowledge)));
+    }
+
+    /**
      * @see Flux#concatMap(Function)
      */
     public <V> AloFlux<V> concatMap(Function<? super T, ? extends Publisher<V>> mapper) {

--- a/core/src/main/java/io/atleon/core/AloOps.java
+++ b/core/src/main/java/io/atleon/core/AloOps.java
@@ -87,6 +87,19 @@ final class AloOps {
         };
     }
 
+    public static <T> BiConsumer<Alo<T>, SynchronousSink<Alo<Void>>>
+    consumingHandler(Consumer<? super T> consumer, Consumer<? super Alo<T>> afterSuccessConsumer) {
+        return (alo, sink) -> {
+            try {
+                consumer.accept(alo.get());
+            } catch (Throwable error) {
+                throw Throwing.propagate(error);
+            }
+
+            afterSuccessConsumer.accept(alo);
+        };
+    }
+
     public static <T> Alo<List<T>> fanIn(List<Alo<T>> alos) {
         Alo<T> firstAlo = alos.get(0);
         if (alos.size() == 1) {

--- a/core/src/test/java/io/atleon/core/AloFluxTest.java
+++ b/core/src/test/java/io/atleon/core/AloFluxTest.java
@@ -48,6 +48,16 @@ class AloFluxTest {
     }
 
     @Test
+    public void alosCanBeConsumed() {
+        TestAlo alo = new TestAlo("DATA");
+
+        Flux.just(alo).as(AloFlux::wrap).consume(System.out::println)
+            .subscribe(__ -> { throw new IllegalStateException("Should not emit anything"); });
+
+        assertTrue(alo.isAcknowledged());
+    }
+
+    @Test
     public void emptyManyMappingHasConsumerExecuted() {
         TestAlo empty = new TestAlo("");
         Flux.just(empty).as(AloFlux::wrap).flatMapCollection(this::extractCharacters).unwrap().then().block();


### PR DESCRIPTION
### :pencil: Description
Allow more intuitive terminal consumption of data items and subsequent subscription

### :link: Related Issues
#154 
