### PR TITLE
[#305] Replace usage of Alo*[Receiver|Sender] `from` with `create`

### DIFF
--- a/aws/aws-sns/src/test/java/io/atleon/aws/sns/AloSnsSenderTest.java
+++ b/aws/aws-sns/src/test/java/io/atleon/aws/sns/AloSnsSenderTest.java
@@ -26,7 +26,7 @@ class AloSnsSenderTest extends LocalStackDependentTest {
             nacknowledgement::set
         );
 
-        AloSnsSender.<String>from(newAloSnsSenderConfigSource())
+        AloSnsSender.<String>create(newAloSnsSenderConfigSource())
             .sendAloMessages(Flux.just(aloSnsMessage), topicArn)
             .consumeAloAndGet(alo -> {
                 Alo.acknowledge(alo);

--- a/aws/aws-sqs/src/main/java/io/atleon/aws/sqs/AloSqsReceiver.java
+++ b/aws/aws-sqs/src/main/java/io/atleon/aws/sqs/AloSqsReceiver.java
@@ -137,13 +137,20 @@ public class AloSqsReceiver<T> {
     }
 
     /**
+     * Alias for {@link #create(SqsConfigSource)}. Will be deprecated in future release.
+     */
+    public static <T> AloSqsReceiver<T> from(SqsConfigSource configSource) {
+        return create(configSource);
+    }
+
+    /**
      * Creates a new AloSqsReceiver from the provided {@link SqsConfigSource}
      *
      * @param configSource The reactive source of {@link SqsConfig}
      * @param <T>          The types of deserialized message bodies contained in received messages
      * @return A new AloSqsReceiver
      */
-    public static <T> AloSqsReceiver<T> from(SqsConfigSource configSource) {
+    public static <T> AloSqsReceiver<T> create(SqsConfigSource configSource) {
         return new AloSqsReceiver<>(configSource);
     }
 

--- a/aws/aws-sqs/src/test/java/io/atleon/aws/sqs/AloProcessingTest.java
+++ b/aws/aws-sqs/src/test/java/io/atleon/aws/sqs/AloProcessingTest.java
@@ -13,18 +13,18 @@ public class AloProcessingTest extends LocalStackDependentTest {
 
     @Test
     public void acknowledgedDataIsNotRepublished() {
-        AloSqsSender.<String>from(newAloSqsSenderConfigSource())
+        AloSqsSender.<String>create(newAloSqsSenderConfigSource())
             .sendBodies(Mono.just("DATA"), ComposedSqsMessage::fromBody, queueUrl)
             .then().block();
 
-        AloSqsReceiver.from(newAloSqsReceiverConfigSource())
+        AloSqsReceiver.create(newAloSqsReceiverConfigSource())
             .receiveAloBodies(queueUrl)
             .as(StepVerifier::create)
             .consumeNextWith(Alo::acknowledge)
             .thenCancel()
             .verify();
 
-        AloSqsReceiver.from(newAloSqsReceiverConfigSource())
+        AloSqsReceiver.create(newAloSqsReceiverConfigSource())
             .receiveAloBodies(queueUrl)
             .as(StepVerifier::create)
             .expectSubscription()
@@ -35,18 +35,18 @@ public class AloProcessingTest extends LocalStackDependentTest {
 
     @Test
     public void unacknowledgedDataIsRepublished() {
-        AloSqsSender.<String>from(newAloSqsSenderConfigSource())
+        AloSqsSender.<String>create(newAloSqsSenderConfigSource())
             .sendBodies(Mono.just("DATA"), ComposedSqsMessage::fromBody, queueUrl)
             .then().block();
 
-        AloSqsReceiver.from(newAloSqsReceiverConfigSource())
+        AloSqsReceiver.create(newAloSqsReceiverConfigSource())
             .receiveAloBodies(queueUrl)
             .as(StepVerifier::create)
             .expectNextCount(1)
             .thenCancel()
             .verify();
 
-        AloSqsReceiver.from(newAloSqsReceiverConfigSource())
+        AloSqsReceiver.create(newAloSqsReceiverConfigSource())
             .receiveAloBodies(queueUrl)
             .as(StepVerifier::create)
             .expectNextCount(1)
@@ -56,11 +56,11 @@ public class AloProcessingTest extends LocalStackDependentTest {
 
     @Test
     public void nacknowledgedDataIsRepublished() {
-        AloSqsSender.<String>from(newAloSqsSenderConfigSource())
+        AloSqsSender.<String>create(newAloSqsSenderConfigSource())
             .sendBodies(Flux.just("DATA1", "DATA2", "DATA3"), ComposedSqsMessage::fromBody, queueUrl)
             .then().block();
 
-        AloSqsReceiver.from(newAloSqsReceiverConfigSource())
+        AloSqsReceiver.create(newAloSqsReceiverConfigSource())
             .receiveAloBodies(queueUrl)
             .resubscribeOnError(AloProcessingTest.class.getSimpleName(), Duration.ofSeconds(0L))
             .as(StepVerifier::create)

--- a/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart1.java
+++ b/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart1.java
@@ -29,7 +29,7 @@ public class KafkaPart1 {
             .withProducerOrderingAndResiliencyConfigs();
 
         //Step 2) Send some Record values to a hardcoded topic, using values as Record keys
-        AloKafkaSender.<String, String>from(kafkaSenderConfig)
+        AloKafkaSender.<String, String>create(kafkaSenderConfig)
             .sendValues(Flux.just("Test"), TOPIC, Function.identity())
             .collectList()
             .doOnNext(senderResults -> System.out.println("senderResults: " + senderResults))

--- a/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart2.java
+++ b/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart2.java
@@ -45,7 +45,7 @@ public class KafkaPart2 {
             .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
 
         //Step 3) Send some Record values to a hardcoded topic, using values as Record keys
-        AloKafkaSender.<String, String>from(kafkaReceiverConfig)
+        AloKafkaSender.<String, String>create(kafkaReceiverConfig)
             .sendValues(Flux.just("Test"), TOPIC, Function.identity())
             .collectList()
             .doOnNext(senderResults -> System.out.println("senderResults: " + senderResults))
@@ -53,7 +53,7 @@ public class KafkaPart2 {
 
         //Step 4) Subscribe to the same topic we produced previous values to. Note that we must
         // specify how many values to process ('.take(1)'), or else this Flow would never complete
-        AloKafkaReceiver.<String>forValues(kafkaSenderConfig)
+        AloKafkaReceiver.<Object, String>create(kafkaSenderConfig)
             .receiveAloValues(TOPIC)
             .consumeAloAndGet(Alo::acknowledge)
             .take(1)

--- a/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart3.java
+++ b/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart3.java
@@ -49,7 +49,7 @@ public class KafkaPart3 {
             .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
 
         //Step 3) Create a Sender which we'll reuse to produce Records
-        AloKafkaSender<String, String> sender = AloKafkaSender.from(kafkaSenderConfig);
+        AloKafkaSender<String, String> sender = AloKafkaSender.create(kafkaSenderConfig);
 
         //Step 4) Send some Record values to a hardcoded topic, using values as Record keys
         sender.sendValues(Flux.just("Test"), TOPIC_1, Function.identity())
@@ -63,7 +63,7 @@ public class KafkaPart3 {
         // the consumption of Alo data (by acknowledging). Note that we again need to explicitly
         // limit the number of results we expect ('.take(1)'), or else this Flow would never
         // complete.
-        AloKafkaReceiver.<String>forValues(kafkaReceiverConfig)
+        AloKafkaReceiver.<Object, String>create(kafkaReceiverConfig)
             .receiveAloValues(TOPIC_1)
             .map(String::toUpperCase)
             .transform(sender.sendAloValues(TOPIC_2, Function.identity()))

--- a/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart4.java
+++ b/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart4.java
@@ -47,10 +47,10 @@ public class KafkaPart4 {
             .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
 
         //Step 3) Create a Sender which we'll reuse to produce Records
-        AloKafkaSender<String, String> sender = AloKafkaSender.from(kafkaSenderConfig);
+        AloKafkaSender<String, String> sender = AloKafkaSender.create(kafkaSenderConfig);
 
         //Step 4) Create a Receiver which we'll reuse to subscribe to Records
-        AloKafkaReceiver<Object, String> receiver = AloKafkaReceiver.forValues(kafkaReceiverConfig);
+        AloKafkaReceiver<Object, String> receiver = AloKafkaReceiver.create(kafkaReceiverConfig);
 
         //Step 5) Send some Record values to a hardcoded topic, using values as Record keys
         sender.sendValues(Flux.just("Test"), TOPIC_1, Function.identity())

--- a/examples/core/src/main/java/io/atleon/examples/endtoendtoend/SqsPart1.java
+++ b/examples/core/src/main/java/io/atleon/examples/endtoendtoend/SqsPart1.java
@@ -36,7 +36,7 @@ public class SqsPart1 {
             .with(AloSqsReceiver.BODY_DESERIALIZER_CONFIG, StringBodyDeserializer.class);
 
         //Step 4) Create Receiver, then apply consumption
-        Disposable processing = AloSqsReceiver.from(configSource)
+        Disposable processing = AloSqsReceiver.create(configSource)
             .receiveAloMessages(queueUrl)
             .consume(message -> System.out.println("Received message: " + message.body()))
             .subscribe();
@@ -60,7 +60,7 @@ public class SqsPart1 {
             .with(AloSqsSender.BODY_SERIALIZER_CONFIG, StringBodySerializer.class);
 
         //Step 2) Create Sender, and produce messages periodically
-        AloSqsSender<String> sender = AloSqsSender.from(configSource);
+        AloSqsSender<String> sender = AloSqsSender.create(configSource);
         return Flux.interval(period)
             .map(number -> ComposedSqsMessage.fromBody("This is message #" + (number + 1)))
             .transform(messages -> sender.sendMessages(messages, queueUrl))

--- a/examples/core/src/main/java/io/atleon/examples/endtoendtoend/SqsPart2.java
+++ b/examples/core/src/main/java/io/atleon/examples/endtoendtoend/SqsPart2.java
@@ -40,8 +40,8 @@ public class SqsPart2 {
             .with(AloSqsSender.BODY_SERIALIZER_CONFIG, StringBodySerializer.class);
 
         //Step 4) Create Sender and Receiver, then apply processing
-        AloSqsSender<String> sender = AloSqsSender.from(configSource);
-        Disposable processing = AloSqsReceiver.<String>from(configSource)
+        AloSqsSender<String> sender = AloSqsSender.create(configSource);
+        Disposable processing = AloSqsReceiver.<String>create(configSource)
             .receiveAloMessages(inputQueueUrl)
             .map(message -> message.body().toUpperCase())
             .transform(sender.sendAloBodies(ComposedSqsMessage::fromBody, outputQueueUrl))
@@ -68,7 +68,7 @@ public class SqsPart2 {
             .with(AloSqsSender.BODY_SERIALIZER_CONFIG, StringBodySerializer.class);
 
         //Step 2) Create Sender, and produce messages periodically
-        AloSqsSender<String> sender = AloSqsSender.from(configSource);
+        AloSqsSender<String> sender = AloSqsSender.create(configSource);
         return Flux.interval(period)
             .map(number -> ComposedSqsMessage.fromBody("This is message #" + number))
             .transform(messages -> sender.sendMessages(messages, queueUrl))

--- a/examples/core/src/main/java/io/atleon/examples/errorhandling/KafkaErrorHandling.java
+++ b/examples/core/src/main/java/io/atleon/examples/errorhandling/KafkaErrorHandling.java
@@ -81,8 +81,8 @@ public class KafkaErrorHandling {
         // BOTH records and successfully process them
         CountDownLatch latch = new CountDownLatch(1);
         List<String> successfullyProcessed = new CopyOnWriteArrayList<>();
-        AloKafkaSender<String, String> sender = AloKafkaSender.from(faultyKafkaSenderConfig);
-        AloKafkaReceiver.<String>forValues(kafkaReceiverConfig)
+        AloKafkaSender<String, String> sender = AloKafkaSender.create(faultyKafkaSenderConfig);
+        AloKafkaReceiver.<Object, String>create(kafkaReceiverConfig)
             .receiveAloValues(TOPIC_1)
             .groupBy(Function.identity(), Integer.MAX_VALUE)
             .innerPublishOn(Schedulers.boundedElastic())
@@ -111,7 +111,7 @@ public class KafkaErrorHandling {
         // them on the same topic-partition
         Flux.just("test_1", "test_2")
             .subscribeOn(Schedulers.boundedElastic())
-            .transform(AloKafkaSender.<String, String>from(kafkaSenderConfig).sendValues(TOPIC_1, string -> "KEY"))
+            .transform(AloKafkaSender.<String, String>create(kafkaSenderConfig).sendValues(TOPIC_1, string -> "KEY"))
             .subscribe();
 
         //Step 6) Await the successful completion of the data we emitted. There should be exactly

--- a/examples/core/src/main/java/io/atleon/examples/metrics/KafkaMicrometer.java
+++ b/examples/core/src/main/java/io/atleon/examples/metrics/KafkaMicrometer.java
@@ -67,15 +67,15 @@ public class KafkaMicrometer {
         Metrics.addRegistry(meterRegistry);
 
         //Step 5) Produce values to the topic we'll process
-        AloKafkaSender.<String, String>from(kafkaSenderConfig)
+        AloKafkaSender.<String, String>create(kafkaSenderConfig)
             .sendValues(Flux.just("test"), TOPIC_1, Function.identity())
             .subscribe();
 
         //Step 6) Apply stream processing to the Kafka topic we produced records to
-        AloKafkaReceiver.<String>forValues(kafkaReceiverConfig)
+        AloKafkaReceiver.<Object, String>create(kafkaReceiverConfig)
             .receiveAloValues(TOPIC_1)
             .map(String::toUpperCase)
-            .transform(AloKafkaSender.<String, String>from(kafkaSenderConfig).sendAloValues(TOPIC_2, Function.identity()))
+            .transform(AloKafkaSender.<String, String>create(kafkaSenderConfig).sendAloValues(TOPIC_2, Function.identity()))
             .tap(AloMicrometer.metrics("atleon.kafka.micrometer.sent"))
             .consumeAloAndGet(Alo::acknowledge)
             .publish()

--- a/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaArbitraryParallelism.java
+++ b/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaArbitraryParallelism.java
@@ -63,7 +63,7 @@ public class KafkaArbitraryParallelism {
         // "processing" in this case introduces a superficial blocking sleep which might mimic an
         // IO-bound process.
         CountDownLatch latch = new CountDownLatch(NUM_SAMPLES);
-        AloKafkaReceiver.<String, String>from(kafkaReceiverConfig)
+        AloKafkaReceiver.<String, String>create(kafkaReceiverConfig)
             .receiveAloRecords(TOPIC)
             .groupByStringHash(ConsumerRecord::key, NUM_GROUPS, ConsumerRecord::value)
             .innerPublishOn(Schedulers.boundedElastic())
@@ -87,7 +87,7 @@ public class KafkaArbitraryParallelism {
             .subscribeOn(Schedulers.boundedElastic())
             .map(i -> UUID.randomUUID())
             .map(UUID::toString)
-            .transform(AloKafkaSender.<String, String>from(kafkaSenderConfig).sendValues(TOPIC, Function.identity()))
+            .transform(AloKafkaSender.<String, String>create(kafkaSenderConfig).sendValues(TOPIC, Function.identity()))
             .subscribe();
 
         //Step 5) Await processing completion of the UUIDs we produced

--- a/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaTopicPartitionParallelism.java
+++ b/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaTopicPartitionParallelism.java
@@ -58,7 +58,7 @@ public class KafkaTopicPartitionParallelism {
         //"processing" in this case introduces a superficial blocking sleep which might mimic an
         //IO-bound process.
         CountDownLatch latch = new CountDownLatch(NUM_SAMPLES);
-        AloKafkaReceiver.<String, String>from(kafkaReceiverConfig)
+        AloKafkaReceiver.<String, String>create(kafkaReceiverConfig)
             .receiveAloRecords(TOPIC)
             .groupBy(ConsumerRecordExtraction::topicPartition, Integer.MAX_VALUE, ConsumerRecord::value)
             .innerPublishOn(Schedulers.boundedElastic())
@@ -82,7 +82,7 @@ public class KafkaTopicPartitionParallelism {
             .subscribeOn(Schedulers.boundedElastic())
             .map(i -> UUID.randomUUID())
             .map(UUID::toString)
-            .transform(AloKafkaSender.<String, String>from(kafkaSenderConfig).sendValues(TOPIC, Function.identity()))
+            .transform(AloKafkaSender.<String, String>create(kafkaSenderConfig).sendValues(TOPIC, Function.identity()))
             .subscribe();
 
         //Step 5) Await processing completion of the UUIDs we produced

--- a/examples/core/src/main/java/io/atleon/examples/tracing/KafkaOpentracing.java
+++ b/examples/core/src/main/java/io/atleon/examples/tracing/KafkaOpentracing.java
@@ -59,7 +59,7 @@ public class KafkaOpentracing {
         GlobalTracer.registerIfAbsent(tracer);
 
         //Step 4) Create an AloKafkaSender with which we'll send records
-        AloKafkaSender<String, String> sender = AloKafkaSender.from(kafkaSenderConfig);
+        AloKafkaSender<String, String> sender = AloKafkaSender.create(kafkaSenderConfig);
 
         //Step 5) Produce records to our input topic
         int numToEmit = 4;
@@ -70,7 +70,7 @@ public class KafkaOpentracing {
 
         //Step 6) Process the records we produced to another topic
         int numToCombine = 2;
-        AloKafkaReceiver.<String, String>from(kafkaReceiverConfig)
+        AloKafkaReceiver.<String, String>create(kafkaReceiverConfig)
             .receiveAloValues(TOPIC_1)
             .bufferTimeout(numToCombine, Duration.ofNanos(Long.MAX_VALUE))
             .map(strings -> String.join(" ", strings))

--- a/examples/spring/src/main/java/io/atleon/examples/spring/awssnssqs/stream/SnsGenerationStreamConfig.java
+++ b/examples/spring/src/main/java/io/atleon/examples/spring/awssnssqs/stream/SnsGenerationStreamConfig.java
@@ -32,7 +32,7 @@ public class SnsGenerationStreamConfig implements AloStreamConfig {
             .with(AloSnsSender.BODY_SERIALIZER_CONFIG, StringBodySerializer.class.getName())
             .with(AloSnsSender.BATCH_SIZE_CONFIG, 10)
             .with(AloSnsSender.BATCH_DURATION_CONFIG, "PT0.1S");
-        return AloSnsSender.from(configSource);
+        return AloSnsSender.create(configSource);
     }
 
     public String getTopicArn() {

--- a/examples/spring/src/main/java/io/atleon/examples/spring/awssnssqs/stream/SqsConsumptionStreamConfig.java
+++ b/examples/spring/src/main/java/io/atleon/examples/spring/awssnssqs/stream/SqsConsumptionStreamConfig.java
@@ -33,7 +33,7 @@ public class SqsConsumptionStreamConfig implements AloStreamConfig {
         SqsConfigSource configSource = SqsConfigSource.named(name())
             .withAll(awsProperties)
             .with(AloSqsReceiver.BODY_DESERIALIZER_CONFIG, LongBodyDeserializer.class);
-        return AloSqsReceiver.from(configSource);
+        return AloSqsReceiver.create(configSource);
     }
 
     public String getQueueUrl() {

--- a/examples/spring/src/main/java/io/atleon/examples/spring/awssnssqs/stream/SqsProcessingStreamConfig.java
+++ b/examples/spring/src/main/java/io/atleon/examples/spring/awssnssqs/stream/SqsProcessingStreamConfig.java
@@ -38,13 +38,13 @@ public class SqsProcessingStreamConfig implements AloStreamConfig {
     public AloSqsReceiver<Long> buildReceiver() {
         SqsConfigSource configSource = baseSqsConfigSource()
             .with(AloSqsReceiver.BODY_DESERIALIZER_CONFIG, LongBodyDeserializer.class.getName());
-        return AloSqsReceiver.from(configSource);
+        return AloSqsReceiver.create(configSource);
     }
 
     public AloSqsSender<Long> buildSender() {
         SqsConfigSource configSource = baseSqsConfigSource()
             .with(AloSqsSender.BODY_SERIALIZER_CONFIG, StringBodySerializer.class.getName());
-        return AloSqsSender.from(configSource);
+        return AloSqsSender.create(configSource);
     }
 
     public String getInputQueueUrl() {

--- a/examples/spring/src/main/java/io/atleon/examples/spring/kafka/stream/KafkaConsumptionStreamConfig.java
+++ b/examples/spring/src/main/java/io/atleon/examples/spring/kafka/stream/KafkaConsumptionStreamConfig.java
@@ -42,7 +42,7 @@ public class KafkaConsumptionStreamConfig implements AloStreamConfig {
             .withKeyDeserializer(LongDeserializer.class)
             .withValueDeserializer(LongDeserializer.class)
             .with(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG, AloKafkaMetricsReporter.class.getName());
-        return AloKafkaReceiver.from(configSource);
+        return AloKafkaReceiver.create(configSource);
     }
 
     public String getTopic() {

--- a/examples/spring/src/main/java/io/atleon/examples/spring/kafka/stream/KafkaGenerationStreamConfig.java
+++ b/examples/spring/src/main/java/io/atleon/examples/spring/kafka/stream/KafkaGenerationStreamConfig.java
@@ -37,7 +37,7 @@ public class KafkaGenerationStreamConfig implements AloStreamConfig {
             .withKeySerializer(LongSerializer.class)
             .withValueSerializer(LongSerializer.class)
             .with(ProducerConfig.METRIC_REPORTER_CLASSES_CONFIG, AloKafkaMetricsReporter.class.getName());
-        return AloKafkaSender.from(configSource);
+        return AloKafkaSender.create(configSource);
     }
 
     public String getTopic() {

--- a/examples/spring/src/main/java/io/atleon/examples/spring/kafka/stream/KafkaProcessingStreamConfig.java
+++ b/examples/spring/src/main/java/io/atleon/examples/spring/kafka/stream/KafkaProcessingStreamConfig.java
@@ -45,7 +45,7 @@ public class KafkaProcessingStreamConfig implements AloStreamConfig {
             .with(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
             .withKeyDeserializer(LongDeserializer.class)
             .withValueDeserializer(LongDeserializer.class);
-        return AloKafkaReceiver.from(configSource);
+        return AloKafkaReceiver.create(configSource);
     }
 
     public AloKafkaSender<Long, Long> buildKafkaLongSender() {
@@ -53,7 +53,7 @@ public class KafkaProcessingStreamConfig implements AloStreamConfig {
             .withProducerOrderingAndResiliencyConfigs()
             .withKeySerializer(LongSerializer.class)
             .withValueSerializer(LongSerializer.class);
-        return AloKafkaSender.from(configSource);
+        return AloKafkaSender.create(configSource);
     }
 
     public String getInputTopic() {

--- a/examples/spring/src/main/java/io/atleon/examples/spring/rabbitmq/stream/RabbitMQConsumptionStreamConfig.java
+++ b/examples/spring/src/main/java/io/atleon/examples/spring/rabbitmq/stream/RabbitMQConsumptionStreamConfig.java
@@ -34,7 +34,7 @@ public class RabbitMQConsumptionStreamConfig implements AloStreamConfig {
         RabbitMQConfigSource configSource = RabbitMQConfigSource.named(name())
             .withAll(rabbitMQProperties)
             .with(AloRabbitMQReceiver.BODY_DESERIALIZER_CONFIG, LongBodyDeserializer.class.getName());
-        return AloRabbitMQReceiver.from(configSource);
+        return AloRabbitMQReceiver.create(configSource);
     }
 
     public String getQueue() {

--- a/examples/spring/src/main/java/io/atleon/examples/spring/rabbitmq/stream/RabbitMQGenerationStreamConfig.java
+++ b/examples/spring/src/main/java/io/atleon/examples/spring/rabbitmq/stream/RabbitMQGenerationStreamConfig.java
@@ -37,7 +37,7 @@ public class RabbitMQGenerationStreamConfig implements AloStreamConfig {
         RabbitMQConfigSource configSource = RabbitMQConfigSource.named(name())
             .withAll(rabbitMQProperties)
             .with(AloRabbitMQSender.BODY_SERIALIZER_CONFIG, LongBodySerializer.class.getName());
-        return AloRabbitMQSender.from(configSource);
+        return AloRabbitMQSender.create(configSource);
     }
 
     public RabbitMQMessageCreator<Long> buildMessageCreator() {

--- a/examples/spring/src/main/java/io/atleon/examples/spring/rabbitmq/stream/RabbitMQProcessingStreamConfig.java
+++ b/examples/spring/src/main/java/io/atleon/examples/spring/rabbitmq/stream/RabbitMQProcessingStreamConfig.java
@@ -45,13 +45,13 @@ public class RabbitMQProcessingStreamConfig implements AloStreamConfig {
     public AloRabbitMQReceiver<Long> buildRabbitMQLongReceiver() {
         RabbitMQConfigSource configSource = baseRabbitMQConfigSource()
             .with(AloRabbitMQReceiver.BODY_DESERIALIZER_CONFIG, LongBodyDeserializer.class.getName());
-        return AloRabbitMQReceiver.from(configSource);
+        return AloRabbitMQReceiver.create(configSource);
     }
 
     public AloRabbitMQSender<Long> buildRabbitMQLongSender() {
         RabbitMQConfigSource configSource = baseRabbitMQConfigSource()
             .with(AloRabbitMQSender.BODY_SERIALIZER_CONFIG, LongBodySerializer.class.getName());
-        return AloRabbitMQSender.from(configSource);
+        return AloRabbitMQSender.create(configSource);
     }
 
     public RabbitMQMessageCreator<Long> buildLongMessageCreator() {

--- a/examples/spring/src/test/java/io/atleon/examples/spring/awssnssqs/IntegrationTest.java
+++ b/examples/spring/src/test/java/io/atleon/examples/spring/awssnssqs/IntegrationTest.java
@@ -64,7 +64,7 @@ public class IntegrationTest {
             .with(AwsConfig.CREDENTIALS_SECRET_ACCESS_KEY_CONFIG, CONTAINER.getSecretKey())
             .with(SnsConfig.ENDPOINT_OVERRIDE_CONFIG, CONTAINER.getSnsEndpointOverride())
             .with(AloSnsSender.BODY_SERIALIZER_CONFIG, StringBodySerializer.class);
-        try (AloSnsSender<Long> sender = AloSnsSender.from(configSource)) {
+        try (AloSnsSender<Long> sender = AloSnsSender.create(configSource)) {
             SnsMessage<Long> message = ComposedSnsMessage.fromBody(number.longValue());
             sender.sendMessage(message, SnsAddress.topicArn(snsInputTopicArn)).block();
         }

--- a/examples/spring/src/test/java/io/atleon/examples/spring/kafka/IntegrationTest.java
+++ b/examples/spring/src/test/java/io/atleon/examples/spring/kafka/IntegrationTest.java
@@ -58,7 +58,7 @@ public class IntegrationTest {
         KafkaConfigSource configSource = baseKafkaConfigSource()
             .withKeySerializer(LongSerializer.class)
             .withValueSerializer(LongSerializer.class);
-        try (AloKafkaSender<Long, Long> sender = AloKafkaSender.from(configSource)) {
+        try (AloKafkaSender<Long, Long> sender = AloKafkaSender.create(configSource)) {
             ProducerRecord<Long, Long> record = new ProducerRecord<>(INPUT_TOPIC, number.longValue(), number.longValue());
             sender.sendRecord(record).block();
         }
@@ -70,7 +70,7 @@ public class IntegrationTest {
             .with(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
             .withKeyDeserializer(LongDeserializer.class)
             .withValueDeserializer(LongDeserializer.class);
-        return AloKafkaReceiver.<Long, Long>from(configSource)
+        return AloKafkaReceiver.<Long, Long>create(configSource)
             .receiveAloValues(OUTPUT_TOPIC)
             .consumeAloAndGet(Alo::acknowledge)
             .any(number::equals)

--- a/examples/spring/src/test/java/io/atleon/examples/spring/rabbitmq/IntegrationTest.java
+++ b/examples/spring/src/test/java/io/atleon/examples/spring/rabbitmq/IntegrationTest.java
@@ -55,7 +55,7 @@ public class IntegrationTest {
         RabbitMQConfigSource configSource = RabbitMQConfigSource.unnamed()
             .withAll(AMQP_CONFIG.asMap())
             .with(AloRabbitMQSender.BODY_SERIALIZER_CONFIG, LongBodySerializer.class);
-        try (AloRabbitMQSender<Long> sender = AloRabbitMQSender.from(configSource)) {
+        try (AloRabbitMQSender<Long> sender = AloRabbitMQSender.create(configSource)) {
             RabbitMQMessage<Long> message =
                 RabbitMQMessage.create(EXCHANGE, INPUT_QUEUE, MessageProperties.MINIMAL_BASIC, number.longValue());
             sender.sendMessage(message).block();

--- a/kafka/src/main/java/io/atleon/kafka/AloKafkaReceiver.java
+++ b/kafka/src/main/java/io/atleon/kafka/AloKafkaReceiver.java
@@ -177,6 +177,13 @@ public class AloKafkaReceiver<K, V> {
     }
 
     /**
+     * Alias for {@link #create(KafkaConfigSource)}. Will be deprecated in future release.
+     */
+    public static <K, V> AloKafkaReceiver<K, V> from(KafkaConfigSource configSource) {
+        return create(configSource);
+    }
+
+    /**
      * Creates a new AloKafkaReceiver from the provided {@link KafkaConfigSource}
      *
      * @param configSource The reactive source of Kafka Receiver properties
@@ -184,7 +191,7 @@ public class AloKafkaReceiver<K, V> {
      * @param <V>          The types of values contained in received records
      * @return A new AloKafkaReceiver
      */
-    public static <K, V> AloKafkaReceiver<K, V> from(KafkaConfigSource configSource) {
+    public static <K, V> AloKafkaReceiver<K, V> create(KafkaConfigSource configSource) {
         return new AloKafkaReceiver<>(configSource);
     }
 
@@ -196,7 +203,9 @@ public class AloKafkaReceiver<K, V> {
      * @param configSource The reactive source of Kafka Receiver properties
      * @param <V>          The types of values contained in received records
      * @return A new AloKafkaReceiver
+     * @deprecated Use {@link AloKafkaReceiver#create(KafkaConfigSource)}
      */
+    @Deprecated
     public static <V> AloKafkaReceiver<Object, V> forValues(KafkaConfigSource configSource) {
         return new AloKafkaReceiver<>(configSource);
     }

--- a/kafka/src/main/java/io/atleon/kafka/AloKafkaSender.java
+++ b/kafka/src/main/java/io/atleon/kafka/AloKafkaSender.java
@@ -93,6 +93,13 @@ public class AloKafkaSender<K, V> implements Closeable {
     }
 
     /**
+     * Alias for {@link #create(KafkaConfigSource)}. Will be deprecated in future release.
+     */
+    public static <K, V> AloKafkaSender<K, V> from(KafkaConfigSource configSource) {
+        return create(configSource);
+    }
+
+    /**
      * Creates a new AloKafkaReceiver from the provided {@link KafkaConfigSource}
      *
      * @param configSource The reactive source of Kafka Sender properties
@@ -100,7 +107,7 @@ public class AloKafkaSender<K, V> implements Closeable {
      * @param <V>          The types of values contained in sent records
      * @return A new AloKafkaSender
      */
-    public static <K, V> AloKafkaSender<K, V> from(KafkaConfigSource configSource) {
+    public static <K, V> AloKafkaSender<K, V> create(KafkaConfigSource configSource) {
         return new AloKafkaSender<>(configSource);
     }
 

--- a/kafka/src/test/java/io/atleon/kafka/AloProcessingTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/AloProcessingTest.java
@@ -22,18 +22,18 @@ public class AloProcessingTest {
 
     @Test
     public void acknowledgedDataIsNotRepublished() {
-        AloKafkaSender.from(KAFKA_CONFIG_SOURCE)
+        AloKafkaSender.create(KAFKA_CONFIG_SOURCE)
             .sendValues(Mono.just("DATA"), topic, Function.identity())
             .then().block();
 
-        AloKafkaReceiver.forValues(KAFKA_CONFIG_SOURCE)
+        AloKafkaReceiver.create(KAFKA_CONFIG_SOURCE)
             .receiveAloValues(Collections.singletonList(topic))
             .as(StepVerifier::create)
             .consumeNextWith(Alo::acknowledge)
             .thenCancel()
             .verify();
 
-        AloKafkaReceiver.forValues(KAFKA_CONFIG_SOURCE)
+        AloKafkaReceiver.create(KAFKA_CONFIG_SOURCE)
             .receiveAloValues(Collections.singletonList(topic))
             .as(StepVerifier::create)
             .expectSubscription()
@@ -44,18 +44,18 @@ public class AloProcessingTest {
 
     @Test
     public void unacknowledgedDataIsRepublished() {
-        AloKafkaSender.from(KAFKA_CONFIG_SOURCE)
+        AloKafkaSender.create(KAFKA_CONFIG_SOURCE)
             .sendValues(Mono.just("DATA"), topic, Function.identity())
             .then().block();
 
-        AloKafkaReceiver.forValues(KAFKA_CONFIG_SOURCE)
+        AloKafkaReceiver.create(KAFKA_CONFIG_SOURCE)
             .receiveAloValues(Collections.singletonList(topic))
             .as(StepVerifier::create)
             .expectNextCount(1)
             .thenCancel()
             .verify();
 
-        AloKafkaReceiver.forValues(KAFKA_CONFIG_SOURCE)
+        AloKafkaReceiver.create(KAFKA_CONFIG_SOURCE)
             .receiveAloValues(Collections.singletonList(topic))
             .as(StepVerifier::create)
             .expectNextCount(1)
@@ -65,11 +65,11 @@ public class AloProcessingTest {
 
     @Test
     public void nacknowledgedDataIsRepublished() {
-        AloKafkaSender.from(KAFKA_CONFIG_SOURCE)
+        AloKafkaSender.create(KAFKA_CONFIG_SOURCE)
             .sendValues(Flux.just("DATA1", "DATA2", "DATA3"), topic, Function.identity())
             .then().block();
 
-        AloKafkaReceiver.forValues(KAFKA_CONFIG_SOURCE)
+        AloKafkaReceiver.create(KAFKA_CONFIG_SOURCE)
             .receiveAloValues(Collections.singletonList(topic))
             .resubscribeOnError(AloProcessingTest.class.getSimpleName(), Duration.ofSeconds(0L))
             .as(StepVerifier::create)

--- a/kafka/src/test/java/io/atleon/kafka/EmbeddedRecordTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/EmbeddedRecordTest.java
@@ -24,11 +24,11 @@ public class EmbeddedRecordTest {
     public void consumedRecordsMatchSent() {
         String value = UUID.randomUUID().toString();
 
-        AloKafkaSender.<String, String>from(KAFKA_CONFIG_SOURCE)
+        AloKafkaSender.<String, String>create(KAFKA_CONFIG_SOURCE)
             .sendValues(Mono.just(value), TOPIC, Function.identity())
             .then().block();
 
-        AloKafkaReceiver.<String>forValues(KAFKA_CONFIG_SOURCE)
+        AloKafkaReceiver.<Object, String>create(KAFKA_CONFIG_SOURCE)
             .receiveAloValues(Collections.singletonList(TOPIC))
             .as(StepVerifier::create)
             .consumeNextWith(aloString -> {

--- a/kafka/src/test/java/io/atleon/kafka/KafkaBoundedReceiverTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/KafkaBoundedReceiverTest.java
@@ -311,7 +311,7 @@ class KafkaBoundedReceiverTest {
         C data,
         Function<T, ProducerRecord<Object, T>> recordCreator
     ) {
-        try (AloKafkaSender<Object, T> sender = AloKafkaSender.from(configSource)) {
+        try (AloKafkaSender<Object, T> sender = AloKafkaSender.create(configSource)) {
             Flux.fromIterable(data)
                 .map(recordCreator)
                 .transform(sender::sendRecords)

--- a/kafka/src/test/java/io/atleon/kafka/KafkaLagThresholdStarterStopperTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/KafkaLagThresholdStarterStopperTest.java
@@ -16,7 +16,7 @@ class KafkaLagThresholdStarterStopperTest {
 
     private static final KafkaConfigSource KAFKA_CONFIG_SOURCE = TestKafkaConfigSourceFactory.createSource(BOOTSTRAP_CONNECT);
 
-    private final AloKafkaSender<String, String> sender = AloKafkaSender.from(KAFKA_CONFIG_SOURCE);
+    private final AloKafkaSender<String, String> sender = AloKafkaSender.create(KAFKA_CONFIG_SOURCE);
 
     private final String topic = KafkaLagThresholdStarterStopperTest.class.getSimpleName() + UUID.randomUUID();
 
@@ -90,7 +90,7 @@ class KafkaLagThresholdStarterStopperTest {
     }
 
     private void consumeMessages(String groupId, int count) {
-        AloKafkaReceiver.<String>forValues(KAFKA_CONFIG_SOURCE.withConsumerGroupId(groupId))
+        AloKafkaReceiver.<Object, String>create(KAFKA_CONFIG_SOURCE.withConsumerGroupId(groupId))
             .receiveAloValues(topic)
             .consumeAloAndGet(Alo::acknowledge)
             .take(count)

--- a/polling/src/main/java/io/atleon/polling/AloPollingReceiver.java
+++ b/polling/src/main/java/io/atleon/polling/AloPollingReceiver.java
@@ -58,8 +58,16 @@ public class AloPollingReceiver<P, O> {
         this.resourcesMono = Mono.just(ReceiveResources.create(AloFactoryConfig.loadDefault(), config.getNackStrategy()));
     }
 
+    /**
+     * Alias for {@link #create(Pollable, PollingSourceConfig)}. Will be deprecated in future release.
+     */
     public static <P, O> AloPollingReceiver<P, O> from(final Pollable<P, O> pollable,
                                                        final PollingSourceConfig config) {
+        return create(pollable, config);
+    }
+
+    public static <P, O> AloPollingReceiver<P, O> create(final Pollable<P, O> pollable,
+                                                         final PollingSourceConfig config) {
         return new AloPollingReceiver<>(pollable, config);
     }
 

--- a/polling/src/test/java/io/atleon/polling/AloPollingReceiverTest.java
+++ b/polling/src/test/java/io/atleon/polling/AloPollingReceiverTest.java
@@ -39,7 +39,7 @@ public class AloPollingReceiverTest {
         messages.add(buildSuccessMessages("Batch - 2", 2));
         messages.add(buildSuccessMessages("Batch - 3", 3));
         pollable = new TestPollable(messages, acks, nacks);
-        AloPollingReceiver<TestMessage, TestMessage> receiver = AloPollingReceiver.from(pollable, config);
+        AloPollingReceiver<TestMessage, TestMessage> receiver = AloPollingReceiver.create(pollable, config);
         receiver.receivePayloads().subscribe();
 
         while (acks.size() < 10) {
@@ -57,7 +57,7 @@ public class AloPollingReceiverTest {
         messages.add(buildSuccessMessages("Batch - 1", 5));
         messages.add(buildFailureMessages("Batch - 2",5, 1));
         pollable = new TestPollable(messages, acks, nacks);
-        AloPollingReceiver<TestMessage, TestMessage> receiver = AloPollingReceiver.from(pollable, config);
+        AloPollingReceiver<TestMessage, TestMessage> receiver = AloPollingReceiver.create(pollable, config);
         receiver.receivePayloads().subscribe(alo -> {
             try {
                 alo.get().getMessage();

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQReceiver.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQReceiver.java
@@ -96,13 +96,20 @@ public class AloRabbitMQReceiver<T> {
     }
 
     /**
+     * Alias for {@link #create(RabbitMQConfigSource)}. Will be deprecated in future release.
+     */
+    public static <T> AloRabbitMQReceiver<T> from(RabbitMQConfigSource configSource) {
+        return create(configSource);
+    }
+
+    /**
      * Creates a new AloRabbitMQReceiver from the provided {@link RabbitMQConfigSource}
      *
      * @param configSource The reactive source of {@link RabbitMQConfig}
      * @param <T>          The types of deserialized message bodies contained in received messages
      * @return A new AloRabbitMQReceiver
      */
-    public static <T> AloRabbitMQReceiver<T> from(RabbitMQConfigSource configSource) {
+    public static <T> AloRabbitMQReceiver<T> create(RabbitMQConfigSource configSource) {
         return new AloRabbitMQReceiver<>(configSource);
     }
 

--- a/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQSender.java
+++ b/rabbitmq/src/main/java/io/atleon/rabbitmq/AloRabbitMQSender.java
@@ -56,13 +56,20 @@ public class AloRabbitMQSender<T> implements Closeable {
     }
 
     /**
+     * Alias for {@link #create(RabbitMQConfigSource)}. Will be deprecated in future release.
+     */
+    public static <T> AloRabbitMQSender<T> from(RabbitMQConfigSource configSource) {
+        return create(configSource);
+    }
+
+    /**
      * Creates a new AloRabbitMQSender from the provided {@link RabbitMQConfigSource}
      *
      * @param configSource The reactive source of {@link RabbitMQConfig}
      * @param <T>          The type of messages bodies sent by this sender
      * @return A new AloRabbitMQSender
      */
-    public static <T> AloRabbitMQSender<T> from(RabbitMQConfigSource configSource) {
+    public static <T> AloRabbitMQSender<T> create(RabbitMQConfigSource configSource) {
         return new AloRabbitMQSender<>(configSource);
     }
 

--- a/rabbitmq/src/test/java/io/atleon/rabbitmq/AloProcessingTest.java
+++ b/rabbitmq/src/test/java/io/atleon/rabbitmq/AloProcessingTest.java
@@ -33,18 +33,18 @@ public class AloProcessingTest {
 
     @Test
     public void acknowledgedDataIsNotRepublished() {
-        AloRabbitMQSender.from(RABBIT_MQ_CONFIG_SOURCE)
+        AloRabbitMQSender.create(RABBIT_MQ_CONFIG_SOURCE)
             .sendBodies(Mono.just("DATA"), DefaultRabbitMQMessageCreator.minimalBasicToDefaultExchange(queue))
             .then().block();
 
-        AloRabbitMQReceiver.from(RABBIT_MQ_CONFIG_SOURCE)
+        AloRabbitMQReceiver.create(RABBIT_MQ_CONFIG_SOURCE)
             .receiveAloBodies(queue)
             .as(StepVerifier::create)
             .consumeNextWith(Alo::acknowledge)
             .thenCancel()
             .verify();
 
-        AloRabbitMQReceiver.from(RABBIT_MQ_CONFIG_SOURCE)
+        AloRabbitMQReceiver.create(RABBIT_MQ_CONFIG_SOURCE)
             .receiveAloBodies(queue)
             .as(StepVerifier::create)
             .expectSubscription()
@@ -55,18 +55,18 @@ public class AloProcessingTest {
 
     @Test
     public void unacknowledgedDataIsRepublished() {
-        AloRabbitMQSender.from(RABBIT_MQ_CONFIG_SOURCE)
+        AloRabbitMQSender.create(RABBIT_MQ_CONFIG_SOURCE)
             .sendBodies(Mono.just("DATA"), DefaultRabbitMQMessageCreator.minimalBasicToDefaultExchange(queue))
             .then().block();
 
-        AloRabbitMQReceiver.from(RABBIT_MQ_CONFIG_SOURCE)
+        AloRabbitMQReceiver.create(RABBIT_MQ_CONFIG_SOURCE)
             .receiveAloBodies(queue)
             .as(StepVerifier::create)
             .expectNextCount(1)
             .thenCancel()
             .verify();
 
-        AloRabbitMQReceiver.from(RABBIT_MQ_CONFIG_SOURCE)
+        AloRabbitMQReceiver.create(RABBIT_MQ_CONFIG_SOURCE)
             .receiveAloBodies(queue)
             .as(StepVerifier::create)
             .expectNextCount(1)
@@ -76,11 +76,11 @@ public class AloProcessingTest {
 
     @Test
     public void nacknowledgedDataIsRepublished() {
-        AloRabbitMQSender.from(RABBIT_MQ_CONFIG_SOURCE)
+        AloRabbitMQSender.create(RABBIT_MQ_CONFIG_SOURCE)
             .sendBodies(Flux.just("DATA1", "DATA2", "DATA3"), DefaultRabbitMQMessageCreator.minimalBasicToDefaultExchange(queue))
             .then().block();
 
-        AloRabbitMQReceiver.from(RABBIT_MQ_CONFIG_SOURCE)
+        AloRabbitMQReceiver.create(RABBIT_MQ_CONFIG_SOURCE)
             .receiveAloBodies(queue)
             .resubscribeOnError(AloProcessingTest.class.getSimpleName(), Duration.ofSeconds(0L))
             .as(StepVerifier::create)

--- a/rabbitmq/src/test/java/io/atleon/rabbitmq/EmbeddedMessageTest.java
+++ b/rabbitmq/src/test/java/io/atleon/rabbitmq/EmbeddedMessageTest.java
@@ -35,11 +35,11 @@ class EmbeddedMessageTest {
     public void consumedMessagesMatchSent() {
         String body = UUID.randomUUID().toString();
 
-        AloRabbitMQSender.<String>from(RABBIT_MQ_CONFIG_SOURCE)
+        AloRabbitMQSender.<String>create(RABBIT_MQ_CONFIG_SOURCE)
             .sendBodies(Mono.just(body), DefaultRabbitMQMessageCreator.minimalBasicToDefaultExchange(queue))
             .then().block();
 
-        AloRabbitMQReceiver.<String>from(RABBIT_MQ_CONFIG_SOURCE)
+        AloRabbitMQReceiver.<String>create(RABBIT_MQ_CONFIG_SOURCE)
             .receiveAloBodies(queue)
             .as(StepVerifier::create)
             .consumeNextWith(aloString -> {


### PR DESCRIPTION
### :pencil: Description
- Add `create` methods and alias `from` methods to it
- Add Javadoc for `AloSqsSender` and `AloSnsSender`

### :link: Related Issues
#305 