### PR TITLE
#232: Ensure Alo produced by AloRabbitMQReceiver is idempotent

### DIFF
--- a/core/src/main/java/io/atleon/core/Acknowledgement.java
+++ b/core/src/main/java/io/atleon/core/Acknowledgement.java
@@ -1,0 +1,37 @@
+package io.atleon.core;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+/**
+ * Wrapper for positive and negative acknowledgement that guarantees only one is ever executed.
+ */
+public final class Acknowledgement {
+
+    private final Runnable acknowledger;
+
+    private final Consumer<? super Throwable> nacknowledger;
+
+    private final AtomicBoolean once = new AtomicBoolean(false);
+
+    private Acknowledgement(Runnable acknowledger, Consumer<? super Throwable> nacknowledger) {
+        this.acknowledger = acknowledger;
+        this.nacknowledger = nacknowledger;
+    }
+
+    public static Acknowledgement create(Runnable acknowledger, Consumer<? super Throwable> nacknowledger) {
+        return new Acknowledgement(acknowledger, nacknowledger);
+    }
+
+    public void positive() {
+        if (once.compareAndSet(false, true)) {
+            acknowledger.run();
+        }
+    }
+
+    public void negative(Throwable error) {
+        if (once.compareAndSet(false, true)) {
+            nacknowledger.accept(error);
+        }
+    }
+}

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQReceiver.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQReceiver.java
@@ -1,5 +1,6 @@
 package io.atleon.rabbitmq;
 
+import io.atleon.core.Acknowledgement;
 import io.atleon.core.Alo;
 import io.atleon.core.AloFactory;
 import io.atleon.core.AloFactoryConfig;
@@ -204,11 +205,12 @@ public class AloRabbitMQReceiver<T> {
                 delivery.getEnvelope().isRedeliver()
             );
 
-            return aloFactory.create(
-                message,
+            Acknowledgement acknowledgement = Acknowledgement.create(
                 () -> ack(delivery, errorEmitter),
                 nacknowledgerFactory.create(message, requeue -> nack(delivery, requeue, errorEmitter), errorEmitter)
             );
+
+            return aloFactory.create(message, acknowledgement::positive, acknowledgement::negative);
         }
 
         private static <T> NacknowledgerFactory<T> createNacknowledgerFactory(RabbitMQConfig config) {


### PR DESCRIPTION
### :pencil: Description
- Make sure acknowledgement on `Alo` produced by `AloRabbitMQReceiver` is idempotent
- Add `Acknowledgement`
- Minor code improvements to `AcknowledgementQueue`

### :link: Related Issues
#232 
