### PR TITLE
#226: Mark `AcknowledgingPublisher` inactive with error emission

### DIFF
--- a/core/src/main/java/io/atleon/core/AcknowledgingPublisher.java
+++ b/core/src/main/java/io/atleon/core/AcknowledgingPublisher.java
@@ -98,6 +98,7 @@ final class AcknowledgingPublisher<T> implements Publisher<Alo<T>> {
 
             Throwable errorToEmit = errorToEmitReference.get();
             if (errorToEmit != null) {
+                state.compareAndSet(State.ACTIVE, State.IN_FLIGHT);
                 subscriber.onError(errorToEmit);
             } else {
                 onComplete();


### PR DESCRIPTION
### :pencil: Description
Guard against downstream cancellation after error emission in `AcknowledgingPublisher`

### :link: Related Issues
#226 
