### PR TITLE
#186: Remove `suspendConsume` in favor of just `suspendMap`

### DIFF
--- a/kotlin/src/main/kotlin/io/atleon/kotlin/AloFlux.kt
+++ b/kotlin/src/main/kotlin/io/atleon/kotlin/AloFlux.kt
@@ -6,40 +6,26 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.reactive.publish
 import kotlinx.coroutines.reactor.asFlux
 import kotlinx.coroutines.reactor.mono
-
-/**
- * Apply a terminal coroutine-based consumption to an [AloFlux].
- */
-fun <T> AloFlux<T>.suspendConsume(consumer: suspend (T) -> Unit): AloFlux<Void> = suspendConsume(consumer, 1)
-
-/**
- * Apply a terminal coroutine-based consumption to an [AloFlux] with a configurable maximum number
- * of concurrent invocations.
- */
-fun <T> AloFlux<T>.suspendConsume(consumer: suspend (T) -> Unit, concurrency: Int): AloFlux<Void> {
-    return if (concurrency == 1) {
-        concatMap({ publish { consumer.invoke(it) } }, 1)
-    } else {
-        flatMap({ publish { consumer.invoke(it) } }, concurrency, 1)
-    }
-}
+import org.reactivestreams.Publisher
 
 /**
  * Apply a coroutine-based mapping of items to an [AloFlux].
  */
-fun <T, V> AloFlux<T>.suspendMap(mapper: suspend (T) -> V): AloFlux<V> = suspendMap(mapper, 1)
+inline fun <T, reified V> AloFlux<T>.suspendMap(noinline mapper: suspend (T) -> V): AloFlux<V> = suspendMap(mapper, 1)
 
 /**
  * Apply a coroutine-based mapping of items to an [AloFlux] with a configurable maximum number of
  * concurrent invocations. Concurrent outputs are interleaved and therefore and therefore emission
  * order is non-deterministic.
  */
-fun <T, V> AloFlux<T>.suspendMap(mapper: suspend (T) -> V, concurrency: Int): AloFlux<V> {
-    return if (concurrency == 1) {
-        concatMap({ mono { mapper.invoke(it) } }, 1)
-    } else {
-        flatMap({ mono { mapper.invoke(it) } }, concurrency, 1)
-    }
+inline fun <T, reified V> AloFlux<T>.suspendMap(noinline mapper: suspend (T) -> V, concurrency: Int): AloFlux<V> {
+    val publishingMapper: (T) -> Publisher<V> =
+        if (V::class != Unit::class) {
+            { mono { mapper.invoke(it) } }
+        } else {
+            { publish { mapper.invoke(it) } }
+        }
+    return if (concurrency == 1) concatMap(publishingMapper, 1) else flatMap(publishingMapper, concurrency, 1)
 }
 
 /**
@@ -53,9 +39,6 @@ fun <T, V : Any> AloFlux<T>.flowMap(mapper: (T) -> Flow<V>): AloFlux<V> = flowMa
  * from inner Flows are interleaved and therefore emission order is non-deterministic.
  */
 fun <T, V : Any> AloFlux<T>.flowMap(mapper: (T) -> Flow<V>, concurrency: Int, prefetch: Int = Defaults.PREFETCH): AloFlux<V> {
-    return if (concurrency == 1) {
-        concatMap({ mapper.invoke(it).asFlux() }, prefetch)
-    } else {
-        flatMap({ mapper.invoke(it).asFlux() }, concurrency, prefetch)
-    }
+    val publishingMapper: (T) -> Publisher<V> = { mapper.invoke(it).asFlux() }
+    return if (concurrency == 1) concatMap(publishingMapper, prefetch) else flatMap(publishingMapper, concurrency, prefetch)
 }

--- a/kotlin/src/test/kotlin/io/atleon/kotlin/AloFluxTest.kt
+++ b/kotlin/src/test/kotlin/io/atleon/kotlin/AloFluxTest.kt
@@ -22,7 +22,7 @@ class AloFluxTest {
 
         val aloFlux = Flux.just(alo)
             .`as` { AloFlux.wrap(it) }
-            .suspendConsume { delay(100) }
+            .suspendMap { delay(100) }
 
         StepVerifier.create(aloFlux).expectComplete().verify()
 


### PR DESCRIPTION
### :pencil: Description
- Make `suspendMap` smart enough to detect mapping to `Unit` and use `publish` instead of `mono`

### :link: Related Issues
#186 
