### PR TITLE
#169: Implement configurable and consistent `Alo` failure handling modes

### DIFF
--- a/aws-sns/src/main/java/io/atleon/aws/sns/AloSnsSender.java
+++ b/aws-sns/src/main/java/io/atleon/aws/sns/AloSnsSender.java
@@ -2,6 +2,7 @@ package io.atleon.aws.sns;
 
 import io.atleon.core.Alo;
 import io.atleon.core.AloFlux;
+import io.atleon.core.SenderResult;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,9 +112,9 @@ public class AloSnsSender<T> implements Closeable {
         SnsMessageCreator<T> messageCreator,
         String topicArn
     ) {
-        return futureResources
-            .flatMapMany(resources -> resources.sendAlos(aloBodies, messageCreator, topicArn))
-            .as(AloFlux::wrap);
+        return futureResources.flatMapMany(resources -> resources.sendAlos(aloBodies, messageCreator, topicArn))
+            .as(AloFlux::wrap)
+            .processFailure(SenderResult::isFailure, SenderResult::toError);
     }
 
     public Function<Publisher<Alo<SnsMessage<T>>>, AloFlux<SnsSenderResult<SnsMessage<T>>>> sendAloMessages(
@@ -126,9 +127,9 @@ public class AloSnsSender<T> implements Closeable {
         Publisher<Alo<SnsMessage<T>>> aloMessages,
         String topicArn
     ) {
-        return futureResources
-            .flatMapMany(resources -> resources.sendAlos(aloMessages, Function.identity(), topicArn))
-            .as(AloFlux::wrap);
+        return futureResources.flatMapMany(resources -> resources.sendAlos(aloMessages, Function.identity(), topicArn))
+            .as(AloFlux::wrap)
+            .processFailure(SenderResult::isFailure, SenderResult::toError);
     }
 
     /**

--- a/aws-sqs/src/main/java/io/atleon/aws/sqs/AloSqsSender.java
+++ b/aws-sqs/src/main/java/io/atleon/aws/sqs/AloSqsSender.java
@@ -2,6 +2,7 @@ package io.atleon.aws.sqs;
 
 import io.atleon.core.Alo;
 import io.atleon.core.AloFlux;
+import io.atleon.core.SenderResult;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,9 +105,9 @@ public class AloSqsSender<T> implements Closeable {
         SqsMessageCreator<T> messageCreator,
         String queueUrl
     ) {
-        return futureResources
-            .flatMapMany(resources -> resources.sendAlos(aloBodies, messageCreator, queueUrl))
-            .as(AloFlux::wrap);
+        return futureResources.flatMapMany(resources -> resources.sendAlos(aloBodies, messageCreator, queueUrl))
+            .as(AloFlux::wrap)
+            .processFailure(SenderResult::isFailure, SenderResult::toError);
     }
 
     public Function<Publisher<Alo<SqsMessage<T>>>, AloFlux<SqsSenderResult<SqsMessage<T>>>> sendAloMessages(
@@ -119,9 +120,9 @@ public class AloSqsSender<T> implements Closeable {
         Publisher<Alo<SqsMessage<T>>> aloMessages,
         String queueUrl
     ) {
-        return futureResources
-            .flatMapMany(resources -> resources.sendAlos(aloMessages, Function.identity(), queueUrl))
-            .as(AloFlux::wrap);
+        return futureResources.flatMapMany(resources -> resources.sendAlos(aloMessages, Function.identity(), queueUrl))
+            .as(AloFlux::wrap)
+            .processFailure(SenderResult::isFailure, SenderResult::toError);
     }
 
     /**

--- a/core/src/main/java/io/atleon/core/AloFailureStrategy.java
+++ b/core/src/main/java/io/atleon/core/AloFailureStrategy.java
@@ -1,0 +1,89 @@
+package io.atleon.core;
+
+import reactor.core.publisher.SynchronousSink;
+
+import java.util.function.Predicate;
+
+/**
+ * A strategy applied when operations on {@link Alo} elements fail. When processing an error
+ * succeeds (strategy returns true), the calling context is safe to discard both the error and
+ * incriminating {@link Alo}, then continue processing. When processing an error fails (strategy
+ * returns false), the calling context must either negatively acknowledge the {@link Alo} element
+ * or otherwise forward the/an error-containing element in the pipeline.
+ */
+interface AloFailureStrategy {
+
+    AloFailureStrategy EMIT = new Emit(__ -> true);
+
+    AloFailureStrategy DELEGATE = new Delegate(__ -> true);
+
+    /**
+     * Process the error and the {@link Alo} that caused it.
+     * <p>
+     * If the strategy fully processes the error, potentially by calling
+     * {@link SynchronousSink#error(Throwable)} or {@link Alo#acknowledge(Alo)}, this method must
+     * return true. When the method returns false, handling the error is delegated to the caller,
+     * who may choose to call {@link Alo#nacknowledge(Alo, Throwable)} or otherwise forward the
+     * error in the pipeline.
+     *
+     * @param sink  Sink into which the provided error may be emitted
+     * @param alo   The Alo that caused the error
+     * @param error The error that has been encountered
+     * @return Whether the error has been fully handled
+     */
+    boolean process(SynchronousSink<?> sink, Alo<?> alo, Throwable error);
+
+    static AloFailureStrategy emit() {
+        return EMIT;
+    }
+
+    static AloFailureStrategy emitUnless(Predicate<? super Throwable> errorPredicate) {
+        return new Emit(errorPredicate.negate());
+    }
+
+    static AloFailureStrategy delegate() {
+        return DELEGATE;
+    }
+
+    static AloFailureStrategy delegateUnless(Predicate<? super Throwable> errorPredicate) {
+        return new Delegate(errorPredicate.negate());
+    }
+
+    class Emit implements AloFailureStrategy {
+
+        private final Predicate<? super Throwable> errorPredicate;
+
+        Emit(Predicate<? super Throwable> errorPredicate) {
+            this.errorPredicate = errorPredicate;
+        }
+
+        @Override
+        public boolean process(SynchronousSink<?> sink, Alo<?> alo, Throwable error) {
+            if (errorPredicate.test(error)) {
+                sink.error(error);
+            } else {
+                Alo.acknowledge(alo);
+            }
+            return true;
+        }
+    }
+
+    class Delegate implements AloFailureStrategy {
+
+        private final Predicate<? super Throwable> errorPredicate;
+
+        Delegate(Predicate<? super Throwable> errorPredicate) {
+            this.errorPredicate = errorPredicate;
+        }
+
+        @Override
+        public boolean process(SynchronousSink<?> sink, Alo<?> alo, Throwable error) {
+            if (errorPredicate.test(error)) {
+                return false;
+            } else {
+                Alo.acknowledge(alo);
+                return true;
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/atleon/core/AloGroupedFlux.java
+++ b/core/src/main/java/io/atleon/core/AloGroupedFlux.java
@@ -2,8 +2,9 @@ package io.atleon.core;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.GroupedFlux;
+import reactor.core.publisher.SynchronousSink;
 
-import java.util.function.Function;
+import java.util.function.BiConsumer;
 
 /**
  * A wrapper around Project Reactor's {@link GroupedFlux} for keys of type K and for Alo elements
@@ -27,8 +28,8 @@ public class AloGroupedFlux<K, T> extends AloFlux<T> {
     }
 
     static <K, T, R> AloGroupedFlux<K, R>
-    create(GroupedFlux<? extends K, Alo<T>> groupedFlux, Function<Alo<T>, Alo<R>> mapper) {
-        return new AloGroupedFlux<>(groupedFlux.map(mapper), groupedFlux.key());
+    create(GroupedFlux<? extends K, Alo<T>> groupedFlux, BiConsumer<Alo<T>, SynchronousSink<Alo<R>>> mappingHandler) {
+        return new AloGroupedFlux<>(groupedFlux.handle(mappingHandler), groupedFlux.key());
     }
 
     public K key() {

--- a/core/src/main/java/io/atleon/core/DefaultAloSenderResultSubscriber.java
+++ b/core/src/main/java/io/atleon/core/DefaultAloSenderResultSubscriber.java
@@ -20,7 +20,7 @@ public class DefaultAloSenderResultSubscriber<T extends SenderResult> extends Ba
             Alo.acknowledge(value);
         } else {
             hookBeforeNacknowledge(senderResult);
-            Alo.nacknowledge(value, senderResult.failureCause().orElseGet(() -> new SenderFailureException(senderResult)));
+            Alo.nacknowledge(value, SenderResult.toError(senderResult));
         }
     }
 
@@ -44,13 +44,6 @@ public class DefaultAloSenderResultSubscriber<T extends SenderResult> extends Ba
      */
     protected void hookBeforeNacknowledge(T senderResult) {
         Throwable failureCause = senderResult.failureCause().orElse(null);
-        LOGGER.warn("SenderResult of type={} has failureCause={}", senderResult.getClass().getSimpleName(), failureCause);
-    }
-
-    private static final class SenderFailureException extends RuntimeException {
-
-        private SenderFailureException(SenderResult senderResult) {
-            super("SenderResult is a failure: " + senderResult);
-        }
+        LOGGER.warn("SenderResult of type={} is failed", senderResult.getClass().getSimpleName(), failureCause);
     }
 }

--- a/core/src/main/java/io/atleon/core/ErrorEmitter.java
+++ b/core/src/main/java/io/atleon/core/ErrorEmitter.java
@@ -9,7 +9,7 @@ import reactor.core.publisher.Sinks;
 import java.time.Duration;
 
 /**
- * Utility class wrapping a {@link reactor.core.publisher.Sinks.Empty} that allows merging and
+ * Utility class wrapping a {@link Sinks.Empty} that allows applying to Publishers and
  * safe, timeout-based error emission.
  *
  * @param <T> The type of elements emitted in merged Publishers

--- a/core/src/main/java/io/atleon/core/SenderResult.java
+++ b/core/src/main/java/io/atleon/core/SenderResult.java
@@ -8,6 +8,18 @@ import java.util.Optional;
 public interface SenderResult {
 
     /**
+     * Convenience method for generating error from SenderResult. If the provided SenderResult has
+     * a failure cause, that is returned. Else a generic {@link FailureException} wrapping the
+     * provided SenderResult is returned.
+     *
+     * @param senderResult The SenderResult to
+     * @return An error that can be thrown or emitted
+     */
+    static Throwable toError(SenderResult senderResult) {
+        return senderResult.failureCause().orElseGet(() -> new FailureException(senderResult));
+    }
+
+    /**
      * Whether this result represents a failure to send a message
      *
      * @return True if the result from attempting to send a message has failed
@@ -23,4 +35,14 @@ public interface SenderResult {
      * @return Underlying cause of send failure if available
      */
     Optional<Throwable> failureCause();
+
+    /**
+     * A generic Exception wrapping a SenderResult that has failed to be processed
+     */
+    class FailureException extends RuntimeException {
+
+        FailureException(SenderResult senderResult) {
+            super("Failed processing where senderResult=" + senderResult);
+        }
+    }
 }

--- a/examples/core/src/main/java/io/atleon/examples/errorhandling/KafkaErrorHandling.java
+++ b/examples/core/src/main/java/io/atleon/examples/errorhandling/KafkaErrorHandling.java
@@ -85,7 +85,6 @@ public class KafkaErrorHandling {
         AloKafkaSender<String, String> sender = AloKafkaSender.from(faultyKafkaSenderConfig);
         AloKafkaReceiver.<String>forValues(kafkaReceiverConfig)
             .receiveAloValues(Collections.singletonList(TOPIC_1))
-            .resubscribeOnError(KafkaErrorHandling.class.getSimpleName(), Duration.ofSeconds(2L))
             .groupBy(Function.identity())
             .map(groupedFlux -> groupedFlux
                 .publishOn(Schedulers.boundedElastic())
@@ -107,6 +106,7 @@ public class KafkaErrorHandling {
                     successfullyProcessed.add(senderResult.correlationMetadata());
                 }
             })
+            .resubscribeOnError(KafkaErrorHandling.class.getSimpleName(), Duration.ofSeconds(2L))
             .subscribe(new DefaultAloSenderResultSubscriber<>());
 
         //Step 5) Produce the records to be consumed above. Note that we are using the same record

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQSender.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQSender.java
@@ -2,6 +2,7 @@ package io.atleon.rabbitmq;
 
 import io.atleon.core.Alo;
 import io.atleon.core.AloFlux;
+import io.atleon.core.SenderResult;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -149,7 +150,9 @@ public class AloRabbitMQSender<T> implements Closeable {
         Publisher<Alo<T>> aloBodies,
         RabbitMQMessageCreator<T> messageCreator
     ) {
-        return futureResources.flatMapMany(resources -> resources.sendAlos(aloBodies, messageCreator)).as(AloFlux::wrap);
+        return futureResources.flatMapMany(resources -> resources.sendAlos(aloBodies, messageCreator))
+            .as(AloFlux::wrap)
+            .processFailure(SenderResult::isFailure, SenderResult::toError);
     }
 
     /**
@@ -166,9 +169,9 @@ public class AloRabbitMQSender<T> implements Closeable {
     public AloFlux<RabbitMQSenderResult<RabbitMQMessage<T>>> sendAloMessages(
         Publisher<Alo<RabbitMQMessage<T>>> aloMessages
     ) {
-        return futureResources
-            .flatMapMany(resources -> resources.sendAlos(aloMessages, Function.identity()))
-            .as(AloFlux::wrap);
+        return futureResources.flatMapMany(resources -> resources.sendAlos(aloMessages, Function.identity()))
+            .as(AloFlux::wrap)
+            .processFailure(SenderResult::isFailure, SenderResult::toError);
     }
 
     /**


### PR DESCRIPTION
### :pencil: Description
* Add methods similar to Reactor's `onError*` methods
  * `onAloErrorEmit`: Treat all errors as terminal by emitting them into the pipeline (this is the default)
  * `onAloErrorEmitUnless(Predicate)`: Treat all errors as terminal, unless the error matches the predicate, in which case, acknowledge and move on
  * `onAloErrorDelegate`: Delegate failure handling to the pipeline, and either negatively acknowledge or forward the error as a data item in the pipeline
  * `onAloErrorDelegate(Predicate)`: Delegate failure handling to pipeline, unless the error matches the predicate, in which case, acknowledge and move on

### :link: Related Issues
#169 
