### PR TITLE
[#366] Must return member ID assignment, even if empty

### DIFF
--- a/kafka/src/test/java/io/atleon/kafka/SingleMachinePartitionAssignorTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/SingleMachinePartitionAssignorTest.java
@@ -40,8 +40,9 @@ class SingleMachinePartitionAssignorTest {
 
         Map<String, List<TopicPartition>> result = assignor.assign(partitionCounts, subscriptionsByMemberId);
 
-        assertEquals(1, result.size());
+        assertEquals(2, result.size());
         assertEquals(4, result.get("old-member").size());
+        assertTrue(result.get("young-member").isEmpty());
         IntStream.range(0, numPartitions).forEach(it ->
                 assertTrue(result.get("old-member").contains(new TopicPartition(topic, it))));
     }


### PR DESCRIPTION
### :pencil: Description

Fix bug where empty member ID assignments were missing

### :link: Related Issues

#366 