### PR TITLE
[#284] Dependency version refresh - January '24

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -11,32 +11,32 @@
     <packaging>pom</packaging>
 
     <properties>
-        <amazon-sdk.version>2.17.150</amazon-sdk.version>
-        <apache-kafka.version>2.8.1</apache-kafka.version>
-        <apache-kafka-doc.version>28</apache-kafka-doc.version>
-        <avro.version>1.10.2</avro.version>
-        <confluent.version>6.2.2</confluent.version> <!-- https://docs.confluent.io/platform/current/installation/versions-interoperability.html -->
-        <guava.version>20.0</guava.version>
-        <jackson.version>2.12.3</jackson.version>
+        <amazon-sdk.version>2.20.162</amazon-sdk.version>
+        <apache-kafka.version>3.4.1</apache-kafka.version>
+        <apache-kafka-doc.version>34</apache-kafka-doc.version>
+        <avro.version>1.11.0</avro.version>
+        <confluent.version>7.4.2</confluent.version> <!-- https://docs.confluent.io/platform/current/installation/versions-interoperability.html -->
+        <guava.version>29.0-jre</guava.version>
+        <jackson.version>2.14.2</jackson.version>
         <jetbrains-annotations.version>23.0.0</jetbrains-annotations.version>
-        <junit-jupiter.version>5.6.3</junit-jupiter.version>
+        <junit-jupiter.version>5.10.1</junit-jupiter.version>
         <kotlin.version>1.6.21</kotlin.version> <!-- Dictated by kotlinx-coroutines version -->
         <kotlinx-coroutines.version>1.6.4</kotlinx-coroutines.version>
         <micrometer.version>1.0.7</micrometer.version>
         <mockito.version>4.11.0</mockito.version>
         <opentracing.verion>0.32.0</opentracing.verion>
-        <protobuf.version>3.11.4</protobuf.version>
-        <rabbitmq-amqp-client.version>5.14.2</rabbitmq-amqp-client.version>
+        <protobuf.version>3.23.2</protobuf.version>
+        <rabbitmq-amqp-client.version>5.18.0</rabbitmq-amqp-client.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
-        <reactor.version>3.5.11</reactor.version>
-        <reactor-kafka.version>1.3.18</reactor-kafka.version>
+        <reactor.version>3.5.14</reactor.version>
+        <reactor-kafka.version>1.3.21</reactor-kafka.version>
         <reactor-rabbitmq.version>1.5.6</reactor-rabbitmq.version>
-        <scala.version>2.13.6</scala.version>
-        <slf4j.version>1.7.36</slf4j.version>
+        <scala.version>2.13.10</scala.version>
+        <slf4j.version>2.0.3</slf4j.version>
         <spring.version>5.3.7</spring.version>
         <swagger3.version>2.1.13</swagger3.version>
-        <testcontainers.version>1.17.6</testcontainers.version>
-        <zookeeper.version>3.6.3</zookeeper.version>
+        <testcontainers.version>1.19.3</testcontainers.version>
+        <zookeeper.version>3.6.4</zookeeper.version>
     </properties>
 
     <dependencyManagement>

--- a/schemas/schema-registry-confluent-embedded/pom.xml
+++ b/schemas/schema-registry-confluent-embedded/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>kafka-schema-registry</artifactId>
             <version>${confluent.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
                 <!-- Excluding to bring in managed version as runtime dependency -->
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -35,6 +39,18 @@
                 <exclusion>
                     <groupId>com.squareup</groupId>
                     <artifactId>kotlinpoet</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.squareup.okio</groupId>
+                    <artifactId>okio-jvm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.squareup.wire</groupId>
+                    <artifactId>wire-runtime-jvm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.squareup.wire</groupId>
+                    <artifactId>wire-schema-jvm</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>jakarta.xml.bind</groupId>


### PR DESCRIPTION
### :pencil: Description
Updated to modern versions of:
- Reactor: 3.5.14
- Kafka: 3.4.1
- AWS SDK: 2.20.162
- AMQP Client: 5.18.0
- JUnit: 5.10.1
- Testcontainers: 1.19.3

### :link: Related Issues
#284 