### PR TITLE
[#372] Monitor total lag across multiple consumer group ids

### DIFF
--- a/kafka/src/main/java/io/atleon/kafka/KafkaLagThresholdStarterStopper.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaLagThresholdStarterStopper.java
@@ -57,7 +57,18 @@ public class KafkaLagThresholdStarterStopper implements StarterStopper {
      * @return A new {@link KafkaLagThresholdStarterStopper}
      */
     public static KafkaLagThresholdStarterStopper create(KafkaConfigSource configSource, String consumerGroupId) {
-        Collection<String> consumerGroupIds = Collections.singletonList(consumerGroupId);
+        return create(configSource, Collections.singleton(consumerGroupId));
+    }
+
+    /**
+     * Create a new {@link KafkaLagThresholdStarterStopper} based on the provided Config Source,
+     * and monitoring the provided consumer group IDs.
+     *
+     * @param configSource The source of configuration used to connect to Kafka
+     * @param consumerGroupIds The IDs of the consumer groups whose combined total lag are monitored
+     * @return A new {@link KafkaLagThresholdStarterStopper}
+     */
+    public static KafkaLagThresholdStarterStopper create(KafkaConfigSource configSource, Collection<String> consumerGroupIds) {
         return new KafkaLagThresholdStarterStopper(configSource, consumerGroupIds, DEFAULT_SAMPLE_INTERVAL, 0, 0);
     }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built the project locally.
* [x] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
Extends KafkaLagThresholdStarterStopper to monitor total lag across multiple consumer groups.

### :link: Related Issues
* https://github.com/atleon/atleon/issues/372