### PR TITLE
[#345] Enable `KafkaBoundedReceiver` to consume `Alo` records based on configured consumer group

### DIFF
--- a/core/src/main/java/io/atleon/core/ErrorEmitter.java
+++ b/core/src/main/java/io/atleon/core/ErrorEmitter.java
@@ -40,6 +40,14 @@ public final class ErrorEmitter<T> {
         return Flux.from(publisher).mergeWith(sink.asMono());
     }
 
+    public void safelyComplete() {
+        try {
+            sink.emitEmpty(Sinks.EmitFailureHandler.busyLooping(timeout));
+        } catch (Sinks.EmissionException emissionException) {
+            LOGGER.info("Failed to emit completion due to reason={}", emissionException.getReason());
+        }
+    }
+
     public void safelyEmit(Throwable error) {
         try {
             sink.emitError(error, Sinks.EmitFailureHandler.busyLooping(timeout));

--- a/kafka/src/main/java/io/atleon/kafka/AloKafkaBoundedReceiver.java
+++ b/kafka/src/main/java/io/atleon/kafka/AloKafkaBoundedReceiver.java
@@ -1,0 +1,129 @@
+package io.atleon.kafka;
+
+import io.atleon.core.Alo;
+import io.atleon.core.AloFlux;
+import io.atleon.core.ComposedAlo;
+import io.atleon.core.ErrorEmitter;
+import io.atleon.util.Consuming;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import reactor.core.publisher.Flux;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Receiver of Kafka Records where the number of Records consumed is finite, and based on the
+ * configured consumer group. This provides at-least-once semantics for discretely consuming
+ * records and statefully tracking progress using the provided consumer group ID. Typical use cases
+ * include:
+ * - Periodically triggering "at-least-once" consumption of data
+ * - Consuming data that has not yet been consumed by a group
+ * <p>
+ * Offsets are committed after the consumption of each range of records from a Topic-Partition has
+ * been fully acknowledged. Each range must be fully acknowledged before the next range is
+ * received.
+ *
+ * @param <K> inbound record key type
+ * @param <V> inbound record value type
+ */
+public class AloKafkaBoundedReceiver<K, V> {
+
+    private final KafkaConfigSource configSource;
+
+    private AloKafkaBoundedReceiver(KafkaConfigSource configSource) {
+        this.configSource = configSource;
+    }
+
+    public static <K, V> AloKafkaBoundedReceiver<K, V> create(KafkaConfigSource configSource) {
+        return new AloKafkaBoundedReceiver<>(configSource);
+    }
+
+    /**
+     * Creates a finite {@link AloFlux} of Kafka {@link ConsumerRecord}s and commits offsets for
+     * the configured consumer group after finite consumption of each {@link TopicPartition} has
+     * been fully acknowledged.
+     *
+     * @param topic        The topic to subscribe to
+     * @param maxInclusive Where consumption should stop
+     * @return An {@link AloFlux} of Kafka ConsumerRecords
+     */
+    public AloFlux<ConsumerRecord<K, V>> receiveAloRecordsUpTo(String topic, OffsetCriteria maxInclusive) {
+        return receiveAloRecordsUpTo(Collections.singletonList(topic), maxInclusive);
+    }
+
+    /**
+     * Creates a finite {@link AloFlux} of Kafka {@link ConsumerRecord}s and commits offsets for
+     * the configured consumer group after finite consumption of each {@link TopicPartition} has
+     * been fully acknowledged.
+     *
+     * @param topics       The topics to subscribe to
+     * @param maxInclusive Where consumption should stop
+     * @return An {@link AloFlux} of Kafka ConsumerRecords
+     */
+    public AloFlux<ConsumerRecord<K, V>> receiveAloRecordsUpTo(Collection<String> topics, OffsetCriteria maxInclusive) {
+        return configSource.create()
+            .flatMapMany(it -> receiveAloRecordsUpTo(it, topics, maxInclusive))
+            .as(AloFlux::wrap);
+    }
+
+    private Flux<Alo<ConsumerRecord<K, V>>> receiveAloRecordsUpTo(
+        KafkaConfig config,
+        Collection<String> topics,
+        OffsetCriteria maxInclusive
+    ) {
+        return Flux.using(
+            () -> ReactiveAdmin.create(config.nativeProperties()),
+            it -> receiveAndCommitRecordsInRange(it, config, topics, maxInclusive),
+            ReactiveAdmin::close);
+    }
+
+    private Flux<Alo<ConsumerRecord<K, V>>> receiveAndCommitRecordsInRange(
+        ReactiveAdmin admin,
+        KafkaConfig config,
+        Collection<String> topics,
+        OffsetCriteria maxInclusive
+    ) {
+        String groupId = config.loadString(ConsumerConfig.GROUP_ID_CONFIG)
+            .orElseThrow(() -> new IllegalArgumentException("Must provide Consumer Group ID"));
+        OffsetResetStrategy resetStrategy = config.loadString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)
+            .map(it -> OffsetResetStrategy.valueOf(it.toUpperCase(Locale.ROOT)))
+            .orElse(OffsetResetStrategy.NONE);
+        return admin.listTopicPartitions(topics)
+            .collectList()
+            .flatMapMany(it -> admin.listTopicPartitionGroupOffsets(groupId, resetStrategy, it))
+            .collectMap(TopicPartitionGroupOffsets::topicPartition, it -> toOffsetRange(it.groupOffset(), maxInclusive))
+            .flatMapMany(it -> RecordRange.list(admin, it))
+            .filter(RecordRange::hasNonNegativeLength)
+            .sort(Comparator.comparing(RecordRange::topicPartition, topicPartitionComparator()))
+            .concatMap(it -> receiveAndCommitRecordsInRange(admin, groupId, it));
+    }
+
+    private AloFlux<ConsumerRecord<K, V>> receiveAndCommitRecordsInRange(
+        ReactiveAdmin admin,
+        String groupId,
+        RecordRange recordRange
+    ) {
+        Map<TopicPartition, Long> offsets =
+            Collections.singletonMap(recordRange.topicPartition(), recordRange.maxInclusive() + 1);
+        ErrorEmitter<Alo<ConsumerRecord<K, V>>> errorEmitter = ErrorEmitter.create();
+        Runnable acknowledger = () -> admin.alterRawConsumerGroupOffsets(groupId, offsets)
+            .subscribe(Consuming.noOp(), errorEmitter::safelyEmit, errorEmitter::safelyComplete);
+        return AloFlux.just(new ComposedAlo<>(recordRange, acknowledger, errorEmitter::safelyEmit))
+            .concatMap(KafkaBoundedReceiver.<K, V>create(configSource)::receiveRecordsInRange)
+            .transform(errorEmitter::applyTo);
+    }
+
+    private static OffsetRange toOffsetRange(long rawMinInclusive, OffsetCriteria maxInclusive) {
+        return OffsetCriteria.raw(rawMinInclusive).to(maxInclusive);
+    }
+
+    private static Comparator<TopicPartition> topicPartitionComparator() {
+        return Comparator.comparing(TopicPartition::topic).thenComparing(TopicPartition::partition);
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/KafkaBoundedReceiver.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaBoundedReceiver.java
@@ -1,24 +1,15 @@
 package io.atleon.kafka;
 
-import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.kafka.receiver.KafkaReceiver;
 import reactor.kafka.receiver.ReceiverOptions;
 
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Receiver of Kafka Records where the number of Records consumed is finite as indicated by
@@ -105,80 +96,13 @@ public class KafkaBoundedReceiver<K, V> {
      * @return A bounded {@link Flux} of {@link ConsumerRecord}
      */
     public Flux<ConsumerRecord<K, V>> receiveRecords(Collection<String> topics, OffsetRangeProvider rangeProvider) {
-        return configSource.create().flatMapMany(it -> receiveRecords(it, topics, rangeProvider));
-    }
-
-    private Flux<ConsumerRecord<K, V>> receiveRecords(
-        KafkaConfig config,
-        Collection<String> topics,
-        OffsetRangeProvider rangeProvider
-    ) {
-        Flux<RecordRange> recordRanges = Flux.using(
-            () -> ReactiveAdmin.create(config.nativeProperties()),
-            it -> listRecordRanges(it, topics, rangeProvider),
-            ReactiveAdmin::close
-        );
-        return recordRanges
+        return configSource.create()
+            .flatMapMany(it -> listRecordRanges(it, topics, rangeProvider))
             .filter(RecordRange::hasNonNegativeLength)
             .concatMap(this::receiveRecordsInRange);
     }
 
-    private Flux<RecordRange> listRecordRanges(
-        ReactiveAdmin admin,
-        Collection<String> topics,
-        OffsetRangeProvider rangeProvider
-    ) {
-        return admin.listTopicPartitions(topics)
-            .collectMap(Function.identity(), rangeProvider::forTopicPartition)
-            .map(it -> sortPresent(it, rangeProvider.topicPartitionComparator()))
-            .flatMapMany(it -> listRecordRanges(admin, it));
-    }
-
-    private Flux<RecordRange> listRecordRanges(ReactiveAdmin admin, SortedMap<TopicPartition, OffsetRange> ranges) {
-        Map<TopicPartition, OffsetCriteria> minCriteria = ranges.entrySet().stream().collect(
-            Collectors.toMap(Map.Entry::getKey, it -> it.getValue().minInclusive()));
-        Map<TopicPartition, OffsetCriteria> maxCriteria = ranges.entrySet().stream().collect(
-            Collectors.toMap(Map.Entry::getKey, it -> it.getValue().maxInclusive()));
-
-        return Mono.zip(
-            calculateRawOffsets(admin, minCriteria, Extrema.MIN),
-            calculateRawOffsets(admin, maxCriteria, Extrema.MAX),
-            admin.listOffsets(minCriteria.keySet(), OffsetSpec.earliest()),
-            admin.listOffsets(maxCriteria.keySet(), OffsetSpec.latest())
-        ).flatMapIterable(it -> createRecordRanges(ranges.keySet(), it.getT1(), it.getT2(), it.getT3(), it.getT4()));
-    }
-
-    private Mono<Map<TopicPartition, Long>> calculateRawOffsets(
-        ReactiveAdmin admin,
-        Map<TopicPartition, OffsetCriteria> criteria,
-        Extrema extrema
-    ) {
-        Map<Class<? extends OffsetCriteria>, Map<TopicPartition, OffsetCriteria>> typedCriteria =
-            criteria.entrySet().stream().collect(Collectors.groupingBy(it -> it.getValue().getClass(),
-                Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-
-        Map<TopicPartition, Long> rawOffsets =
-            typedCriteria.getOrDefault(OffsetCriteria.Raw.class, Collections.emptyMap()).entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, it -> toRawOffset(it.getValue(), extrema)));
-        Map<TopicPartition, OffsetSpec> timestampSpecs =
-            typedCriteria.getOrDefault(OffsetCriteria.Timestamp.class, Collections.emptyMap()).entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, it -> toTimestampSpec(it.getValue(), extrema)));
-        Map<TopicPartition, OffsetSpec> earliestSpecs =
-            typedCriteria.getOrDefault(OffsetCriteria.Earliest.class, Collections.emptyMap()).entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, __ -> OffsetSpec.earliest()));
-        Map<TopicPartition, OffsetSpec> latestSpecs =
-            typedCriteria.getOrDefault(OffsetCriteria.Latest.class, Collections.emptyMap()).entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, __ -> OffsetSpec.latest()));
-
-        return Mono.just(rawOffsets)
-            .mergeWith(admin.listOffsets(timestampSpecs, offset -> offset == -1 ? Long.MAX_VALUE : offset))
-            .mergeWith(admin.listOffsets(earliestSpecs, offset -> offset + (extrema == Extrema.MAX ? 1 : 0)))
-            .mergeWith(admin.listOffsets(latestSpecs, offset -> offset - (extrema == Extrema.MIN ? 1 : 0)))
-            .flatMapIterable(Map::entrySet)
-            .collectMap(Map.Entry::getKey, Map.Entry::getValue);
-    }
-
-    private Flux<ConsumerRecord<K, V>> receiveRecordsInRange(RecordRange recordRange) {
+    Flux<ConsumerRecord<K, V>> receiveRecordsInRange(RecordRange recordRange) {
         return configSource.create().flatMapMany(it -> receiveRecordsInRange(it, recordRange));
     }
 
@@ -195,71 +119,14 @@ public class KafkaBoundedReceiver<K, V> {
             .takeUntil(it -> it.offset() == recordRange.maxInclusive());
     }
 
-    private static List<RecordRange> createRecordRanges(
-        Collection<TopicPartition> topicPartitions,
-        Map<TopicPartition, Long> minOffsets,
-        Map<TopicPartition, Long> maxOffsets,
-        Map<TopicPartition, Long> earliestOffsets,
-        Map<TopicPartition, Long> latestOffsets
+    private static Flux<RecordRange> listRecordRanges(
+        KafkaConfig config,
+        Collection<String> topics,
+        OffsetRangeProvider rangeProvider
     ) {
-        return topicPartitions.stream()
-            .map(topicPartition -> new RecordRange(
-                topicPartition,
-                Math.max(earliestOffsets.get(topicPartition), minOffsets.get(topicPartition)),
-                Math.min(latestOffsets.get(topicPartition), maxOffsets.get(topicPartition)) - 1))
-            .collect(Collectors.toList());
-    }
-
-    private static <K, V> SortedMap<K, V> sortPresent(Map<K, Optional<V>> map, Comparator<? super K> comparator) {
-        return map.entrySet().stream()
-            .filter(it -> it.getValue().isPresent())
-            .collect(Collectors.toMap(
-                Map.Entry::getKey,
-                it -> it.getValue().get(),
-                (l, r) -> l, // Won't be called, since we know the keys are unique
-                () -> new TreeMap<>(comparator))
-            );
-    }
-
-    private static long toRawOffset(OffsetCriteria endpoint, Extrema extrema) {
-        return OffsetCriteria.Raw.class.cast(endpoint).offset() + (extrema == Extrema.MAX ? 1 : 0);
-    }
-
-    private static OffsetSpec toTimestampSpec(OffsetCriteria offsetCriteria, Extrema extrema) {
-        OffsetCriteria.Timestamp timestampEndpoint = OffsetCriteria.Timestamp.class.cast(offsetCriteria);
-        return OffsetSpec.forTimestamp(timestampEndpoint.epochMillis() + (extrema == Extrema.MAX ? 1 : 0));
-    }
-
-    private enum Extrema {MIN, MAX}
-
-    private static final class RecordRange {
-
-        private final TopicPartition topicPartition;
-
-        private final long minInclusive;
-
-        private final long maxInclusive;
-
-        public RecordRange(TopicPartition topicPartition, long minInclusive, long maxExclusive) {
-            this.topicPartition = topicPartition;
-            this.minInclusive = minInclusive;
-            this.maxInclusive = maxExclusive;
-        }
-
-        public TopicPartition topicPartition() {
-            return topicPartition;
-        }
-
-        public boolean hasNonNegativeLength() {
-            return maxInclusive - minInclusive >= 0;
-        }
-
-        public long minInclusive() {
-            return minInclusive;
-        }
-
-        public long maxInclusive() {
-            return maxInclusive;
-        }
+        return Flux.using(
+            () -> ReactiveAdmin.create(config.nativeProperties()),
+            it -> RecordRange.list(it, topics, rangeProvider),
+            ReactiveAdmin::close);
     }
 }

--- a/kafka/src/main/java/io/atleon/kafka/OffsetRangeProvider.java
+++ b/kafka/src/main/java/io/atleon/kafka/OffsetRangeProvider.java
@@ -36,7 +36,14 @@ public interface OffsetRangeProvider {
      * Consume Records from a single TopicPartition within the provided OffsetRange
      */
     static OffsetRangeProvider inOffsetRangeFromTopicPartition(TopicPartition topicPartition, OffsetRange offsetRange) {
-        return it -> topicPartition.equals(it) ? Optional.of(offsetRange) : Optional.empty();
+        return inOffsetRangesFromTopicPartitions(Collections.singletonMap(topicPartition, offsetRange));
+    }
+
+    /**
+     * Consume Records from TopicPartitions within mapped OffsetRanges
+     */
+    static OffsetRangeProvider inOffsetRangesFromTopicPartitions(Map<TopicPartition, OffsetRange> offsetRanges) {
+        return it -> Optional.ofNullable(offsetRanges.get(it));
     }
 
     /**

--- a/kafka/src/main/java/io/atleon/kafka/ReactiveAdmin.java
+++ b/kafka/src/main/java/io/atleon/kafka/ReactiveAdmin.java
@@ -6,6 +6,7 @@ import org.apache.kafka.clients.admin.ListOffsetsOptions;
 import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
@@ -14,10 +15,12 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
 
 import java.io.Closeable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.LongUnaryOperator;
@@ -40,6 +43,20 @@ public class ReactiveAdmin implements Closeable {
 
     public static ReactiveAdmin create(Map<String, Object> config) {
         return new ReactiveAdmin(Admin.create(config));
+    }
+
+    /**
+     * Alters offsets for the specified group. In order to succeed, the group must be empty, i.e.
+     * not actively consuming.
+     *
+     * @param groupId The group for which to alter offsets.
+     * @param offsets A map of raw offsets by partition
+     * @return A {@link Mono} that signals success or error of offset alteration
+     */
+    public Mono<Void> alterRawConsumerGroupOffsets(String groupId, Map<TopicPartition, Long> offsets) {
+        Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata = offsets.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, it -> new OffsetAndMetadata(it.getValue())));
+        return execute(admin -> admin.alterConsumerGroupOffsets(groupId, offsetsAndMetadata).all());
     }
 
     /**
@@ -75,6 +92,51 @@ public class ReactiveAdmin implements Closeable {
             .collect(Collectors.toMap(Function.identity(), __ -> new ListConsumerGroupOffsetsSpec()));
         return execute(admin -> admin.listConsumerGroupOffsets(offsetSpecs).all())
             .flatMapMany(this::listTopicPartitionGroupOffsets);
+    }
+
+    /**
+     * Describes the current state of committed offsets for the provided {@link TopicPartition}s and
+     * consumer group IDs. There will be one result for each existing {@link TopicPartition} and
+     * group ID. If there is not a committed offset for a given group ID, then the provided
+     * {@link OffsetResetStrategy} will be used to determine where the consumer group <i>would</i>
+     * begin consuming from.
+     *
+     * @param groupId         The consumer group ID to describe offsets for
+     * @param resetStrategy   Where consumption would begin if there are no committed offsets
+     * @param topicPartitions The {@link TopicPartition}s to describe offsets for
+     * @return A {@link Flux} of {@link TopicPartitionGroupOffsets} describing group and partition offsets
+     */
+    public Flux<TopicPartitionGroupOffsets> listTopicPartitionGroupOffsets(
+        String groupId,
+        OffsetResetStrategy resetStrategy,
+        Collection<TopicPartition> topicPartitions
+    ) {
+        return listTopicPartitionGroupOffsets(Collections.singletonMap(groupId, resetStrategy), topicPartitions);
+    }
+
+    /**
+     * Describes the current state of committed offsets for the provided {@link TopicPartition}s and
+     * consumer group IDs. There will be one result for each existing {@link TopicPartition} and
+     * group ID. If there is not a committed offset for a given group ID, then the provided
+     * {@link OffsetResetStrategy} will be used to determine where the consumer group <i>would</i>
+     * begin consuming from.
+     *
+     * @param groupIds        Group IDs to describe offsets for and where consumption would begin if none exist
+     * @param topicPartitions The {@link TopicPartition}s to describe offsets for
+     * @return A {@link Flux} of {@link TopicPartitionGroupOffsets} describing group and partition offsets
+     */
+    public Flux<TopicPartitionGroupOffsets> listTopicPartitionGroupOffsets(
+        Map<String, OffsetResetStrategy> groupIds,
+        Collection<TopicPartition> topicPartitions
+    ) {
+        ListConsumerGroupOffsetsSpec offsetsSpec = new ListConsumerGroupOffsetsSpec().topicPartitions(topicPartitions);
+        Map<String, ListConsumerGroupOffsetsSpec> offsetSpecs = groupIds.keySet().stream()
+            .collect(Collectors.toMap(Function.identity(), __ -> offsetsSpec));
+        return Mono.zip(
+            execute(admin -> admin.listConsumerGroupOffsets(offsetSpecs).all()),
+            listOffsets(topicPartitions, OffsetSpec.earliest()),
+            listOffsets(topicPartitions, OffsetSpec.latest())
+        ).flatMapIterable(it -> createTopicPartitionGroupOffsets(groupIds, it.getT1(), it.getT2(), it.getT3()));
     }
 
     /**
@@ -161,6 +223,12 @@ public class ReactiveAdmin implements Closeable {
         return Mono.create(sink -> method.apply(admin).whenComplete(new SinkKafkaBiConsumer<>(sink)));
     }
 
+    private static List<TopicPartition> extractTopicPartitions(TopicDescription topicDescription) {
+        return topicDescription.partitions().stream()
+            .map(it -> new TopicPartition(topicDescription.name(), it.partition()))
+            .collect(Collectors.toList());
+    }
+
     private static List<TopicPartitionGroupOffsets> createTopicPartitionGroupOffsets(
         Map<String, Map<TopicPartition, OffsetAndMetadata>> offsetsByGroup,
         Map<TopicPartition, Long> latestOffsets
@@ -182,10 +250,44 @@ public class ReactiveAdmin implements Closeable {
             .collect(Collectors.toList());
     }
 
-    private static List<TopicPartition> extractTopicPartitions(TopicDescription topicDescription) {
-        return topicDescription.partitions().stream()
-            .map(it -> new TopicPartition(topicDescription.name(), it.partition()))
-            .collect(Collectors.toList());
+    private static List<TopicPartitionGroupOffsets> createTopicPartitionGroupOffsets(
+        Map<String, OffsetResetStrategy> groupIds,
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> offsetsByGroup,
+        Map<TopicPartition, Long> earliestOffsets,
+        Map<TopicPartition, Long> latestOffsets
+    ) {
+        List<TopicPartitionGroupOffsets> result = new ArrayList<>();
+        for (String groupId : groupIds.keySet()) {
+            OffsetResetStrategy resetStrategy = groupIds.get(groupId);
+            Map<TopicPartition, OffsetAndMetadata> offsets = offsetsByGroup.getOrDefault(groupId, Collections.emptyMap());
+            for (TopicPartition topicPartition : latestOffsets.keySet()) {
+                long earliestOffset = earliestOffsets.get(topicPartition);
+                long latestOffset = latestOffsets.get(topicPartition);
+                calculateGroupOffset(topicPartition, offsets, resetStrategy, earliestOffset, latestOffset)
+                    .map(it -> new TopicPartitionGroupOffsets(topicPartition, latestOffset, groupId, it))
+                    .ifPresent(result::add);
+            }
+        }
+        return result;
+    }
+
+    private static Optional<Long> calculateGroupOffset(
+        TopicPartition topicPartition,
+        Map<TopicPartition, OffsetAndMetadata> committedOffsets,
+        OffsetResetStrategy resetStrategy,
+        long earliestOffset,
+        long latestOffset
+    ) {
+        OffsetAndMetadata committedOffsetAndMetadata = committedOffsets.get(topicPartition);
+        if (committedOffsetAndMetadata != null) {
+            return Optional.of(committedOffsetAndMetadata.offset());
+        } else if (resetStrategy == OffsetResetStrategy.EARLIEST) {
+            return Optional.of(earliestOffset);
+        } else if (resetStrategy == OffsetResetStrategy.LATEST) {
+            return Optional.of(latestOffset);
+        } else {
+            return Optional.empty();
+        }
     }
 
     private static final class SinkKafkaBiConsumer<T> implements KafkaFuture.BiConsumer<T, Throwable> {

--- a/kafka/src/main/java/io/atleon/kafka/RecordRange.java
+++ b/kafka/src/main/java/io/atleon/kafka/RecordRange.java
@@ -1,0 +1,136 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.common.TopicPartition;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+final class RecordRange {
+
+    private final TopicPartition topicPartition;
+
+    private final long minInclusive;
+
+    private final long maxInclusive;
+
+    public RecordRange(TopicPartition topicPartition, long minInclusive, long maxExclusive) {
+        this.topicPartition = topicPartition;
+        this.minInclusive = minInclusive;
+        this.maxInclusive = maxExclusive;
+    }
+
+    public static Flux<RecordRange> list(ReactiveAdmin admin, Collection<String> topics, OffsetRangeProvider rangeProvider) {
+        return admin.listTopicPartitions(topics)
+            .collectMap(Function.identity(), rangeProvider::forTopicPartition)
+            .map(it -> sortPresent(it, rangeProvider.topicPartitionComparator()))
+            .flatMapMany(it -> list(admin, it));
+    }
+
+    public static Flux<RecordRange> list(ReactiveAdmin admin, Map<TopicPartition, OffsetRange> ranges) {
+        Map<TopicPartition, OffsetCriteria> minCriteria = ranges.entrySet().stream().collect(
+            Collectors.toMap(Map.Entry::getKey, it -> it.getValue().minInclusive()));
+        Map<TopicPartition, OffsetCriteria> maxCriteria = ranges.entrySet().stream().collect(
+            Collectors.toMap(Map.Entry::getKey, it -> it.getValue().maxInclusive()));
+
+        return Mono.zip(
+                calculateRawOffsets(admin, minCriteria, Extrema.MIN),
+                calculateRawOffsets(admin, maxCriteria, Extrema.MAX),
+                admin.listOffsets(minCriteria.keySet(), OffsetSpec.earliest()),
+                admin.listOffsets(maxCriteria.keySet(), OffsetSpec.latest()))
+            .flatMapIterable(it -> createRecordRanges(ranges.keySet(), it.getT1(), it.getT2(), it.getT3(), it.getT4()));
+    }
+
+    public TopicPartition topicPartition() {
+        return topicPartition;
+    }
+
+    public boolean hasNonNegativeLength() {
+        return maxInclusive - minInclusive >= 0;
+    }
+
+    public long minInclusive() {
+        return minInclusive;
+    }
+
+    public long maxInclusive() {
+        return maxInclusive;
+    }
+
+    private static Mono<Map<TopicPartition, Long>> calculateRawOffsets(
+        ReactiveAdmin admin,
+        Map<TopicPartition, OffsetCriteria> criteria,
+        Extrema extrema
+    ) {
+        Map<Class<? extends OffsetCriteria>, Map<TopicPartition, OffsetCriteria>> typedCriteria =
+            criteria.entrySet().stream().collect(Collectors.groupingBy(it -> it.getValue().getClass(),
+                Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+
+        Map<TopicPartition, Long> rawOffsets =
+            typedCriteria.getOrDefault(OffsetCriteria.Raw.class, Collections.emptyMap()).entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, it -> toRawOffset(it.getValue(), extrema)));
+        Map<TopicPartition, OffsetSpec> timestampSpecs =
+            typedCriteria.getOrDefault(OffsetCriteria.Timestamp.class, Collections.emptyMap()).entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, it -> toTimestampSpec(it.getValue(), extrema)));
+        Map<TopicPartition, OffsetSpec> earliestSpecs =
+            typedCriteria.getOrDefault(OffsetCriteria.Earliest.class, Collections.emptyMap()).entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, __ -> OffsetSpec.earliest()));
+        Map<TopicPartition, OffsetSpec> latestSpecs =
+            typedCriteria.getOrDefault(OffsetCriteria.Latest.class, Collections.emptyMap()).entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, __ -> OffsetSpec.latest()));
+
+        return Mono.just(rawOffsets)
+            .mergeWith(admin.listOffsets(timestampSpecs, offset -> offset == -1 ? Long.MAX_VALUE : offset))
+            .mergeWith(admin.listOffsets(earliestSpecs, offset -> offset + (extrema == Extrema.MAX ? 1 : 0)))
+            .mergeWith(admin.listOffsets(latestSpecs, offset -> offset - (extrema == Extrema.MIN ? 1 : 0)))
+            .flatMapIterable(Map::entrySet)
+            .collectMap(Map.Entry::getKey, Map.Entry::getValue);
+    }
+
+    private static List<RecordRange> createRecordRanges(
+        Collection<TopicPartition> topicPartitions,
+        Map<TopicPartition, Long> minOffsets,
+        Map<TopicPartition, Long> maxOffsets,
+        Map<TopicPartition, Long> earliestOffsets,
+        Map<TopicPartition, Long> latestOffsets
+    ) {
+        return topicPartitions.stream()
+            .filter(it -> minOffsets.containsKey(it) && maxOffsets.containsKey(it))
+            .map(topicPartition -> new RecordRange(
+                topicPartition,
+                Math.max(earliestOffsets.get(topicPartition), minOffsets.get(topicPartition)),
+                Math.min(latestOffsets.get(topicPartition), maxOffsets.get(topicPartition)) - 1))
+            .collect(Collectors.toList());
+    }
+
+    private static long toRawOffset(OffsetCriteria endpoint, Extrema extrema) {
+        return OffsetCriteria.Raw.class.cast(endpoint).offset() + (extrema == Extrema.MAX ? 1 : 0);
+    }
+
+    private static OffsetSpec toTimestampSpec(OffsetCriteria offsetCriteria, Extrema extrema) {
+        OffsetCriteria.Timestamp timestampEndpoint = OffsetCriteria.Timestamp.class.cast(offsetCriteria);
+        return OffsetSpec.forTimestamp(timestampEndpoint.epochMillis() + (extrema == Extrema.MAX ? 1 : 0));
+    }
+
+    private static <K, V> SortedMap<K, V> sortPresent(Map<K, Optional<V>> map, Comparator<? super K> comparator) {
+        return map.entrySet().stream()
+            .filter(it -> it.getValue().isPresent())
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                it -> it.getValue().get(),
+                (l, r) -> l, // Won't be called, since we know the keys are unique
+                () -> new TreeMap<>(comparator)));
+    }
+
+    private enum Extrema {MIN, MAX}
+}

--- a/kafka/src/main/java/io/atleon/kafka/TopicPartitionGroupOffsets.java
+++ b/kafka/src/main/java/io/atleon/kafka/TopicPartitionGroupOffsets.java
@@ -46,4 +46,8 @@ public final class TopicPartitionGroupOffsets {
     public String groupId() {
         return groupId;
     }
+
+    public long groupOffset() {
+        return groupOffset;
+    }
 }

--- a/kafka/src/test/java/io/atleon/kafka/AloKafkaBoundedReceiverTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/AloKafkaBoundedReceiverTest.java
@@ -1,0 +1,122 @@
+package io.atleon.kafka;
+
+import io.atleon.core.Alo;
+import io.atleon.kafka.embedded.EmbeddedKafka;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AloKafkaBoundedReceiverTest {
+
+    private static final String BOOTSTRAP_CONNECT = EmbeddedKafka.startAndGetBootstrapServersConnect(10092);
+
+    @Test
+    public void recordsCanBeConsumedAndCommittedForAConsumerGroup() {
+        String topic = UUID.randomUUID().toString();
+        List<Long> producedValues1 = produceRecordsFromValues(
+            newProducerConfigs(LongSerializer.class, LongSerializer.class),
+            createRandomLongValues(4, Collectors.toList()),
+            value -> new ProducerRecord<>(topic, 0, value, value)
+        );
+
+        assertTrue(receiveAloValuesAsLongs(topic, OffsetResetStrategy.NONE, OffsetCriteria.latest()).isEmpty());
+        assertTrue(receiveAloValuesAsLongs(topic, OffsetResetStrategy.LATEST, OffsetCriteria.latest()).isEmpty());
+        assertEquals(producedValues1, receiveAloValuesAsLongs(topic, OffsetResetStrategy.EARLIEST, OffsetCriteria.latest()));
+        assertTrue(receiveAloValuesAsLongs(topic, OffsetResetStrategy.EARLIEST, OffsetCriteria.latest()).isEmpty());
+
+        List<Long> producedValues2 = produceRecordsFromValues(
+            newProducerConfigs(LongSerializer.class, LongSerializer.class),
+            createRandomLongValues(1, Collectors.toList()),
+            value -> new ProducerRecord<>(topic, 0, value, value)
+        );
+
+        assertEquals(producedValues2, receiveAloValuesAsLongs(topic, OffsetResetStrategy.EARLIEST, OffsetCriteria.latest()));
+
+        List<Long> producedValues3 = produceRecordsFromValues(
+            newProducerConfigs(LongSerializer.class, LongSerializer.class),
+            createRandomLongValues(1, Collectors.toList()),
+            value -> new ProducerRecord<>(topic, 1, value, value)
+        );
+
+        assertTrue(receiveAloValuesAsLongs(topic, OffsetResetStrategy.NONE, OffsetCriteria.latest()).isEmpty());
+        assertEquals(producedValues3, receiveAloValuesAsLongs(topic, OffsetResetStrategy.EARLIEST, OffsetCriteria.latest()));
+    }
+
+    private List<Long> receiveAloValuesAsLongs(String topic, OffsetResetStrategy resetStrategy, OffsetCriteria maxInclusive) {
+        return newConsumerConfigSource(ByteArrayDeserializer.class, LongDeserializer.class)
+            .with(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, resetStrategy.toString())
+            .as(AloKafkaBoundedReceiver::<Object, Long>create)
+            .receiveAloRecordsUpTo(topic, maxInclusive)
+            .consumeAloAndGet(Alo::acknowledge)
+            .map(ConsumerRecord::value)
+            .collectList()
+            .block();
+    }
+
+    private KafkaConfigSource newProducerConfigs(
+        Class<? extends Serializer<?>> keySerializer,
+        Class<? extends Serializer<?>> valueSerializer
+    ) {
+        return newBaseConfigSource()
+            .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializer.getName())
+            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer.getName());
+    }
+
+    private KafkaConfigSource newConsumerConfigSource(
+        Class<? extends Deserializer<?>> keyDeserializer,
+        Class<? extends Deserializer<?>> valueDeserializer
+    ) {
+        return newBaseConfigSource()
+            .with(ConsumerConfig.GROUP_ID_CONFIG, AloKafkaBoundedReceiverTest.class.getSimpleName())
+            .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.getName())
+            .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.getName());
+    }
+
+    private KafkaConfigSource newBaseConfigSource() {
+        return KafkaConfigSource.useClientIdAsName()
+            .withClientId(KafkaBoundedReceiverTest.class.getSimpleName())
+            .withBootstrapServers(BOOTSTRAP_CONNECT);
+    }
+
+    private <T, C extends Collection<T>> C produceRecordsFromValues(
+        KafkaConfigSource configSource,
+        C data,
+        Function<T, ProducerRecord<Object, T>> recordCreator
+    ) {
+        try (AloKafkaSender<Object, T> sender = AloKafkaSender.create(configSource)) {
+            Flux.fromIterable(data)
+                .map(recordCreator)
+                .transform(sender::sendRecords)
+                .then()
+                .block(Duration.ofSeconds(30));
+        }
+        return data;
+    }
+
+    private <T> T createRandomLongValues(int count, Collector<Long, ?, T> collector) {
+        Random random = new Random();
+        return IntStream.range(0, count).mapToObj(unused -> random.nextLong()).collect(collector);
+    }
+}


### PR DESCRIPTION
### :pencil: Description

### :link: Related Issues
#345 