### PR TITLE
#204: Implement fluent `Alo` error delegation

### DIFF
--- a/core/src/main/java/io/atleon/core/AloErrorDelegatingMapper.java
+++ b/core/src/main/java/io/atleon/core/AloErrorDelegatingMapper.java
@@ -1,0 +1,43 @@
+package io.atleon.core;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+final class AloErrorDelegatingMapper<T> implements Function<Alo<T>, Alo<T>> {
+
+    private final BiFunction<? super T, ? super Throwable, ? extends Publisher<?>> delegate;
+
+    AloErrorDelegatingMapper(BiFunction<? super T, ? super Throwable, ? extends Publisher<?>> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Alo<T> apply(Alo<T> alo) {
+        Consumer<Throwable> nacknowledger = buildNacknowledger(alo.get(), alo.getAcknowledger(), alo.getNacknowledger());
+        return alo.<T>propagator().create(alo.get(), alo.getAcknowledger(), nacknowledger);
+    }
+
+    private Consumer<Throwable> buildNacknowledger(T t, Runnable acknowledger, Consumer<? super Throwable> nacknowledger) {
+        return error -> delegateError(t, error).subscribe(__ -> {}, nacknowledger, acknowledger);
+    }
+
+    private Mono<Void> delegateError(T t, Throwable error) {
+        try {
+            return Mono.when(delegate.apply(t, error))
+                .onErrorMap(delegateError -> consolidateErrors(error, delegateError));
+        } catch (Throwable delegateError) {
+            return Mono.error(consolidateErrors(error, delegateError));
+        }
+    }
+
+    private static Throwable consolidateErrors(Throwable originalError, Throwable delegateError) {
+        if (originalError != delegateError) {
+            originalError.addSuppressed(delegateError);
+        }
+        return originalError;
+    }
+}

--- a/examples/core/src/main/java/io/atleon/examples/deadlettering/KafkaDeadlettering.java
+++ b/examples/core/src/main/java/io/atleon/examples/deadlettering/KafkaDeadlettering.java
@@ -1,0 +1,87 @@
+package io.atleon.examples.deadlettering;
+
+import io.atleon.core.Alo;
+import io.atleon.kafka.AloKafkaReceiver;
+import io.atleon.kafka.AloKafkaSender;
+import io.atleon.kafka.KafkaConfigSource;
+import io.atleon.kafka.embedded.EmbeddedKafka;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import reactor.core.publisher.Flux;
+
+public class KafkaDeadlettering {
+
+    private static final String BOOTSTRAP_SERVERS = EmbeddedKafka.startAndGetBootstrapServersConnect();
+
+    private static final String MAIN_TOPIC = "MAIN";
+
+    private static final String DEADLETTER_TOPIC = "DEADLETTER";
+
+    public static void main(String[] args) {
+        //Step 1) Create Kafka Config for Producer that backs Sender
+        KafkaConfigSource kafkaSenderConfig = KafkaConfigSource.useClientIdAsName()
+            .with(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
+            .with(CommonClientConfigs.CLIENT_ID_CONFIG, KafkaDeadlettering.class.getSimpleName())
+            .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
+            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
+            .withProducerOrderingAndResiliencyConfigs();
+
+        //Step 2) Create Kafka Config for Consumer that backs Receiver. Note that we use an Auto
+        // Offset Reset of 'earliest' to ensure we receive Records produced before subscribing with
+        // our new consumer group
+        KafkaConfigSource kafkaReceiverConfig = KafkaConfigSource.useClientIdAsName()
+            .with(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
+            .with(CommonClientConfigs.CLIENT_ID_CONFIG, KafkaDeadlettering.class.getSimpleName())
+            .with(ConsumerConfig.GROUP_ID_CONFIG, KafkaDeadlettering.class.getSimpleName())
+            .with(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+            .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName())
+            .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName())
+            .with(AloKafkaReceiver.MAX_IN_FLIGHT_PER_SUBSCRIPTION_CONFIG, 1);
+
+        //Step 3) Create a Sender which we'll reuse to produce Records
+        AloKafkaSender<String, String> sender = AloKafkaSender.from(kafkaSenderConfig);
+
+        //Step 4) Send two records, one "bad" and one "good"
+        sender.sendValues(Flux.just("bad", "good"), MAIN_TOPIC, __ -> "key")
+            .collectList()
+            .doOnNext(senderResults -> System.out.println("senderResults: " + senderResults))
+            .block();
+
+        //Step 5) Apply consumption of the main topic we've produced data to as a stream process.
+        // When we encounter "bad" data that causes an error, we will "deadletter" it by sending
+        // the originating record to our dedicated topic
+        AloKafkaReceiver.<String>forValues(kafkaReceiverConfig)
+            .receiveAloValues(MAIN_TOPIC)
+            .addAloErrorDelegation((string, error) ->
+                sender.sendRecord(new ProducerRecord<>(DEADLETTER_TOPIC, "key", string))
+            )
+            .map(string -> {
+                if (string.equalsIgnoreCase("bad")) {
+                    throw new UnsupportedOperationException("Boom");
+                } else {
+                    return string.toUpperCase();
+                }
+            })
+            .onAloErrorDelegate()
+            .consumeAloAndGet(Alo::acknowledge)
+            .take(1)
+            .collectList()
+            .doOnNext(receivedValues -> System.out.println("receivedValues: " + receivedValues))
+            .block();
+
+        //Step 6) Receive the values that were deadlettered
+        AloKafkaReceiver.<String>forValues(kafkaReceiverConfig)
+            .receiveAloValues(DEADLETTER_TOPIC)
+            .consumeAloAndGet(Alo::acknowledge)
+            .take(1)
+            .collectList()
+            .doOnNext(deadletteredValues -> System.out.println("deadletteredValues: " + deadletteredValues))
+            .block();
+
+        System.exit(0);
+    }
+}

--- a/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart1.java
+++ b/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart1.java
@@ -26,8 +26,7 @@ public class KafkaPart1 {
             .with(ProducerConfig.CLIENT_ID_CONFIG, KafkaPart1.class.getSimpleName())
             .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
             .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1)
-            .with(ProducerConfig.ACKS_CONFIG, "all");
+            .withProducerOrderingAndResiliencyConfigs();
 
         //Step 2) Send some Record values to a hardcoded topic, using values as Record keys
         AloKafkaSender.<String, String>from(kafkaSenderConfig)

--- a/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart2.java
+++ b/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart2.java
@@ -12,7 +12,6 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import reactor.core.publisher.Flux;
 
-import java.util.Collections;
 import java.util.function.Function;
 
 /**
@@ -32,8 +31,7 @@ public class KafkaPart2 {
             .with(CommonClientConfigs.CLIENT_ID_CONFIG, KafkaPart2.class.getSimpleName())
             .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
             .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1)
-            .with(ProducerConfig.ACKS_CONFIG, "all");
+            .withProducerOrderingAndResiliencyConfigs();
 
         //Step 2) Create Kafka Config for Consumer that backs Receiver. Note that we use an Auto
         // Offset Reset of 'earliest' to ensure we receive Records produced before subscribing with
@@ -56,7 +54,7 @@ public class KafkaPart2 {
         //Step 4) Subscribe to the same topic we produced previous values to. Note that we must
         // specify how many values to process ('.take(1)'), or else this Flow would never complete
         AloKafkaReceiver.<String>forValues(kafkaSenderConfig)
-            .receiveAloValues(Collections.singletonList(TOPIC))
+            .receiveAloValues(TOPIC)
             .consumeAloAndGet(Alo::acknowledge)
             .take(1)
             .collectList()

--- a/examples/core/src/main/java/io/atleon/examples/errorhandling/KafkaErrorHandling.java
+++ b/examples/core/src/main/java/io/atleon/examples/errorhandling/KafkaErrorHandling.java
@@ -84,7 +84,7 @@ public class KafkaErrorHandling {
         List<String> successfullyProcessed = new CopyOnWriteArrayList<>();
         AloKafkaSender<String, String> sender = AloKafkaSender.from(faultyKafkaSenderConfig);
         AloKafkaReceiver.<String>forValues(kafkaReceiverConfig)
-            .receiveAloValues(Collections.singletonList(TOPIC_1))
+            .receiveAloValues(TOPIC_1)
             .groupBy(Function.identity(), Integer.MAX_VALUE)
             .map(groupedFlux -> groupedFlux
                 .publishOn(Schedulers.boundedElastic())

--- a/examples/core/src/main/java/io/atleon/examples/infrastructuralinteroperability/KafkaToRabbitMQ.java
+++ b/examples/core/src/main/java/io/atleon/examples/infrastructuralinteroperability/KafkaToRabbitMQ.java
@@ -84,7 +84,7 @@ public class KafkaToRabbitMQ {
 
         //Step 6) Apply a streaming process over a Kafka -> RabbitMQ pairing
         AloKafkaReceiver.<String>forValues(kafkaReceiverConfig)
-            .receiveAloValues(Collections.singletonList(TOPIC))
+            .receiveAloValues(TOPIC)
             .map(String::toUpperCase)
             .transform(AloRabbitMQSender.<String>from(rabbitMQConfig)
                 .sendAloBodies(DefaultRabbitMQMessageCreator.minimalBasicToDefaultExchange(QUEUE)))

--- a/examples/core/src/main/java/io/atleon/examples/metrics/KafkaMicrometer.java
+++ b/examples/core/src/main/java/io/atleon/examples/metrics/KafkaMicrometer.java
@@ -74,7 +74,7 @@ public class KafkaMicrometer {
 
         //Step 6) Apply stream processing to the Kafka topic we produced records to
         AloKafkaReceiver.<String>forValues(kafkaReceiverConfig)
-            .receiveAloValues(Collections.singletonList(TOPIC_1))
+            .receiveAloValues(TOPIC_1)
             .map(String::toUpperCase)
             .transform(AloKafkaSender.<String, String>from(kafkaSenderConfig).sendAloValues(TOPIC_2, Function.identity()))
             .tap(AloMicrometer.metrics("atleon.kafka.micrometer.sent"))


### PR DESCRIPTION
### :pencil: Description
- Implements fluent delegation of failures to reactive delegate
- Includes example usage applied to deadlettering

### :link: Related Issues
#204 
