### PR TITLE
#236: Use `long` to represent last active epoch millisecond rather than `Instant`

### DIFF
--- a/core/src/main/java/io/atleon/core/ActivityEnforcingTransformer.java
+++ b/core/src/main/java/io/atleon/core/ActivityEnforcingTransformer.java
@@ -7,9 +7,9 @@ import reactor.core.publisher.Mono;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
-import java.util.function.Supplier;
+import java.util.function.LongSupplier;
 
 final class ActivityEnforcingTransformer<T> implements Function<Publisher<T>, Publisher<T>> {
 
@@ -29,32 +29,33 @@ final class ActivityEnforcingTransformer<T> implements Function<Publisher<T>, Pu
     }
 
     private Flux<T> enforceActivity(Publisher<T> publisher) {
-        AtomicReference<Instant> lastActive = new AtomicReference<>(Instant.now());
-        return Flux.merge(createInactivityError(lastActive::get), publisher)
-            .doOnEach(signal -> lastActive.set(Instant.now()));
+        AtomicLong lastActiveEpochMilli = new AtomicLong(System.currentTimeMillis());
+        return Flux.merge(createInactivityError(lastActiveEpochMilli::get), publisher)
+            .doOnEach(signal -> lastActiveEpochMilli.set(System.currentTimeMillis()));
     }
 
-    private Mono<T> createInactivityError(Supplier<Instant> lastActive) {
+    private Mono<T> createInactivityError(LongSupplier lastActiveEpochMilli) {
         return Flux.interval(config.getDelay(), config.getInterval())
-            .map(i -> lastActive.get())
+            .map(i -> lastActiveEpochMilli.getAsLong())
             .filter(this::hasBecomeInactiveSince)
             .next()
             .flatMap(this::createInactivityError);
     }
 
-    private boolean hasBecomeInactiveSince(Instant lastActive) {
-        return config.getMaxInactivity().compareTo(Duration.between(lastActive, Instant.now())) < 0;
+    private boolean hasBecomeInactiveSince(long lastActiveEpochMilli) {
+        Duration durationSinceLastActivity = Duration.ofMillis(System.currentTimeMillis() - lastActiveEpochMilli);
+        return durationSinceLastActivity.compareTo(config.getMaxInactivity()) > 0;
     }
 
-    private Mono<T> createInactivityError(Instant lastActive) {
-        return Mono.error(new InactiveStreamException(config.getName(), config.getMaxInactivity(), lastActive));
+    private Mono<T> createInactivityError(long lastActiveEpochMilli) {
+        return Mono.error(new InactiveStreamException(config.getName(), config.getMaxInactivity(), lastActiveEpochMilli));
     }
 
     private static final class InactiveStreamException extends TimeoutException {
 
-        public InactiveStreamException(String name, Duration maxInactivity, Instant lastActive) {
+        public InactiveStreamException(String name, Duration maxInactivity, long lastActiveEpochMilli) {
             super(String.format("Stream=%s has been inactive for longer than duration=%s with lastActive=%s",
-                name, maxInactivity, lastActive));
+                name, maxInactivity, Instant.ofEpochMilli(lastActiveEpochMilli)));
         }
     }
 }


### PR DESCRIPTION
### :pencil: Description

### :link: Related Issues
#236 
