### PR TITLE
[#302] Initial pass at Kafka utility functions

### DIFF
--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -68,6 +68,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>

--- a/kafka/src/main/java/io/atleon/kafka/KafkaBoundedReceiver.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaBoundedReceiver.java
@@ -1,0 +1,265 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.kafka.receiver.KafkaReceiver;
+import reactor.kafka.receiver.ReceiverOptions;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Receiver of Kafka Records where the number of Records consumed is finite as indicated by
+ * Offset Range Providers. Typical use cases include:
+ * - Get all Records from earliest to latest (at time of subscription)
+ * - Get all Records produced in a given timespan
+ * - Get all Records in a given "raw" offset range
+ * - Get all Records starting/resuming from specific partition and offset
+ */
+public class KafkaBoundedReceiver<K, V> {
+
+    /**
+     * Prefix used on all KafkaRangeReceiver-specific configurations
+     */
+    public static final String CONFIG_PREFIX = "kafka.bounded.receiver";
+
+    /**
+     * Controls timeouts of polls to Kafka. This config can be increased if a Kafka cluster is
+     * slow to respond. Specified as ISO-8601 Duration, e.g. PT10S
+     */
+    public static final String POLL_TIMEOUT_CONFIG = CONFIG_PREFIX + "poll.timeout";
+
+    /**
+     * Closing the underlying Kafka Consumer is a fallible process. In order to not infinitely
+     * deadlock a Consumer during this process (which can lead to non-consumption of assigned
+     * partitions), we use a default equal to what's used in KafkaConsumer::close
+     */
+    public static final String CLOSE_TIMEOUT_CONFIG = CONFIG_PREFIX + "close.timeout";
+
+    private static final Duration DEFAULT_POLL_TIMEOUT = Duration.ofMillis(100L);
+
+    private static final Duration DEFAULT_CLOSE_TIMEOUT = Duration.ofSeconds(30L);
+
+    private final KafkaConfigSource configSource;
+
+    private KafkaBoundedReceiver(KafkaConfigSource configSource) {
+        this.configSource = configSource;
+    }
+
+    public static <K, V> KafkaBoundedReceiver<K, V> create(KafkaConfigSource configSource) {
+        return new KafkaBoundedReceiver<>(configSource);
+    }
+
+    /**
+     * Receive records from a given topic in the provided relative offset range.
+     *
+     * @param topic The name of a topic to receive records from
+     * @param offsetRange The relative range of offsets to receive
+     * @return A bounded {@link Flux\} of {@link ConsumerRecord}
+     */
+    public Flux<ConsumerRecord<K, V>> receiveRecords(String topic, OffsetRange offsetRange) {
+        return receiveRecords(Collections.singletonList(topic), offsetRange);
+    }
+
+    /**
+     * Receive records from given topics in the provided relative offset range.
+     *
+     * @param topics The topic names to receive records from
+     * @param offsetRange The relative range of offsets to receive
+     * @return A bounded {@link Flux\} of {@link ConsumerRecord}
+     */
+    public Flux<ConsumerRecord<K, V>> receiveRecords(Collection<String> topics, OffsetRange offsetRange) {
+        return receiveRecords(topics, OffsetRangeProvider.inOffsetRangeFromAllTopicPartitions(offsetRange));
+    }
+
+    /**
+     * Receive records from a given topic based on relative offset ranges provided by the given
+     * {@link OffsetRangeProvider}.
+     *
+     * @param topic The topic to receive records from
+     * @param rangeProvider Provider of relative offset ranges to receive, given {@link TopicPartition}s
+     * @return A bounded {@link Flux\} of {@link ConsumerRecord}
+     */
+    public Flux<ConsumerRecord<K, V>> receiveRecords(String topic, OffsetRangeProvider rangeProvider) {
+        return receiveRecords(Collections.singletonList(topic), rangeProvider);
+    }
+
+    /**
+     * Receive records from given topics based on relative offset ranges provided by the given
+     * {@link OffsetRangeProvider}.
+     *
+     * @param topics The topic names to receive records from
+     * @param rangeProvider Provider of relative offset ranges to receive, given {@link TopicPartition}s
+     * @return A bounded {@link Flux\} of {@link ConsumerRecord}
+     */
+    public Flux<ConsumerRecord<K, V>> receiveRecords(Collection<String> topics, OffsetRangeProvider rangeProvider) {
+        return configSource.create().flatMapMany(it -> receiveRecords(it, topics, rangeProvider));
+    }
+
+    private Flux<ConsumerRecord<K, V>> receiveRecords(
+        KafkaConfig config,
+        Collection<String> topics,
+        OffsetRangeProvider rangeProvider
+    ) {
+        Flux<RecordRange> recordRanges = Flux.using(
+            () -> ReactiveAdmin.create(config.nativeProperties()),
+            it -> listRecordRanges(it, topics, rangeProvider),
+            ReactiveAdmin::close
+        );
+        return recordRanges
+            .filter(RecordRange::hasNonNegativeLength)
+            .concatMap(this::receiveRecordsInRange);
+    }
+
+    private Flux<RecordRange> listRecordRanges(
+        ReactiveAdmin admin,
+        Collection<String> topics,
+        OffsetRangeProvider rangeProvider
+    ) {
+        return admin.listTopicPartitions(topics)
+            .collectMap(Function.identity(), rangeProvider::forTopicPartition)
+            .map(it -> sortPresent(it, rangeProvider.topicPartitionComparator()))
+            .flatMapMany(it -> listRecordRanges(admin, it));
+    }
+
+    private Flux<RecordRange> listRecordRanges(ReactiveAdmin admin, SortedMap<TopicPartition, OffsetRange> ranges) {
+        Map<TopicPartition, OffsetCriteria> minCriteria = ranges.entrySet().stream().collect(
+            Collectors.toMap(Map.Entry::getKey, it -> it.getValue().minInclusive()));
+        Map<TopicPartition, OffsetCriteria> maxCriteria = ranges.entrySet().stream().collect(
+            Collectors.toMap(Map.Entry::getKey, it -> it.getValue().maxInclusive()));
+
+        return Mono.zip(
+            calculateRawOffsets(admin, minCriteria, Extrema.MIN),
+            calculateRawOffsets(admin, maxCriteria, Extrema.MAX),
+            admin.listOffsets(minCriteria.keySet(), OffsetSpec.earliest()),
+            admin.listOffsets(maxCriteria.keySet(), OffsetSpec.latest())
+        ).flatMapIterable(it -> createRecordRanges(ranges.keySet(), it.getT1(), it.getT2(), it.getT3(), it.getT4()));
+    }
+
+    private Mono<Map<TopicPartition, Long>> calculateRawOffsets(
+        ReactiveAdmin admin,
+        Map<TopicPartition, OffsetCriteria> criteria,
+        Extrema extrema
+    ) {
+        Map<Class<? extends OffsetCriteria>, Map<TopicPartition, OffsetCriteria>> typedCriteria =
+            criteria.entrySet().stream().collect(Collectors.groupingBy(it -> it.getValue().getClass(),
+                Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+
+        Map<TopicPartition, Long> rawOffsets =
+            typedCriteria.getOrDefault(OffsetCriteria.Raw.class, Collections.emptyMap()).entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, it -> toRawOffset(it.getValue(), extrema)));
+        Map<TopicPartition, OffsetSpec> timestampSpecs =
+            typedCriteria.getOrDefault(OffsetCriteria.Timestamp.class, Collections.emptyMap()).entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, it -> toTimestampSpec(it.getValue(), extrema)));
+        Map<TopicPartition, OffsetSpec> earliestSpecs =
+            typedCriteria.getOrDefault(OffsetCriteria.Earliest.class, Collections.emptyMap()).entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, __ -> OffsetSpec.earliest()));
+        Map<TopicPartition, OffsetSpec> latestSpecs =
+            typedCriteria.getOrDefault(OffsetCriteria.Latest.class, Collections.emptyMap()).entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, __ -> OffsetSpec.latest()));
+
+        return Mono.just(rawOffsets)
+            .mergeWith(admin.listOffsets(timestampSpecs, offset -> offset == -1 ? Long.MAX_VALUE : offset))
+            .mergeWith(admin.listOffsets(earliestSpecs, offset -> offset + (extrema == Extrema.MAX ? 1 : 0)))
+            .mergeWith(admin.listOffsets(latestSpecs, offset -> offset - (extrema == Extrema.MIN ? 1 : 0)))
+            .flatMapIterable(Map::entrySet)
+            .collectMap(Map.Entry::getKey, Map.Entry::getValue);
+    }
+
+    private Flux<ConsumerRecord<K, V>> receiveRecordsInRange(RecordRange recordRange) {
+        return configSource.create().flatMapMany(it -> receiveRecordsInRange(it, recordRange));
+    }
+
+    private Flux<ConsumerRecord<K, V>> receiveRecordsInRange(KafkaConfig kafkaConfig, RecordRange recordRange) {
+        ReceiverOptions<K, V> receiverOptions = ReceiverOptions.<K, V>create(kafkaConfig.nativeProperties())
+            .assignment(Collections.singletonList(recordRange.topicPartition()))
+            .pollTimeout(kafkaConfig.loadDuration(POLL_TIMEOUT_CONFIG).orElse(DEFAULT_POLL_TIMEOUT))
+            .closeTimeout(kafkaConfig.loadDuration(CLOSE_TIMEOUT_CONFIG).orElse(DEFAULT_CLOSE_TIMEOUT))
+            .addAssignListener(partitions -> partitions.forEach(it -> it.seek(recordRange.minInclusive())));
+
+        return KafkaReceiver.create(receiverOptions).receive()
+            .<ConsumerRecord<K, V>>map(Function.identity())
+            .takeWhile(it -> it.offset() <= recordRange.maxInclusive())
+            .takeUntil(it -> it.offset() == recordRange.maxInclusive());
+    }
+
+    private static List<RecordRange> createRecordRanges(
+        Collection<TopicPartition> topicPartitions,
+        Map<TopicPartition, Long> minOffsets,
+        Map<TopicPartition, Long> maxOffsets,
+        Map<TopicPartition, Long> earliestOffsets,
+        Map<TopicPartition, Long> latestOffsets
+    ) {
+        return topicPartitions.stream()
+            .map(topicPartition -> new RecordRange(
+                topicPartition,
+                Math.max(earliestOffsets.get(topicPartition), minOffsets.get(topicPartition)),
+                Math.min(latestOffsets.get(topicPartition), maxOffsets.get(topicPartition)) - 1))
+            .collect(Collectors.toList());
+    }
+
+    private static <K, V> SortedMap<K, V> sortPresent(Map<K, Optional<V>> map, Comparator<? super K> comparator) {
+        return map.entrySet().stream()
+            .filter(it -> it.getValue().isPresent())
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                it -> it.getValue().get(),
+                (l, r) -> l, // Won't be called, since we know the keys are unique
+                () -> new TreeMap<>(comparator))
+            );
+    }
+
+    private static long toRawOffset(OffsetCriteria endpoint, Extrema extrema) {
+        return OffsetCriteria.Raw.class.cast(endpoint).offset() + (extrema == Extrema.MAX ? 1 : 0);
+    }
+
+    private static OffsetSpec toTimestampSpec(OffsetCriteria offsetCriteria, Extrema extrema) {
+        OffsetCriteria.Timestamp timestampEndpoint = OffsetCriteria.Timestamp.class.cast(offsetCriteria);
+        return OffsetSpec.forTimestamp(timestampEndpoint.epochMillis() + (extrema == Extrema.MAX ? 1 : 0));
+    }
+
+    private enum Extrema {MIN, MAX}
+
+    private static final class RecordRange {
+
+        private final TopicPartition topicPartition;
+
+        private final long minInclusive;
+
+        private final long maxInclusive;
+
+        public RecordRange(TopicPartition topicPartition, long minInclusive, long maxExclusive) {
+            this.topicPartition = topicPartition;
+            this.minInclusive = minInclusive;
+            this.maxInclusive = maxExclusive;
+        }
+
+        public TopicPartition topicPartition() {
+            return topicPartition;
+        }
+
+        public boolean hasNonNegativeLength() {
+            return maxInclusive - minInclusive >= 0;
+        }
+
+        public long minInclusive() {
+            return minInclusive;
+        }
+
+        public long maxInclusive() {
+            return maxInclusive;
+        }
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/OffsetCriteria.java
+++ b/kafka/src/main/java/io/atleon/kafka/OffsetCriteria.java
@@ -1,0 +1,105 @@
+package io.atleon.kafka;
+
+import java.time.Instant;
+
+/**
+ * Criteria that describe offsets that may exist in a TopicPartition. All Criteria are "inclusive".
+ */
+public abstract class OffsetCriteria {
+
+    private OffsetCriteria() {
+
+    }
+
+    /**
+     * Points to the first Record's offset in a TopicPartition
+     */
+    public static OffsetCriteria earliest() {
+        return new Earliest();
+    }
+
+    /**
+     * Points to the last Record's offset in a TopicPartition
+     */
+    public static OffsetCriteria latest() {
+        return new Latest();
+    }
+
+    /**
+     * Points to the Record's offset which was produced "around" the given timestamp. If used as a
+     * min-criteria, points to Record's offset produced at-or-after given timestamp. If used as a
+     * max-criteria, points to a Record's offset produced at-or-before given timestamp.
+     */
+    public static OffsetCriteria timestamp(Instant instant) {
+        return new Timestamp(instant.toEpochMilli());
+    }
+
+    /**
+     * Points to the Record's offset which was produced "around" the given timestamp. If used as a
+     * min-criteria, points to Record's offset produced at-or-after given timestamp. If used as a
+     * max-criteria, points to a Record's offset produced at-or-before given timestamp.
+     */
+    public static OffsetCriteria timestamp(long epochMillis) {
+        return new Timestamp(epochMillis);
+    }
+
+    /**
+     * Points to Record with given offset. Package private as usage only makes sense when combined
+     * with a TopicPartition.
+     */
+    static OffsetCriteria raw(long offset) {
+        return new Raw(offset);
+    }
+
+    /**
+     * Converts Criteria to a zero-length Range. Only Records that exactly satisfy this Criteria
+     * will be returned.
+     */
+    public OffsetRange asRange() {
+        return to(this);
+    }
+
+    public OffsetRange to(OffsetCriteria maxInclusive) {
+        return OffsetRange.of(this, maxInclusive);
+    }
+
+    public static final class Earliest extends OffsetCriteria {
+
+        private Earliest() {
+
+        }
+    }
+
+    public static final class Latest extends OffsetCriteria {
+
+        private Latest() {
+
+        }
+    }
+
+    public static final class Timestamp extends OffsetCriteria {
+
+        private final long epochMillis;
+
+        private Timestamp(long epochMillis) {
+            this.epochMillis = epochMillis;
+        }
+
+        public long epochMillis() {
+            return epochMillis;
+        }
+    }
+
+    public static final class Raw extends OffsetCriteria {
+
+        private final long offset;
+
+        private Raw(long offset) {
+            this.offset = offset;
+        }
+
+        public long offset() {
+            return offset;
+        }
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/OffsetRange.java
+++ b/kafka/src/main/java/io/atleon/kafka/OffsetRange.java
@@ -1,0 +1,29 @@
+package io.atleon.kafka;
+
+/**
+ * Describes a range of Offsets where the minimum offset will satisfy the min Criteria and the
+ * maximum offset will satisfy the max Criteria.
+ */
+public final class OffsetRange {
+
+    private final OffsetCriteria minInclusive;
+
+    private final OffsetCriteria maxInclusive;
+
+    private OffsetRange(OffsetCriteria minInclusive, OffsetCriteria maxInclusive) {
+        this.minInclusive = minInclusive;
+        this.maxInclusive = maxInclusive;
+    }
+
+    public static OffsetRange of(OffsetCriteria minInclusive, OffsetCriteria maxInclusive) {
+        return new OffsetRange(minInclusive, maxInclusive);
+    }
+
+    public OffsetCriteria minInclusive() {
+        return minInclusive;
+    }
+
+    public OffsetCriteria maxInclusive() {
+        return maxInclusive;
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/OffsetRangeProvider.java
+++ b/kafka/src/main/java/io/atleon/kafka/OffsetRangeProvider.java
@@ -1,0 +1,119 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * When describing the current state of a Topic, each {@link TopicPartition} is passed to an
+ * implementation of this type in order to describe the range of Records that should be consumed.
+ * In addition, this interface provides a {@link Comparator} used to order TopicPartitions such
+ * that their order of consumption is deterministic. By default, this ordering is by the name of
+ * the topic, then the partition number.
+ */
+@FunctionalInterface
+public interface OffsetRangeProvider {
+
+    /**
+     * Consume all Records across all TopicPartitions from the earliest to latest (at time of
+     * describing the Topic)
+     */
+    static OffsetRangeProvider earliestToLatestFromAllTopicPartitions() {
+        return inOffsetRangeFromAllTopicPartitions(OffsetCriteria.earliest().to(OffsetCriteria.latest()));
+    }
+
+    /**
+     * Consume Records across all TopicPartitions within the provided OffsetRange
+     */
+    static OffsetRangeProvider inOffsetRangeFromAllTopicPartitions(OffsetRange offsetRange) {
+        return __ -> Optional.of(offsetRange);
+    }
+
+    /**
+     * Consume Records from a single TopicPartition within the provided OffsetRange
+     */
+    static OffsetRangeProvider inOffsetRangeFromTopicPartition(TopicPartition topicPartition, OffsetRange offsetRange) {
+        return it -> topicPartition.equals(it) ? Optional.of(offsetRange) : Optional.empty();
+    }
+
+    /**
+     * Consume Records starting from a "raw" offset to the offset that matches the max Criteria
+     */
+    static OffsetRangeProvider inOffsetRangeFromTopicPartition(
+        TopicPartition topicPartition,
+        long rawOffset,
+        OffsetCriteria maxInclusive
+    ) {
+        return inOffsetRangeFromTopicPartition(topicPartition, OffsetCriteria.raw(rawOffset).to(maxInclusive));
+    }
+
+    /**
+     * Starting from a provided TopicPartition and "raw" offset, continue consuming Records from
+     * there through the subsequent TopicPartitions matching the provided OffsetRange. Note that
+     * "subsequent" is determined by the default Comparator (sort by Topic, then Partition)
+     */
+    static OffsetRangeProvider startingFromRawOffsetInTopicPartition(
+        TopicPartition topicPartition,
+        long rawOffset,
+        OffsetRange offsetRange
+    ) {
+        return new StartingFromRawOffsetInTopicPartition(topicPartition, rawOffset, offsetRange);
+    }
+
+    /**
+     * Consume Records from a single TopicPartition that are in the provided "raw" Offset range
+     */
+    static OffsetRangeProvider usingRawOffsetRange(TopicPartition topicPartition, RawOffsetRange rawOffsetRange) {
+        return usingRawOffsetRanges(Collections.singletonMap(topicPartition, rawOffsetRange));
+    }
+
+    /**
+     * Consume Records from provided TopicPartitions that are in the provided mapped "raw" Offset
+     * ranges
+     */
+    static OffsetRangeProvider usingRawOffsetRanges(Map<TopicPartition, RawOffsetRange> rawOffsetRangesByTopicPartition) {
+        return it -> Optional.ofNullable(rawOffsetRangesByTopicPartition.get(it)).map(RawOffsetRange::toOffsetRange);
+    }
+
+    Optional<OffsetRange> forTopicPartition(TopicPartition topicPartition);
+
+    /**
+     * Returns a Comparator used to sort RecordRanges such that Records are consumed in a
+     * deterministic order
+     */
+    default Comparator<? super TopicPartition> topicPartitionComparator() {
+        return Comparator.comparing(TopicPartition::topic).thenComparing(TopicPartition::partition);
+    }
+
+    final class StartingFromRawOffsetInTopicPartition implements OffsetRangeProvider {
+
+        private final TopicPartition startingTopicPartition;
+
+        private final long startingRawOffset;
+
+        private final OffsetRange offsetRange;
+
+        private StartingFromRawOffsetInTopicPartition(
+            TopicPartition topicPartition,
+            long rawOffset,
+            OffsetRange offsetRange
+        ) {
+            this.startingTopicPartition = topicPartition;
+            this.startingRawOffset = rawOffset;
+            this.offsetRange = offsetRange;
+        }
+
+        @Override
+        public Optional<OffsetRange> forTopicPartition(TopicPartition topicPartition) {
+            int comparison = topicPartitionComparator().compare(startingTopicPartition, topicPartition);
+            if (comparison == 0) {
+                return Optional.of(OffsetCriteria.raw(startingRawOffset).to(offsetRange.maxInclusive()));
+            } else {
+                return comparison < 0 ? Optional.of(offsetRange) : Optional.empty();
+            }
+        }
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/RawOffsetRange.java
+++ b/kafka/src/main/java/io/atleon/kafka/RawOffsetRange.java
@@ -1,0 +1,24 @@
+package io.atleon.kafka;
+
+/**
+ * Describes a "raw" range of offsets.
+ */
+public final class RawOffsetRange {
+
+    private final long minInclusive;
+
+    private final long maxInclusive;
+
+    private RawOffsetRange(long minInclusive, long maxInclusive) {
+        this.minInclusive = minInclusive;
+        this.maxInclusive = maxInclusive;
+    }
+
+    public static RawOffsetRange of(long minInclusive, long maxInclusive) {
+        return new RawOffsetRange(minInclusive, maxInclusive);
+    }
+
+    public OffsetRange toOffsetRange() {
+        return OffsetCriteria.raw(minInclusive).to(OffsetCriteria.raw(maxInclusive));
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/ReactiveAdmin.java
+++ b/kafka/src/main/java/io/atleon/kafka/ReactiveAdmin.java
@@ -1,0 +1,212 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsSpec;
+import org.apache.kafka.clients.admin.ListOffsetsOptions;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.TopicPartition;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoSink;
+
+import java.io.Closeable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.LongUnaryOperator;
+import java.util.stream.Collectors;
+
+/**
+ * Wrapper around a Kafka {@link Admin} instance providing a reactive facade for commonly used
+ * utility functions.
+ */
+public class ReactiveAdmin implements Closeable {
+
+    private static final ListOffsetsOptions LIST_OFFSETS_OPTIONS =
+        new ListOffsetsOptions(IsolationLevel.READ_COMMITTED);
+
+    private final Admin admin;
+
+    ReactiveAdmin(Admin admin) {
+        this.admin = admin;
+    }
+
+    public static ReactiveAdmin create(Map<String, Object> config) {
+        return new ReactiveAdmin(Admin.create(config));
+    }
+
+    /**
+     * Describes the current state of committed offsets for the provided consumer group ID, along
+     * with the latest offsets for each of the {@link TopicPartition}s for which the group has
+     * committed offsets, thus allowing for an estimation of the group's lag.
+     * <p>
+     * Note that if a consumer is consuming or has consumed messages from any given topic's
+     * partition, but not yet committed any offsets for that partition, then there will be no data
+     * emitted for that {@link TopicPartition}.
+     *
+     * @param groupId The consumer group ID to describe offsets for
+     * @return A {@link Flux} of {@link TopicPartitionGroupOffsets} describing group and partition offsets
+     */
+    public Flux<TopicPartitionGroupOffsets> listTopicPartitionGroupOffsets(String groupId) {
+        return listTopicPartitionGroupOffsets(Collections.singletonList(groupId));
+    }
+
+    /**
+     * Describes the current state of committed offsets for the provided consumer group IDs, along
+     * with the latest offsets for each of the {@link TopicPartition}s for which the groups have
+     * committed offsets, thus allowing for an estimation of the groups' lag.
+     * <p>
+     * Note that if a consumer is consuming or has consumed messages from any given topic's
+     * partition, but not yet committed any offsets for that partition, then there will be no data
+     * emitted for that {@link TopicPartition}.
+     *
+     * @param groupIds The consumer group IDs to describe offsets for
+     * @return A {@link Flux} of {@link TopicPartitionGroupOffsets} describing group and partition offsets
+     */
+    public Flux<TopicPartitionGroupOffsets> listTopicPartitionGroupOffsets(Collection<String> groupIds) {
+        Map<String, ListConsumerGroupOffsetsSpec> offsetSpecs = groupIds.stream()
+            .collect(Collectors.toMap(Function.identity(), __ -> new ListConsumerGroupOffsetsSpec()));
+        return execute(admin -> admin.listConsumerGroupOffsets(offsetSpecs).all())
+            .flatMapMany(this::listTopicPartitionGroupOffsets);
+    }
+
+    /**
+     * Retrieve the offsets for the provided {@link TopicPartition}s that match the provided
+     * {@link OffsetSpec}.
+     *
+     * @param topicPartitions The {@link TopicPartition}s to describe offsets for
+     * @param offsetSpec The criteria used to describe offsets for
+     * @return A {@link Mono} of a single {@link Map} containing offsets for the provided {@link TopicPartition}s
+     */
+    public Mono<Map<TopicPartition, Long>> listOffsets(Collection<TopicPartition> topicPartitions, OffsetSpec offsetSpec) {
+        return listOffsets(topicPartitions.stream().collect(Collectors.toMap(Function.identity(), __ -> offsetSpec)));
+    }
+
+    /**
+     * Retrieve the offsets that match each {@link TopicPartition}'s mapped {@link OffsetSpec}
+     *
+     * @param offsetSpecs The mapped {@link OffsetSpec} for each {@link TopicPartition} to retrieve
+     * @return A {@link Mono} of a single {@link Map} containing offsets for the provided {@link TopicPartition}s
+     */
+    public Mono<Map<TopicPartition, Long>> listOffsets(Map<TopicPartition, OffsetSpec> offsetSpecs) {
+        return listOffsets(offsetSpecs, LongUnaryOperator.identity());
+    }
+
+    /**
+     * Retrieve the offsets that match each {@link TopicPartition}'s mapped {@link OffsetSpec},
+     * while applying an "adjustment" to each offset before collecting it to a result.
+     *
+     * @param offsetSpecs The mapped {@link OffsetSpec} for each {@link TopicPartition} to retrieve
+     * @param adjustment Modification to make to offset before collecting it to returned result
+     * @return A {@link Mono} of a single {@link Map} containing offsets for the provided {@link TopicPartition}s
+     */
+    public Mono<Map<TopicPartition, Long>> listOffsets(
+        Map<TopicPartition, OffsetSpec> offsetSpecs,
+        LongUnaryOperator adjustment
+    ) {
+        if (offsetSpecs.isEmpty()) {
+            return Mono.empty();
+        } else {
+            return execute(admin -> admin.listOffsets(offsetSpecs, LIST_OFFSETS_OPTIONS).all())
+                .flatMapIterable(Map::entrySet)
+                .collectMap(Map.Entry::getKey, it -> adjustment.applyAsLong(it.getValue().offset()));
+        }
+    }
+
+    /**
+     * Describes the existing partitions for the provided topic.
+     *
+     * @param topic The name of the topic to describe partitions for
+     * @return A {@link Flux} of {@link TopicPartition} for each of the topic's partitions
+     */
+    public Flux<TopicPartition> listTopicPartitions(String topic) {
+        return listTopicPartitions(Collections.singletonList(topic));
+    }
+
+    /**
+     * Describes the existing partitions for the provided topics.
+     *
+     * @param topics The name of the topics to describe partitions for
+     * @return A {@link Flux} of {@link TopicPartition} for each of the topics' partitions
+     */
+    public Flux<TopicPartition> listTopicPartitions(Collection<String> topics) {
+        return execute(admin -> admin.describeTopics(topics).allTopicNames())
+            .flatMapIterable(Map::values)
+            .flatMapIterable(ReactiveAdmin::extractTopicPartitions);
+    }
+
+    @Override
+    public void close() {
+        admin.close();
+    }
+
+    private Flux<TopicPartitionGroupOffsets> listTopicPartitionGroupOffsets(
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> offsetsByGroup
+    ) {
+        Set<TopicPartition> topicPartitions = offsetsByGroup.values().stream()
+            .flatMap(it -> it.keySet().stream())
+            .collect(Collectors.toSet());
+        return listOffsets(topicPartitions, OffsetSpec.latest())
+            .flatMapIterable(it -> createTopicPartitionGroupOffsets(offsetsByGroup, it));
+    }
+
+    private <T> Mono<T> execute(Function<Admin, KafkaFuture<T>> method) {
+        return Mono.create(sink -> method.apply(admin).whenComplete(new SinkKafkaBiConsumer<>(sink)));
+    }
+
+    private static List<TopicPartitionGroupOffsets> createTopicPartitionGroupOffsets(
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> offsetsByGroup,
+        Map<TopicPartition, Long> latestOffsets
+    ) {
+        return offsetsByGroup.entrySet().stream()
+            .flatMap(it -> createTopicPartitionGroupOffsets(it.getKey(), it.getValue(), latestOffsets).stream())
+            .collect(Collectors.toList());
+    }
+
+    private static List<TopicPartitionGroupOffsets> createTopicPartitionGroupOffsets(
+        String groupId,
+        Map<TopicPartition, OffsetAndMetadata> groupOffsets,
+        Map<TopicPartition, Long> latestOffsets
+    ) {
+        return latestOffsets.entrySet().stream()
+            .filter(it -> groupOffsets.get(it.getKey()) != null) // Values may be explicitly set to null
+            .map(it -> new TopicPartitionGroupOffsets(
+                it.getKey(), it.getValue(), groupId, groupOffsets.get(it.getKey()).offset()))
+            .collect(Collectors.toList());
+    }
+
+    private static List<TopicPartition> extractTopicPartitions(TopicDescription topicDescription) {
+        return topicDescription.partitions().stream()
+            .map(it -> new TopicPartition(topicDescription.name(), it.partition()))
+            .collect(Collectors.toList());
+    }
+
+    private static final class SinkKafkaBiConsumer<T> implements KafkaFuture.BiConsumer<T, Throwable> {
+
+        private final MonoSink<T> sink;
+
+        public SinkKafkaBiConsumer(MonoSink<T> sink) {
+            this.sink = sink;
+        }
+
+        @Override
+        public void accept(T t, Throwable throwable) {
+            if (throwable != null) {
+                sink.error(throwable);
+            }
+            // These are no-op's if an error was previously signaled
+            if (t != null) {
+                sink.success(t);
+            } else {
+                sink.success();
+            }
+        }
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/TopicPartitionGroupOffsets.java
+++ b/kafka/src/main/java/io/atleon/kafka/TopicPartitionGroupOffsets.java
@@ -1,0 +1,49 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * Describes the relevant offsets for a {@link TopicPartition} in the context its consumption by a
+ * particular consumer group. This allows for estimating the "lag" of the given consumer group by
+ * comparing the latest offset on the partition to the committed offset for the consumer group.
+ */
+public final class TopicPartitionGroupOffsets {
+
+    private final TopicPartition topicPartition;
+
+    private final long topicPartitionLatestOffset;
+
+    private final String groupId;
+
+    private final long groupOffset;
+
+    public TopicPartitionGroupOffsets(
+        TopicPartition topicPartition,
+        long topicPartitionLatestOffset,
+        String groupId,
+        long groupOffset
+    ) {
+        this.topicPartition = topicPartition;
+        this.topicPartitionLatestOffset = topicPartitionLatestOffset;
+        this.groupId = groupId;
+        this.groupOffset = groupOffset;
+    }
+
+    /**
+     * Estimates the lag for the given {@link TopicPartition} and consumer group. It cannot be
+     * guaranteed that this estimation is or ever was exactly correct due to the facts that the
+     * queried offsets cannot be queried atomically and that it may be possible that there is no
+     * record at any given offset due to compaction, or other form of deletion.
+     */
+    public long estimateLag() {
+        return topicPartitionLatestOffset - groupOffset;
+    }
+
+    public TopicPartition topicPartition() {
+        return topicPartition;
+    }
+
+    public String groupId() {
+        return groupId;
+    }
+}

--- a/kafka/src/test/java/io/atleon/kafka/KafkaBoundedReceiverTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/KafkaBoundedReceiverTest.java
@@ -1,0 +1,332 @@
+package io.atleon.kafka;
+
+import io.atleon.kafka.embedded.EmbeddedKafka;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class KafkaBoundedReceiverTest {
+
+    private static final String BOOTSTRAP_CONNECT = EmbeddedKafka.startAndGetBootstrapServersConnect(10092);
+
+    @Test
+    public void allDataCurrentlyOnATopicCanBeConsumed() {
+        String topic = UUID.randomUUID().toString();
+        Set<Long> producedValues = produceRecordsFromValues(
+            newProducerConfigs(LongSerializer.class, LongSerializer.class),
+            createRandomLongValues(1000, Collectors.toSet()),
+            value -> new ProducerRecord<>(topic, value, value)
+        );
+
+        OffsetRange offsetRange = OffsetCriteria.earliest().to(OffsetCriteria.latest());
+        Set<Long> result = receiveRecordValues(topic, LongDeserializer.class, offsetRange, Collectors.toSet());
+
+        assertEquals(producedValues, result);
+    }
+
+    @Test
+    public void theEarliestRecordOnATopicPartitionCanBeConsumed() {
+        String topic = UUID.randomUUID().toString();
+        List<Long> producedValues = produceRecordsFromValues(
+            newProducerConfigs(LongSerializer.class, LongSerializer.class),
+            createRandomLongValues(4, Collectors.toList()),
+            value -> new ProducerRecord<>(topic, 0, value, value)
+        );
+
+        List<Long> result = receiveValuesAsLongs(topic, OffsetCriteria.earliest().asRange());
+
+        assertEquals(producedValues.subList(0, 1), result);
+    }
+
+    @Test
+    public void theLatestRecordOnATopicPartitionCanBeConsumed() {
+        String topic = UUID.randomUUID().toString();
+        List<Long> producedValues = produceRecordsFromValues(
+            newProducerConfigs(LongSerializer.class, LongSerializer.class),
+            createRandomLongValues(4, Collectors.toList()),
+            value -> new ProducerRecord<>(topic, 0, value, value)
+        );
+
+        List<Long> result = receiveValuesAsLongs(topic, OffsetCriteria.latest().asRange());
+
+        assertEquals(producedValues.subList(producedValues.size() - 1, producedValues.size()), result);
+    }
+
+    @Test
+    public void recordAtASpecificOffsetCanBeConsumed() {
+        String topic = UUID.randomUUID().toString();
+        List<Long> producedValues = produceRecordsFromValues(
+            newProducerConfigs(LongSerializer.class, LongSerializer.class),
+            createRandomLongValues(4, Collectors.toList()),
+            value -> new ProducerRecord<>(topic, 0, value, value)
+        );
+
+        List<Long> result = receiveValuesAsLongs(topic, OffsetCriteria.raw(1).asRange());
+
+        assertEquals(producedValues.subList(1, 2), result);
+    }
+
+    @Test
+    public void recordsInASpecificOffsetRangeCanBeConsumed() {
+        String topic = UUID.randomUUID().toString();
+        List<Long> producedValues = produceRecordsFromValues(
+            newProducerConfigs(LongSerializer.class, LongSerializer.class),
+            createRandomLongValues(4, Collectors.toList()),
+            value -> new ProducerRecord<>(topic, 0, value, value)
+        );
+
+        assertEquals(
+            producedValues.subList(0, 2),
+            receiveValuesAsLongs(topic, OffsetCriteria.raw(0).to(OffsetCriteria.raw(1)))
+        );
+        assertEquals(
+            producedValues.subList(1, 3),
+            receiveValuesAsLongs(topic, OffsetCriteria.raw(1).to(OffsetCriteria.raw(2)))
+        );
+        assertEquals(
+            producedValues.subList(2, 4),
+            receiveValuesAsLongs(topic, OffsetCriteria.raw(2).to(OffsetCriteria.raw(3)))
+        );
+        assertEquals(
+            producedValues.subList(3, 4),
+            receiveValuesAsLongs(topic, OffsetCriteria.raw(3).to(OffsetCriteria.raw(4)))
+        );
+    }
+
+    @Test
+    public void recordAtASpecificTimestampCanBeConsumed() {
+        String topic = UUID.randomUUID().toString();
+        long now = System.currentTimeMillis();
+        List<Long> producedTimestamps = produceRecordsFromValues(
+            newProducerConfigs(LongSerializer.class, LongSerializer.class),
+            IntStream.range(0, 3).mapToObj(index -> now + (index * 2L)).collect(Collectors.toList()),
+            epochMillis -> new ProducerRecord<>(topic, 0, epochMillis, epochMillis, epochMillis)
+        );
+
+        List<Long> result = receiveValuesAsLongs(topic, OffsetCriteria.timestamp(producedTimestamps.get(1)).asRange());
+
+        assertEquals(producedTimestamps.subList(1, 2), result);
+    }
+
+    @Test
+    public void recordsInATimestampRangeCanBeConsumed() {
+        String topic = UUID.randomUUID().toString();
+        long now = System.currentTimeMillis();
+        List<Long> producedTimestamps = produceRecordsFromValues(
+            newProducerConfigs(LongSerializer.class, LongSerializer.class),
+            IntStream.range(0, 3).mapToObj(index -> now + (index * 2L)).collect(Collectors.toList()),
+            epochMillis -> new ProducerRecord<>(topic, 0, epochMillis, epochMillis, epochMillis)
+        );
+
+        assertEquals(
+            Collections.emptyList(),
+            receiveValuesAsLongs(topic, timestampRange(producedTimestamps.get(0) - 2, producedTimestamps.get(0) - 1))
+        );
+        assertEquals(
+            producedTimestamps.subList(0, 1),
+            receiveValuesAsLongs(topic, timestampRange(producedTimestamps.get(0) - 1, producedTimestamps.get(0)))
+        );
+        assertEquals(
+            producedTimestamps.subList(0, 1),
+            receiveValuesAsLongs(topic, timestampRange(producedTimestamps.get(0) - 1, producedTimestamps.get(0) + 1))
+        );
+        assertEquals(
+            producedTimestamps.subList(0, 1),
+            receiveValuesAsLongs(topic, timestampRange(producedTimestamps.get(0), producedTimestamps.get(0) + 1))
+        );
+        assertEquals(
+            producedTimestamps.subList(0, 2),
+            receiveValuesAsLongs(topic, timestampRange(producedTimestamps.get(0), producedTimestamps.get(1)))
+        );
+        assertEquals(
+            producedTimestamps.subList(1, 2),
+            receiveValuesAsLongs(topic, timestampRange(producedTimestamps.get(1) - 1, producedTimestamps.get(1) + 1))
+        );
+        assertEquals(
+            producedTimestamps.subList(1, 3),
+            receiveValuesAsLongs(topic, timestampRange(producedTimestamps.get(1), producedTimestamps.get(2)))
+        );
+        assertEquals(
+            producedTimestamps.subList(2, 3),
+            receiveValuesAsLongs(topic, timestampRange(producedTimestamps.get(2) - 1, producedTimestamps.get(2)))
+        );
+        assertEquals(
+            producedTimestamps.subList(2, 3),
+            receiveValuesAsLongs(topic, timestampRange(producedTimestamps.get(2) - 1, producedTimestamps.get(2) + 1))
+        );
+        assertEquals(
+            producedTimestamps.subList(2, 3),
+            receiveValuesAsLongs(topic, timestampRange(producedTimestamps.get(2), producedTimestamps.get(2) + 1))
+        );
+        assertEquals(
+            Collections.emptyList(),
+            receiveValuesAsLongs(topic, timestampRange(producedTimestamps.get(2) + 1, producedTimestamps.get(2) + 2))
+        );
+        assertEquals(
+            producedTimestamps,
+            receiveValuesAsLongs(topic, timestampRange(producedTimestamps.get(0), producedTimestamps.get(2)))
+        );
+    }
+
+    @Test
+    public void recordsCanBeConsumedFromASingleTopicPartition() {
+        String topic = UUID.randomUUID().toString();
+        List<Long> producedValues = produceRecordsFromValues(
+            newProducerConfigs(LongSerializer.class, LongSerializer.class),
+            LongStream.range(0, 6).boxed().collect(Collectors.toList()),
+            value -> new ProducerRecord<>(topic, (int) (value / 3), value, value)
+        );
+
+        OffsetRangeProvider allValuesFromFirstPartition = OffsetRangeProvider.inOffsetRangeFromTopicPartition(
+            new TopicPartition(topic, 0),
+            OffsetCriteria.earliest().to(OffsetCriteria.latest())
+        );
+        OffsetRangeProvider partialValuesFromSecondPartition = OffsetRangeProvider.inOffsetRangeFromTopicPartition(
+            new TopicPartition(topic, 1),
+            1,
+            OffsetCriteria.latest()
+        );
+
+        assertEquals(producedValues.subList(0, 3), receiveValuesAsLongs(topic, allValuesFromFirstPartition));
+        assertEquals(producedValues.subList(4, 6), receiveValuesAsLongs(topic, partialValuesFromSecondPartition));
+    }
+
+    @Test
+    public void recordsCanBeConsumedStartingFromASpecificPartitionAndOffset() {
+        String topic = UUID.randomUUID().toString();
+        List<Long> producedValues = produceRecordsFromValues(
+            newProducerConfigs(LongSerializer.class, LongSerializer.class),
+            LongStream.range(0, 6).boxed().collect(Collectors.toList()),
+            value -> new ProducerRecord<>(topic, (int) (value / 3), value, value)
+        );
+
+        OffsetRangeProvider startingInFirstPartition = OffsetRangeProvider.startingFromRawOffsetInTopicPartition(
+            new TopicPartition(topic, 0),
+            2,
+            OffsetCriteria.earliest().to(OffsetCriteria.latest())
+        );
+
+        assertEquals(producedValues.subList(2, 6), receiveValuesAsLongs(topic, startingInFirstPartition));
+    }
+
+    @Test
+    public void recordsCanBeConsumedUsingRawOffsets() {
+        String topic = UUID.randomUUID().toString();
+        List<Long> producedValues = produceRecordsFromValues(
+            newProducerConfigs(LongSerializer.class, LongSerializer.class),
+            LongStream.range(0, 6).boxed().collect(Collectors.toList()),
+            value -> new ProducerRecord<>(topic, (int) (value / 3), value, value)
+        );
+
+        OffsetRangeProvider recordsInFirstPartition = OffsetRangeProvider.usingRawOffsetRange(
+            new TopicPartition(topic, 0),
+            RawOffsetRange.of(1, 2)
+        );
+
+        assertEquals(producedValues.subList(1, 3), receiveValuesAsLongs(topic, recordsInFirstPartition));
+    }
+
+    private List<Long> receiveValuesAsLongs(String topic, OffsetRange offsetRange) {
+        return receiveValuesAsLongs(topic, OffsetRangeProvider.inOffsetRangeFromAllTopicPartitions(offsetRange));
+    }
+
+    private List<Long> receiveValuesAsLongs(String topic, OffsetRangeProvider rangeProvider) {
+        return receiveRecordValues(topic, LongDeserializer.class, rangeProvider, Collectors.toList());
+    }
+
+    private <T, C extends Collection<T>> C receiveRecordValues(
+        String topic,
+        Class<? extends Deserializer<T>> deserializer,
+        OffsetRange offsetRange,
+        Collector<T, ?, C> collector
+    ) {
+        OffsetRangeProvider rangeProvider = OffsetRangeProvider.inOffsetRangeFromAllTopicPartitions(offsetRange);
+        return receiveRecordValues(topic, deserializer, rangeProvider, collector);
+    }
+
+    private <T, C extends Collection<T>> C receiveRecordValues(
+        String topic,
+        Class<? extends Deserializer<T>> deserializer,
+        OffsetRangeProvider rangeProvider,
+        Collector<T, ?, C> collector
+    ) {
+        return KafkaBoundedReceiver.<Object, T>create(newConsumerConfigSource(ByteArrayDeserializer.class, deserializer))
+            .receiveRecords(Collections.singletonList(topic), rangeProvider)
+            .map(ConsumerRecord::value)
+            .collect(collector)
+            .block(Duration.ofSeconds(30));
+    }
+
+    private KafkaConfigSource newProducerConfigs(
+        Class<? extends Serializer<?>> keySerializer,
+        Class<? extends Serializer<?>> valueSerializer
+    ) {
+        return newBaseConfigSource()
+            .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializer.getName())
+            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer.getName());
+    }
+
+    private KafkaConfigSource newConsumerConfigSource(
+        Class<? extends Deserializer<?>> keyDeserializer,
+        Class<? extends Deserializer<?>> valueDeserializer
+    ) {
+        return newBaseConfigSource()
+            .with(ConsumerConfig.GROUP_ID_CONFIG, KafkaBoundedReceiverTest.class.getSimpleName())
+            .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.getName())
+            .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.getName());
+    }
+
+    private KafkaConfigSource newBaseConfigSource() {
+        return KafkaConfigSource.useClientIdAsName()
+            .withClientId(KafkaBoundedReceiverTest.class.getSimpleName())
+            .withBootstrapServers(BOOTSTRAP_CONNECT);
+    }
+
+    private <T, C extends Collection<T>> C produceRecordsFromValues(
+        KafkaConfigSource configSource,
+        C data,
+        Function<T, ProducerRecord<Object, T>> recordCreator
+    ) {
+        try (AloKafkaSender<Object, T> sender = AloKafkaSender.from(configSource)) {
+            Flux.fromIterable(data)
+                .map(recordCreator)
+                .transform(sender::sendRecords)
+                .then()
+                .block(Duration.ofSeconds(30));
+        }
+        return data;
+    }
+
+    private <T> T createRandomLongValues(int count, Collector<Long, ?, T> collector) {
+        Random random = new Random();
+        return IntStream.range(0, count).mapToObj(unused -> random.nextLong()).collect(collector);
+    }
+
+    private static OffsetRange timestampRange(long minEpochMillis, long maxEpochMillis) {
+        return OffsetCriteria.timestamp(minEpochMillis).to(OffsetCriteria.timestamp(maxEpochMillis));
+    }
+}

--- a/kafka/src/test/java/io/atleon/kafka/ReactiveAdminTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/ReactiveAdminTest.java
@@ -1,0 +1,115 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.admin.TestDescribeTopicsResult;
+import org.apache.kafka.clients.admin.TestListConsumerGroupOffsetsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicPartitionInfo;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ReactiveAdminTest {
+
+    @Test
+    public void listTopicPartitions_givenExistingPartitionsForTopic_expectsReturnedTopicPartitions() {
+        TopicPartition topicPartition = new TopicPartition("topic", 0);
+        TopicPartitionInfo partitionInfo =
+            new TopicPartitionInfo(topicPartition.partition(), null, Collections.emptyList(), Collections.emptyList());
+        TopicDescription topicDescription =
+            new TopicDescription(topicPartition.topic(), false, Collections.singletonList(partitionInfo));
+        Map<String, KafkaFuture<TopicDescription>> topicDescriptionNameFutures =
+            Collections.singletonMap(topicPartition.topic(), KafkaFuture.completedFuture(topicDescription));
+
+        Admin admin = mock(Admin.class);
+        when(admin.describeTopics(collectionContaining(topicPartition.topic())))
+            .thenReturn(new TestDescribeTopicsResult(topicDescriptionNameFutures));
+
+        List<TopicPartition> results = new ReactiveAdmin(admin)
+            .listTopicPartitions(topicPartition.topic())
+            .collectList()
+            .block();
+
+        assertEquals(Collections.singletonList(topicPartition), results);
+    }
+
+    @Test
+    public void listOffsets_givenExistingTopicPartitions_expectsReturnedOffsets() {
+        TopicPartition topicPartition = new TopicPartition("topic", 0);
+        ListOffsetsResult.ListOffsetsResultInfo listOffsetsResult =
+            new ListOffsetsResult.ListOffsetsResultInfo(123456L, System.currentTimeMillis(), Optional.empty());
+        Map<TopicPartition, KafkaFuture<ListOffsetsResult.ListOffsetsResultInfo>> listOffsetsResultFutures =
+            Collections.singletonMap(topicPartition, KafkaFuture.completedFuture(listOffsetsResult));
+        OffsetSpec offsetSpec = OffsetSpec.latest();
+
+        Admin admin = mock(Admin.class);
+        when(admin.listOffsets(mapContaining(topicPartition, offsetSpec), any()))
+            .thenReturn(new ListOffsetsResult(listOffsetsResultFutures));
+
+        Map<TopicPartition, Long> results = new ReactiveAdmin(admin)
+            .listOffsets(Collections.singletonList(topicPartition), offsetSpec)
+            .block();
+
+        assertEquals(Collections.singletonMap(topicPartition, listOffsetsResult.offset()), results);
+    }
+
+    @Test
+    public void listTopicPartitionGroupOffsets_givenCommittedOffsetsForGroup_expectsReturnedOffsets() {
+        String groupId = UUID.randomUUID().toString();
+        TopicPartition topicPartition = new TopicPartition("topic", 0);
+        ListOffsetsResult.ListOffsetsResultInfo listOffsetsResult =
+            new ListOffsetsResult.ListOffsetsResultInfo(123456L, System.currentTimeMillis(), Optional.empty());
+        Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata =
+            Collections.singletonMap(topicPartition, new OffsetAndMetadata(listOffsetsResult.offset(), "metadata"));
+
+        Map<String, KafkaFuture<Map<TopicPartition, OffsetAndMetadata>>> offsetAndMetadataFutures =
+            Collections.singletonMap(groupId, KafkaFuture.completedFuture(offsetsAndMetadata));
+        Map<TopicPartition, KafkaFuture<ListOffsetsResult.ListOffsetsResultInfo>> listOffsetsResultFutures =
+            Collections.singletonMap(topicPartition, KafkaFuture.completedFuture(listOffsetsResult));
+
+        Admin admin = mock(Admin.class);
+        when(admin.listConsumerGroupOffsets(mapContainingKey(groupId)))
+            .thenReturn(TestListConsumerGroupOffsetsResult.create(offsetAndMetadataFutures));
+        when(admin.listOffsets(mapContainingKey(topicPartition), any()))
+            .thenReturn(new ListOffsetsResult(listOffsetsResultFutures));
+
+        List<TopicPartitionGroupOffsets> results = new ReactiveAdmin(admin)
+            .listTopicPartitionGroupOffsets(groupId)
+            .collectList()
+            .block();
+
+        assertEquals(1, results.size());
+        assertEquals(0, results.get(0).estimateLag());
+        assertEquals(topicPartition, results.get(0).topicPartition());
+        assertEquals(groupId, results.get(0).groupId());
+    }
+
+    private static <T> Collection<T> collectionContaining(T t) {
+        return argThat(it -> it.contains(t));
+    }
+
+    private static <K, V> Map<K, V> mapContainingKey(K key) {
+        return argThat(it -> it.containsKey(key));
+    }
+
+    private static <K, V> Map<K, V> mapContaining(K key, V value) {
+        return argThat(it -> it.containsKey(key) && Objects.equals(value, it.get(key)));
+    }
+}

--- a/kafka/src/test/java/org/apache/kafka/clients/admin/TestDescribeTopicsResult.java
+++ b/kafka/src/test/java/org/apache/kafka/clients/admin/TestDescribeTopicsResult.java
@@ -1,0 +1,15 @@
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+
+import java.util.Map;
+
+/**
+ * Test extension of {@link DescribeTopicsResult} to allow creation for tests
+ */
+public class TestDescribeTopicsResult extends DescribeTopicsResult {
+
+    public TestDescribeTopicsResult(Map<String, KafkaFuture<TopicDescription>> futures) {
+        super(null, futures);
+    }
+}

--- a/kafka/src/test/java/org/apache/kafka/clients/admin/TestListConsumerGroupOffsetsResult.java
+++ b/kafka/src/test/java/org/apache/kafka/clients/admin/TestListConsumerGroupOffsetsResult.java
@@ -1,0 +1,31 @@
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.clients.admin.internals.CoordinatorKey;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Test extension of {@link ListConsumerGroupOffsetsResult} to allow creation for tests
+ */
+public class TestListConsumerGroupOffsetsResult extends ListConsumerGroupOffsetsResult{
+
+    private TestListConsumerGroupOffsetsResult(
+        Map<CoordinatorKey, KafkaFuture<Map<TopicPartition, OffsetAndMetadata>>> futures
+    ) {
+        super(futures);
+    }
+
+    public static TestListConsumerGroupOffsetsResult create(
+        Map<String, KafkaFuture<Map<TopicPartition, OffsetAndMetadata>>> futures
+    ) {
+        Map<CoordinatorKey, KafkaFuture<Map<TopicPartition, OffsetAndMetadata>>> convertedFutures =
+            futures.entrySet()
+                .stream()
+                .collect(Collectors.toMap(it -> CoordinatorKey.byGroupId(it.getKey()), Map.Entry::getValue));
+        return new TestListConsumerGroupOffsetsResult(convertedFutures);
+    }
+}

--- a/util/src/main/java/io/atleon/util/ConfigLoading.java
+++ b/util/src/main/java/io/atleon/util/ConfigLoading.java
@@ -33,7 +33,7 @@ public final class ConfigLoading {
      */
     public static Map<String, Object> loadNative(Map<String, Object> configs) {
         return configs.entrySet().stream()
-            .filter(entry -> !entry.getKey().matches("^((atleon\\.)|(\\w+\\.(receiver|sender)\\.)).+"))
+            .filter(entry -> !entry.getKey().matches("^((atleon\\.)|(\\w+\\.(bounded\\.)?(receiver|sender)\\.)).+"))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 

--- a/util/src/test/java/io/atleon/util/ConfigLoadingTest.java
+++ b/util/src/test/java/io/atleon/util/ConfigLoadingTest.java
@@ -23,6 +23,7 @@ public class ConfigLoadingTest {
     public void propertiesCanBeStrippedDownToNativeProperties() {
         Map<String, Object> configs = new HashMap<>();
         configs.put("special.receiver.config", "value");
+        configs.put("special.bounded.receiver.config", "value");
         configs.put("atleon.config", "value");
         configs.put("native.config", "value");
 


### PR DESCRIPTION
### :pencil: Description
Initial implementation of reusable Kafka administration-oriented utilities.

### :link: Related Issues
[#302]