### PR TITLE
#162: Always execute acknowledgement in order

### DIFF
--- a/core/src/main/java/io/atleon/core/AcknowledgementQueue.java
+++ b/core/src/main/java/io/atleon/core/AcknowledgementQueue.java
@@ -18,16 +18,7 @@ abstract class AcknowledgementQueue {
 
     protected final Queue<InFlight> queue = new ConcurrentLinkedQueue<>();
 
-    private final boolean executeErrorsImmediately;
-
     private volatile int drainsInProgress;
-
-    /**
-     * @param executeErrorsImmediately Whether or not errored Acknowledgements are immediately executed
-     */
-    public AcknowledgementQueue(boolean executeErrorsImmediately) {
-        this.executeErrorsImmediately = executeErrorsImmediately;
-    }
 
     /**
      * Append an In-Flight Acknowledgement to the Queue backed by the following Acknowledger and
@@ -53,11 +44,7 @@ abstract class AcknowledgementQueue {
      * @return The number of elements drained from this Queue due to completion of Acknowledgement
      */
     public long completeExceptionally(InFlight toComplete, Throwable error) {
-        boolean completed = complete(toComplete, inFlight -> inFlight.completeExceptionally(error));
-        if (completed && executeErrorsImmediately) {
-            toComplete.execute();
-        }
-        return completed ? drain() : 0L;
+        return complete(toComplete, inFlight -> inFlight.completeExceptionally(error)) ? drain() : 0L;
     }
 
     protected abstract boolean complete(InFlight inFlight, Function<InFlight, Boolean> completer);

--- a/core/src/main/java/io/atleon/core/AloOps.java
+++ b/core/src/main/java/io/atleon/core/AloOps.java
@@ -43,11 +43,14 @@ final class AloOps {
     public static <T, R> Function<Alo<T>, Alo<R>>
     mapping(Function<? super T, ? extends R> mapper) {
         return alo -> {
+            Alo<R> result;
             try {
-                return Objects.requireNonNull(alo.map(mapper), "Alo implementation returned null mapping");
+                result = Objects.requireNonNull(alo.map(mapper), "Alo implementation returned null mapping");
             } catch (Throwable error) {
                 throw Throwing.propagate(error);
             }
+
+            return result;
         };
     }
 

--- a/core/src/main/java/io/atleon/core/MultipleAcknowledgementOperator.java
+++ b/core/src/main/java/io/atleon/core/MultipleAcknowledgementOperator.java
@@ -21,6 +21,8 @@ public class MultipleAcknowledgementOperator<T, A extends Alo<T>> implements Pub
 
     @Override
     public void subscribe(Subscriber<? super Alo<T>> actual) {
-        source.subscribe(new AloQueueingSubscriber<>(actual, groupExtractor, MultipleAcknowledgementQueue::new, maxInFlight));
+        source.subscribe(
+            new AloQueueingSubscriber<>(actual, groupExtractor, MultipleAcknowledgementQueue::create, maxInFlight)
+        );
     }
 }

--- a/core/src/main/java/io/atleon/core/MultipleAcknowledgementQueue.java
+++ b/core/src/main/java/io/atleon/core/MultipleAcknowledgementQueue.java
@@ -5,8 +5,12 @@ import java.util.function.Function;
 
 final class MultipleAcknowledgementQueue extends AcknowledgementQueue {
 
-    public MultipleAcknowledgementQueue() {
-        super(false);
+    private MultipleAcknowledgementQueue() {
+
+    }
+
+    public static AcknowledgementQueue create() {
+        return new MultipleAcknowledgementQueue();
     }
 
     //TODO This method may possibly be made more performant, but would be non-trivial to do so. At

--- a/core/src/main/java/io/atleon/core/OrderManagingAcknowledgementOperator.java
+++ b/core/src/main/java/io/atleon/core/OrderManagingAcknowledgementOperator.java
@@ -34,6 +34,6 @@ public class OrderManagingAcknowledgementOperator<T, A extends Alo<T>> implement
     }
 
     private static Supplier<AcknowledgementQueue> newQueueSupplier() {
-        return OrderManagingAcknowledgementQueue::newWithImmediateErrors;
+        return OrderManagingAcknowledgementQueue::create;
     }
 }

--- a/core/src/main/java/io/atleon/core/OrderManagingAcknowledgementQueue.java
+++ b/core/src/main/java/io/atleon/core/OrderManagingAcknowledgementQueue.java
@@ -4,16 +4,12 @@ import java.util.function.Function;
 
 final class OrderManagingAcknowledgementQueue extends AcknowledgementQueue {
 
-    private OrderManagingAcknowledgementQueue(boolean executeErrorsImmediately) {
-        super(executeErrorsImmediately);
+    private OrderManagingAcknowledgementQueue() {
+
     }
 
-    public static OrderManagingAcknowledgementQueue newWithImmediateErrors() {
-        return new OrderManagingAcknowledgementQueue(true);
-    }
-
-    public static OrderManagingAcknowledgementQueue newWithInOrderErrors() {
-        return new OrderManagingAcknowledgementQueue(false);
+    public static AcknowledgementQueue create() {
+        return new OrderManagingAcknowledgementQueue();
     }
 
     @Override

--- a/core/src/test/java/io/atleon/core/AloQueuingSubscriberTest.java
+++ b/core/src/test/java/io/atleon/core/AloQueuingSubscriberTest.java
@@ -56,7 +56,9 @@ public class AloQueuingSubscriberTest {
         Subscriber<Alo<String>> subscriber = Adapters.toSubscriber(emitted::add);
 
         Sinks.Many<TestAlo> sink = Sinks.many().multicast().onBackpressureBuffer();
-        sink.asFlux().subscribe(new AloQueueingSubscriber<>(subscriber, String::length, OrderManagingAcknowledgementQueue::newWithImmediateErrors, 2));
+        sink.asFlux().subscribe(
+            new AloQueueingSubscriber<>(subscriber, String::length, OrderManagingAcknowledgementQueue::create, 2)
+        );
 
         sink.tryEmitNext(firstAcknowledgeable);
         sink.tryEmitNext(secondAcknowledgeable);
@@ -99,7 +101,9 @@ public class AloQueuingSubscriberTest {
         Subscriber<Alo<String>> subscriber = Adapters.toSubscriber(emitted::add);
 
         Sinks.Many<TestAlo> sink = Sinks.many().multicast().onBackpressureBuffer();
-        sink.asFlux().subscribe(new AloQueueingSubscriber<>(subscriber, String::length, OrderManagingAcknowledgementQueue::newWithImmediateErrors, 2));
+        sink.asFlux().subscribe(
+            new AloQueueingSubscriber<>(subscriber, String::length, OrderManagingAcknowledgementQueue::create, 2)
+        );
 
         sink.tryEmitNext(mom);
         sink.tryEmitNext(dad);
@@ -159,7 +163,9 @@ public class AloQueuingSubscriberTest {
         List<Alo<String>> emitted = new ArrayList<>();
         Subscriber<Alo<String>> subscriber = Adapters.toSubscriber(emitted::add);
 
-        sink.asFlux().subscribe(new AloQueueingSubscriber<>(subscriber, String::length, OrderManagingAcknowledgementQueue::newWithImmediateErrors, 3));
+        sink.asFlux().subscribe(
+            new AloQueueingSubscriber<>(subscriber, String::length, OrderManagingAcknowledgementQueue::create, 3)
+        );
 
         all.forEach(sink::tryEmitNext);
 

--- a/core/src/test/java/io/atleon/core/MultipleAcknowledgementQueueTest.java
+++ b/core/src/test/java/io/atleon/core/MultipleAcknowledgementQueueTest.java
@@ -14,7 +14,7 @@ public class MultipleAcknowledgementQueueTest {
 
     @Test
     public void acknowledgementAppliesUpToAndIncludingAllPreviousInFlightAcknowledgements() {
-        AcknowledgementQueue queue = new MultipleAcknowledgementQueue();
+        AcknowledgementQueue queue = MultipleAcknowledgementQueue.create();
 
         AtomicBoolean firstAcknowledged = new AtomicBoolean();
         AtomicReference<Throwable> firstNacknowledged = new AtomicReference<>();

--- a/core/src/test/java/io/atleon/core/OrderManagingAcknowledgementQueueTest.java
+++ b/core/src/test/java/io/atleon/core/OrderManagingAcknowledgementQueueTest.java
@@ -19,7 +19,7 @@ public class OrderManagingAcknowledgementQueueTest {
 
     @Test
     public void acknowledgementsAreExecutedInOrderOfCreationAfterCompletion() {
-        AcknowledgementQueue queue = OrderManagingAcknowledgementQueue.newWithInOrderErrors();
+        AcknowledgementQueue queue = OrderManagingAcknowledgementQueue.create();
 
         AtomicBoolean firstAcknowledged = new AtomicBoolean();
         AtomicBoolean secondAcknowledged = new AtomicBoolean();
@@ -46,7 +46,7 @@ public class OrderManagingAcknowledgementQueueTest {
 
     @Test
     public void nacknowledgementCanBeCompletedInOrder() {
-        AcknowledgementQueue queue = OrderManagingAcknowledgementQueue.newWithInOrderErrors();
+        AcknowledgementQueue queue = OrderManagingAcknowledgementQueue.create();
 
         AtomicBoolean firstAcknowledged = new AtomicBoolean();
         AtomicReference<Throwable> firstNacknowledged = new AtomicReference<>();
@@ -74,45 +74,8 @@ public class OrderManagingAcknowledgementQueueTest {
     }
 
     @Test
-    public void nacknowledgementCanBeExecutedImmediately() {
-        AcknowledgementQueue queue = OrderManagingAcknowledgementQueue.newWithImmediateErrors();
-
-        AtomicBoolean firstAcknowledged = new AtomicBoolean();
-        AtomicReference<Throwable> firstNacknowledged = new AtomicReference<>();
-        AtomicBoolean secondAcknowledged = new AtomicBoolean();
-        AtomicReference<Throwable> secondNacknowledged = new AtomicReference<>();
-
-        AcknowledgementQueue.InFlight firstInFlight = queue.add(() -> firstAcknowledged.set(true), firstNacknowledged::set);
-        AcknowledgementQueue.InFlight secondInFlight = queue.add(() -> secondAcknowledged.set(true), secondNacknowledged::set);
-
-        long drained = queue.completeExceptionally(secondInFlight, new IllegalStateException());
-
-        assertEquals(0L, drained);
-        assertFalse(firstAcknowledged.get());
-        assertNull(firstNacknowledged.get());
-        assertFalse(secondAcknowledged.get());
-        assertTrue(secondNacknowledged.get() instanceof IllegalStateException);
-
-        drained = queue.complete(secondInFlight);
-
-        assertEquals(0L, drained);
-        assertFalse(firstAcknowledged.get());
-        assertNull(firstNacknowledged.get());
-        assertFalse(secondAcknowledged.get());
-        assertTrue(secondNacknowledged.get() instanceof IllegalStateException);
-
-        drained = queue.complete(firstInFlight);
-
-        assertEquals(2L, drained);
-        assertTrue(firstAcknowledged.get());
-        assertNull(firstNacknowledged.get());
-        assertFalse(secondAcknowledged.get());
-        assertTrue(secondNacknowledged.get() instanceof IllegalStateException);
-    }
-
-    @Test
     public void recompletionOfInFlightsIsIgnored() {
-        AcknowledgementQueue queue = OrderManagingAcknowledgementQueue.newWithInOrderErrors();
+        AcknowledgementQueue queue = OrderManagingAcknowledgementQueue.create();
 
         AtomicInteger firstAcknowledgements = new AtomicInteger();
         AtomicReference<Throwable> firstNacknowledged = new AtomicReference<>();
@@ -174,7 +137,7 @@ public class OrderManagingAcknowledgementQueueTest {
         CompletableFuture<Boolean> secondAcknowledgementStarted = new CompletableFuture<>();
         Runnable secondAcknowledger = () -> secondAcknowledgementStarted.complete(true);
 
-        AcknowledgementQueue queue = OrderManagingAcknowledgementQueue.newWithInOrderErrors();
+        AcknowledgementQueue queue = OrderManagingAcknowledgementQueue.create();
 
         AcknowledgementQueue.InFlight firstInFlight = queue.add(firstAcknowledger, error -> {});
         AcknowledgementQueue.InFlight secondInFlight = queue.add(secondAcknowledger, error -> {});


### PR DESCRIPTION
### :pencil: Description
- Always execute acknowledgement in order
- Rely on the fact that we can't drop `Alo` items

### :link: Related Issues
#162 
