### PR TITLE
#171: SQS messages still in flight until terminal response received

### DIFF
--- a/aws-sqs/src/main/java/io/atleon/aws/sqs/SqsMessageVisibilityChanger.java
+++ b/aws-sqs/src/main/java/io/atleon/aws/sqs/SqsMessageVisibilityChanger.java
@@ -10,12 +10,12 @@ public interface SqsMessageVisibilityChanger {
 
     /**
      * Changes the visibility timeout of the associated {@link SqsMessage} by the provided duration
-     * and may mark the message as no longer in flight. When stillInFlight is "false", it implies
+     * and may mark the message as no longer in flight. When stillInProcess is "false", it implies
      * that processing of the Message has terminated and another Message might be requested. When
-     * stillInFlight is "true", it implies that the message is still being processed.
+     * stillInProcess is "true", it implies that the message is still being processed.
      *
-     * @param timeout The amount of time to reset the visibility by, by whole seconds
-     * @param stillInFlight Whether Message is still being processed
+     * @param timeout        The amount of time to reset the visibility by, by whole seconds
+     * @param stillInProcess Whether Message is still being processed
      */
-    void execute(Duration timeout, boolean stillInFlight);
+    void execute(Duration timeout, boolean stillInProcess);
 }

--- a/aws-sqs/src/main/java/io/atleon/aws/sqs/SqsReceiverMessage.java
+++ b/aws-sqs/src/main/java/io/atleon/aws/sqs/SqsReceiverMessage.java
@@ -90,7 +90,7 @@ public final class SqsReceiverMessage extends AbstractSqsMessage<String> impleme
 
     /**
      * Schedules a change of this Message's visibility by the provided Duration (which should
-     * have a whole number of seconds) and marks the message as no longer in flight.
+     * have a whole number of seconds) and marks the message as no longer in process.
      */
     public void changeVisibility(Duration timeout) {
         changeVisibility(timeout, false);
@@ -98,10 +98,10 @@ public final class SqsReceiverMessage extends AbstractSqsMessage<String> impleme
 
     /**
      * Schedules a change of this Message's visibility by the provided Duration (which should
-     * have a whole number of seconds) and may mark the message as still in flight.
+     * have a whole number of seconds) and may mark the message as still in process.
      */
-    public void changeVisibility(Duration timeout, boolean stillInFlight) {
-        visibilityChanger.execute(timeout, stillInFlight);
+    public void changeVisibility(Duration timeout, boolean stillInProcess) {
+        visibilityChanger.execute(timeout, stillInProcess);
     }
 
     /**


### PR DESCRIPTION
### :pencil: Description
Avoid unbounded memory usage by considering SQS messages still in flight until a successful response is received from SQS after having marked the messages as no longer in process.

### :link: Related Issues
#171 
