### PR TITLE
#172: Encapsulate Kafka config as `KafkaConfig`

### DIFF
--- a/aws-sqs/src/main/java/io/atleon/aws/sqs/AloSqsReceiver.java
+++ b/aws-sqs/src/main/java/io/atleon/aws/sqs/AloSqsReceiver.java
@@ -197,10 +197,10 @@ public class AloSqsReceiver<T> {
         }
 
         private AloFactory<ReceivedSqsMessage<T>> loadAloFactory(String queueUrl) {
-            return AloFactoryConfig.loadDecorated(
-                config.modifyAndGetProperties(it -> it.put(AloReceivedSqsMessageDecorator.QUEUE_URL_CONFIG, queueUrl)),
-                AloReceivedSqsMessageDecorator.class
+            Map<String, Object> factoryConfig = config.modifyAndGetProperties(it ->
+                it.put(AloReceivedSqsMessageDecorator.QUEUE_URL_CONFIG, queueUrl)
             );
+            return AloFactoryConfig.loadDecorated(factoryConfig, AloReceivedSqsMessageDecorator.class);
         }
 
         private ErrorEmitter<Alo<ReceivedSqsMessage<T>>> newErrorEmitter() {

--- a/kafka/src/main/java/io/atleon/kafka/KafkaConfig.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaConfig.java
@@ -1,0 +1,55 @@
+package io.atleon.kafka;
+
+import io.atleon.util.ConfigLoading;
+import io.atleon.util.Configurable;
+import org.apache.kafka.clients.CommonClientConfigs;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class KafkaConfig {
+
+    private final Map<String, Object> properties;
+
+    public KafkaConfig(Map<String, Object> properties) {
+        this.properties = properties;
+    }
+
+    public Map<String, Object> modifyAndGetProperties(Consumer<Map<String, Object>> modifier) {
+        Map<String, Object> modifiedProperties = new HashMap<>(properties);
+        modifier.accept(modifiedProperties);
+        return modifiedProperties;
+    }
+
+    public String loadClientId() {
+        return ConfigLoading.loadStringOrThrow(properties, CommonClientConfigs.CLIENT_ID_CONFIG);
+    }
+
+    public <T extends Configurable> Optional<T> loadConfiguredWithPredefinedTypes(
+        String key,
+        Class<? extends T> type,
+        Function<String, Optional<T>> predefinedTypeInstantiator
+    ) {
+        return ConfigLoading.loadConfiguredWithPredefinedTypes(properties, key, type, predefinedTypeInstantiator);
+    }
+
+    public Optional<Duration> loadDuration(String property) {
+        return ConfigLoading.loadDuration(properties, property);
+    }
+
+    public Optional<Boolean> loadBoolean(String property) {
+        return ConfigLoading.loadBoolean(properties, property);
+    }
+
+    public Optional<Integer> loadInt(String property) {
+        return ConfigLoading.loadInt(properties, property);
+    }
+
+    public Optional<Long> loadLong(String property) {
+        return ConfigLoading.loadLong(properties, property);
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/KafkaConfigSource.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaConfigSource.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-public class KafkaConfigSource extends ConfigSource<Map<String, Object>, KafkaConfigSource> {
+public class KafkaConfigSource extends ConfigSource<KafkaConfig, KafkaConfigSource> {
 
     protected KafkaConfigSource() {
 
@@ -82,7 +82,7 @@ public class KafkaConfigSource extends ConfigSource<Map<String, Object>, KafkaCo
     }
 
     @Override
-    protected Map<String, Object> postProcessProperties(Map<String, Object> properties) {
-        return properties;
+    protected KafkaConfig postProcessProperties(Map<String, Object> properties) {
+        return new KafkaConfig(properties);
     }
 }

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQReceiver.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQReceiver.java
@@ -155,10 +155,10 @@ public class AloRabbitMQReceiver<T> {
         }
 
         private AloFactory<ReceivedRabbitMQMessage<T>> loadAloFactory(String queue) {
-            return AloFactoryConfig.loadDecorated(
-                config.modifyAndGetProperties(it -> it.put(AloReceivedRabbitMQMessageDecorator.QUEUE_CONFIG, queue)),
-                AloReceivedRabbitMQMessageDecorator.class
+            Map<String, Object> factoryConfig = config.modifyAndGetProperties(it ->
+                it.put(AloReceivedRabbitMQMessageDecorator.QUEUE_CONFIG, queue)
             );
+            return AloFactoryConfig.loadDecorated(factoryConfig, AloReceivedRabbitMQMessageDecorator.class);
         }
 
         private ErrorEmitter<Alo<ReceivedRabbitMQMessage<T>>> newErrorEmitter() {

--- a/util/src/main/java/io/atleon/util/ConfigLoading.java
+++ b/util/src/main/java/io/atleon/util/ConfigLoading.java
@@ -132,7 +132,7 @@ public final class ConfigLoading {
         Class<? extends T> type,
         Function<String, Optional<List<T>>> predefinedTypeInstantiator
     ) {
-        return ConfigLoading.loadStream(configs, property, Function.identity())
+        return loadStream(configs, property, Function.identity())
             .map(stream -> coerceToList(stream, type, predefinedTypeInstantiator));
     }
 


### PR DESCRIPTION
### :pencil: Description
- Instead of producing `Map<String, Object>` from `KafkaConfigSource`, produce an encapsulation
- Stop passing around raw config in Kafka Receiver and Sender

### :link: Related Issues
#172 