### PR TITLE
#177: Remove implicit `groupBy` methods on `AloFlux`

### DIFF
--- a/core/src/main/java/io/atleon/core/AloFlux.java
+++ b/core/src/main/java/io/atleon/core/AloFlux.java
@@ -273,7 +273,7 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
      */
     public GroupFlux<AloGroupedFlux<Integer, T>>
     groupByNumberHash(Function<? super T, ? extends Number> numberExtractor, int numGroups) {
-        return groupBy(NumberHashGroupExtractor.composed(numberExtractor, numGroups));
+        return groupBy(NumberHashGroupExtractor.composed(numberExtractor, numGroups), numGroups);
     }
 
     /**
@@ -290,7 +290,7 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
         int numGroups,
         Function<? super T, V> valueMapper
     ) {
-        return groupBy(NumberHashGroupExtractor.composed(numberExtractor, numGroups), valueMapper);
+        return groupBy(NumberHashGroupExtractor.composed(numberExtractor, numGroups), numGroups, valueMapper);
     }
 
     /**
@@ -319,21 +319,6 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
     public <V> GroupFlux<AloGroupedFlux<Integer, V>>
     groupByStringHash(Function<? super T, String> stringExtractor, int numGroups, Function<? super T, V> valueMapper) {
         return groupBy(StringHashGroupExtractor.composed(stringExtractor, numGroups), numGroups, valueMapper);
-    }
-
-    /**
-     * @see Flux#groupBy(Function)
-     */
-    public <K> GroupFlux<AloGroupedFlux<K, T>> groupBy(Function<? super T, ? extends K> groupExtractor) {
-        return groupBy(groupExtractor, Integer.MAX_VALUE);
-    }
-
-    /**
-     * @see Flux#groupBy(Function)
-     */
-    public <K, V> GroupFlux<AloGroupedFlux<K, V>>
-    groupBy(Function<? super T, ? extends K> groupExtractor, Function<? super T, V> valueMapper) {
-        return groupBy(groupExtractor, Integer.MAX_VALUE, valueMapper);
     }
 
     /**

--- a/examples/core/src/main/java/io/atleon/examples/errorhandling/KafkaErrorHandling.java
+++ b/examples/core/src/main/java/io/atleon/examples/errorhandling/KafkaErrorHandling.java
@@ -85,7 +85,7 @@ public class KafkaErrorHandling {
         AloKafkaSender<String, String> sender = AloKafkaSender.from(faultyKafkaSenderConfig);
         AloKafkaReceiver.<String>forValues(kafkaReceiverConfig)
             .receiveAloValues(Collections.singletonList(TOPIC_1))
-            .groupBy(Function.identity())
+            .groupBy(Function.identity(), Integer.MAX_VALUE)
             .map(groupedFlux -> groupedFlux
                 .publishOn(Schedulers.boundedElastic())
                 .map(String::toUpperCase)

--- a/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaTopicPartitionParallelism.java
+++ b/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaTopicPartitionParallelism.java
@@ -59,7 +59,7 @@ public class KafkaTopicPartitionParallelism {
         CountDownLatch latch = new CountDownLatch(NUM_SAMPLES);
         AloKafkaReceiver.<String, String>from(kafkaReceiverConfig)
             .receiveAloRecords(TOPIC)
-            .groupBy(ConsumerRecordExtraction::topicPartition)
+            .groupBy(ConsumerRecordExtraction::topicPartition, Integer.MAX_VALUE)
             .flatMapAlo(groupedFlux -> groupedFlux
                 .publishOn(Schedulers.boundedElastic())
                 .map(consumerRecord -> consumerRecord.value().toUpperCase())


### PR DESCRIPTION
### :pencil: Description

### :link: Related Issues
#177 