### PR TITLE
[#396] Implement optimized reactive Kafka Sender and Receiver

### DIFF
--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -69,6 +69,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/kafka/src/main/java/io/atleon/kafka/AcknowledgedOffset.java
+++ b/kafka/src/main/java/io/atleon/kafka/AcknowledgedOffset.java
@@ -1,0 +1,55 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Objects;
+
+/**
+ * An offset for a {@link org.apache.kafka.clients.consumer.ConsumerRecord} from a particular
+ * {@link TopicPartition} that has been acknowledged, and contains an {@link OffsetAndMetadata}
+ * which may be committed, and is the offset <i>just after</i> the record for which this
+ * acknowledgement is associated.
+ */
+final class AcknowledgedOffset {
+
+    private final TopicPartition topicPartition;
+
+    private final OffsetAndMetadata nextOffsetAndMetadata;
+
+    public AcknowledgedOffset(TopicPartition topicPartition, OffsetAndMetadata nextOffsetAndMetadata) {
+        this.topicPartition = topicPartition;
+        this.nextOffsetAndMetadata = nextOffsetAndMetadata;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AcknowledgedOffset that = (AcknowledgedOffset) o;
+        return Objects.equals(topicPartition, that.topicPartition)
+            && Objects.equals(nextOffsetAndMetadata, that.nextOffsetAndMetadata);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(topicPartition, nextOffsetAndMetadata);
+    }
+
+    @Override
+    public String toString() {
+        return "AcknowledgedOffset{" +
+            "topicPartition=" + topicPartition +
+            ", nextOffsetAndMetadata=" + nextOffsetAndMetadata +
+            '}';
+    }
+
+    public TopicPartition topicPartition() {
+        return topicPartition;
+    }
+
+    public OffsetAndMetadata nextOffsetAndMetadata() {
+        return nextOffsetAndMetadata;
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
+++ b/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
@@ -1,0 +1,233 @@
+package io.atleon.kafka;
+
+import io.atleon.core.AcknowledgementQueue;
+import io.atleon.core.AcknowledgementQueueMode;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Scheduler;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.ToLongFunction;
+
+/**
+ * A partition that is currently assigned, being actively consumed, and may be associated with
+ * records that are being processed.
+ */
+final class ActivePartition {
+
+    private final TopicPartition topicPartition;
+
+    private final AcknowledgementQueue acknowledgementQueue;
+
+    // This counter doubles as both our publishing state (via polarity: positive == ACTIVE,
+    // negative == TERMINABLE, zero == TERMINATED) and our count of activated in-flight records
+    // (via magnitude: subtract 1 if positive, negate if negative). The extra/initializing count of
+    // 1 is in reserve for deactivation of this partition (self). As such, when this becomes
+    // non-positive, it means this partition has been deactivated. When it becomes zero, it means
+    // termination has been enqueued to subscribers of this partition's sinks.
+    private final AtomicLong activated = new AtomicLong(1);
+
+    private final Queue<Deactivation> deactivationQueue = new ConcurrentLinkedQueue<>();
+
+    private final AtomicInteger deactivationDrainsInProgress = new AtomicInteger();
+
+    private final Sinks.Many<OffsetAndMetadata> nextOffsetsOfAcknowledged = Sinks.unsafe().many().replay().latest();
+
+    private final Sinks.Many<Long> deactivatedRecordCounts = Sinks.unsafe().many().unicast().onBackpressureError();
+
+    public ActivePartition(TopicPartition topicPartition, AcknowledgementQueueMode acknowledgementQueueMode) {
+        this.topicPartition = topicPartition;
+        this.acknowledgementQueue = AcknowledgementQueue.create(acknowledgementQueueMode);
+    }
+
+    /**
+     * Activates a {@link ConsumerRecord} for processing, which is a prerequisite for emission.
+     * This will only return a non-empty result if this partition has not yet been deactivated.
+     */
+    public <K, V> Optional<KafkaReceiverRecord<K, V>> activateForProcessing(ConsumerRecord<K, V> consumerRecord) {
+        return activate(new OffsetAndMetadata(consumerRecord.offset() + 1, consumerRecord.leaderEpoch(), ""))
+            .map(it -> KafkaReceiverRecord.create(consumerRecord, () -> ack(it), error -> nack(it, error)));
+    }
+
+    /**
+     * Deactivates this partition with possible grace period, and returns the last acknowledged
+     * offset which may be committed. If the grace period is non-positive, deactivation will be
+     * signaled as soon as possible. A short-circuiting "forced timeout" signal may be provided
+     * such as to manually timeout, which is useful if termination is requested from downstream.
+     */
+    public Mono<AcknowledgedOffset> deactivateLatest(Duration gracePeriod, Scheduler scheduler, Mono<?> forcedTimeout) {
+        return deactivateTimeout(gracePeriod, scheduler)
+            .timeout(forcedTimeout)
+            .onErrorComplete(GracelessTimeoutException.class)
+            .onErrorResume(TimeoutException.class, __ -> deactivateForcefully())
+            .then(acknowledgedOffsets().onErrorComplete().takeLast(1).next());
+    }
+
+    /**
+     * Deactivates this partition with possible grace period, returning nothing as data, but
+     * possibly emitting {@link TimeoutException} if either the provided grace period elapses
+     * before deactivation of in-flight records is completed. If the grace period is
+     * non-positive, deactivation will be immediately forced, and a {@link TimeoutException}
+     * will be emitted if there were any remaining in-flight records.
+     */
+    public <T> Mono<T> deactivateTimeout(Duration gracePeriod, Scheduler scheduler) {
+        if (gracePeriod.isZero() || gracePeriod.isNegative()) {
+            return deactivateForcefully()
+                .flatMap(it -> it > 0 ? Mono.error(new GracelessTimeoutException()) : Mono.empty());
+        } else {
+            Mono<T> acknowledgementCompletion = nextOffsetsOfAcknowledged.asFlux()
+                .onErrorComplete()
+                .then(Mono.<T>empty())
+                .timeout(gracePeriod, scheduler);
+            return deactivateGracefully().then(acknowledgementCompletion);
+        }
+    }
+
+    /**
+     * Forces deactivation as soon as possible and returns the number of records that were
+     * deactivated.
+     */
+    public Mono<Long> deactivateForcefully() {
+        return Mono.create(sink -> enqueueAndDrain(() -> {
+            // Ensure that the activation count is updated to reflect TERMINATED state and then
+            // ensure termination of next offset emission, which may be a no-op if any in-flight
+            // records have been negatively acknowledged.
+            long previousActivated = activated.getAndSet(0);
+            nextOffsetsOfAcknowledged.tryEmitComplete();
+
+            // Finally, calculate the number of deactivated records based on the previous count
+            // which, if positive, means this partition had not yet been deactivated, so we need
+            // to subtract one, and if negative, means this partition had already been deactivated,
+            // and we need to negate.
+            long deactivatedRecordCount = previousActivated > 0 ? previousActivated - 1 : -previousActivated;
+            sink.success(deactivatedRecordCount);
+            return deactivatedRecordCount;
+        }));
+    }
+
+    /**
+     * Returns a publisher of offsets that have been acknowledged and may be directly committed.
+     */
+    public Flux<AcknowledgedOffset> acknowledgedOffsets() {
+        return nextOffsetsOfAcknowledged.asFlux().map(it -> new AcknowledgedOffset(topicPartition, it));
+    }
+
+    public Flux<Long> deactivatedRecordCounts() {
+        return deactivatedRecordCounts.asFlux();
+    }
+
+    public TopicPartition topicPartition() {
+        return topicPartition;
+    }
+
+    private Optional<AcknowledgementQueue.InFlight> activate(OffsetAndMetadata nextOffset) {
+        // If registration is successful (neither has a possible deactivation not finished, nor has
+        // processing been forcibly deactivated), allow processing attempt. Else do not return
+        // anything for acknowledgement, which prevents emission for processing.
+        if (activated.getAndUpdate(it -> it > 0 ? it + 1 : it) > 0) {
+            Runnable acknowledger = () -> nextOffsetsOfAcknowledged.tryEmitNext(nextOffset);
+            Consumer<Throwable> nacknowledger = error -> {
+                nextOffsetsOfAcknowledged.tryEmitError(error);
+                deactivateForcefully().subscribe();
+            };
+            return Optional.of(acknowledgementQueue.add(acknowledger, nacknowledger));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private void ack(AcknowledgementQueue.InFlight inFlight) {
+        acknowledge(queue -> queue.complete(inFlight));
+    }
+
+    private void nack(AcknowledgementQueue.InFlight inFlight, Throwable error) {
+        acknowledge(queue -> queue.completeExceptionally(inFlight, error));
+    }
+
+    private void acknowledge(ToLongFunction<AcknowledgementQueue> completer) {
+        enqueueAndDrain(() -> {
+            long completedRecords = completer.applyAsLong(acknowledgementQueue);
+            long previousActivated = activated.getAndUpdate(count -> {
+                if (count > 0) {
+                    // Not deactivated yet, so just subtract.
+                    return count - completedRecords;
+                } else if (count == 0) {
+                    // Terminated, so do nothing.
+                    return count;
+                } else {
+                    // Deactivated but not terminated yet, so add until we get to zero.
+                    return count + completedRecords;
+                }
+            });
+            // It is only valid to emit termination if the updated activation count has reached
+            // zero. In order for that to be the case, the previous count must have been negative
+            // (indicating TERMINABLE state, but not yet TERMINATED) and its magnitude must be
+            // equal to the number of completed in-flight records. Therefore, we can determine if
+            // we should emit termination by checking the polarity of the previous count and
+            // whether the sum of completed records and the previous count cancel out.
+            if (previousActivated < 0 && completedRecords + previousActivated == 0) {
+                nextOffsetsOfAcknowledged.tryEmitComplete();
+            }
+            return completedRecords;
+        });
+    }
+
+    private Mono<Void> deactivateGracefully() {
+        return Mono.create(sink -> enqueueAndDrain(() -> {
+            if (activated.getAndUpdate(it -> it > 0 ? 1 - it : it) == 1) {
+                // This deactivation is eligible to trigger termination, so attempt to do so,
+                // knowing that this could be a no-op if any in-flight records have been negatively
+                // acknowledged.
+                nextOffsetsOfAcknowledged.tryEmitComplete();
+            }
+            sink.success();
+            return 0L;
+        }));
+    }
+
+    private void enqueueAndDrain(Deactivation deactivation) {
+        deactivationQueue.add(deactivation);
+
+        if (deactivationDrainsInProgress.getAndIncrement() != 0) {
+            return;
+        }
+
+        int missed = 1;
+        do {
+            long deactivatedRecordCount = 0;
+            while ((deactivation = deactivationQueue.poll()) != null) {
+                deactivatedRecordCount += deactivation.executeAndGetDeactivatedRecordCount();
+            }
+
+            if (deactivatedRecordCount != 0) {
+                deactivatedRecordCounts.tryEmitNext(deactivatedRecordCount);
+            }
+
+            if (activated.get() == 0) {
+                deactivatedRecordCounts.tryEmitComplete();
+            }
+
+            missed = deactivationDrainsInProgress.addAndGet(-missed);
+        } while (missed != 0);
+    }
+
+    private static final class GracelessTimeoutException extends TimeoutException {
+
+    }
+
+    private interface Deactivation {
+
+        long executeAndGetDeactivatedRecordCount();
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/AloQueueReceptionListener.java
+++ b/kafka/src/main/java/io/atleon/kafka/AloQueueReceptionListener.java
@@ -1,0 +1,36 @@
+package io.atleon.kafka;
+
+import io.atleon.core.AloQueueListener;
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * An adapter that bridges {@link AloQueueListener} to {@link ReceptionListener}.
+ */
+final class AloQueueReceptionListener implements ReceptionListener {
+
+    private final AloQueueListener delegate;
+
+    public AloQueueReceptionListener(AloQueueListener delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void onPartitionActivated(TopicPartition partition) {
+        delegate.created(partition);
+    }
+
+    @Override
+    public void onRecordsActivated(TopicPartition partition, long count) {
+        delegate.enqueued(partition, count);
+    }
+
+    @Override
+    public void onRecordsDeactivated(TopicPartition partition, long count) {
+        delegate.dequeued(partition, count);
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/CommittableOffset.java
+++ b/kafka/src/main/java/io/atleon/kafka/CommittableOffset.java
@@ -1,0 +1,30 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * An offset for a particular {@link TopicPartition} that may be committed.
+ */
+final class CommittableOffset {
+
+    private final TopicPartition topicPartition;
+
+    private final OffsetAndMetadata offsetAndMetadata;
+
+    private final long sequence;
+
+    public CommittableOffset(AcknowledgedOffset acknowledgedOffset, long sequence) {
+        this.topicPartition = acknowledgedOffset.topicPartition();
+        this.offsetAndMetadata = acknowledgedOffset.nextOffsetAndMetadata();
+        this.sequence = sequence;
+    }
+
+    public TopicPartition topicPartition() {
+        return topicPartition;
+    }
+
+    public SequencedOffset sequencedOffset() {
+        return new SequencedOffset(offsetAndMetadata, sequence);
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/ConsumerInvocable.java
+++ b/kafka/src/main/java/io/atleon/kafka/ConsumerInvocable.java
@@ -1,0 +1,27 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+/**
+ * A facade around an active {@link Consumer} instance that allows safely scheduling (allowed)
+ * invocations on that consumer in the active polling thread. NOTE: It is invalid to invoke these
+ * methods <i>from</i> the polling thread itself, for example from within invocations of
+ * {@link ConsumerListener#onPartitionsAssigned(Consumer, Collection)}. In such cases, it is
+ * rather permissible to call methods on the explicitly provided Consumer instance, since the
+ * callback is already executing on the polling thread.
+ */
+public interface ConsumerInvocable {
+
+    default Mono<Void> invoke(java.util.function.Consumer<Consumer<?, ?>> invocation) {
+        return invokeAndGet(consumer -> {
+            invocation.accept(consumer);
+            return null;
+        });
+    }
+
+    <T> Mono<T> invokeAndGet(Function<? super Consumer<?, ?>, T> invocation);
+}

--- a/kafka/src/main/java/io/atleon/kafka/ConsumerListener.java
+++ b/kafka/src/main/java/io/atleon/kafka/ConsumerListener.java
@@ -1,0 +1,140 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+/**
+ * A listener interface for callbacks associated with the lifecycle of Kafka record consumption.
+ * Instances are created from {@link ConsumerListenerFactory#create(ConsumerInvocable)}, which
+ * allows for implementations to be constructed with an on-demand handle to the underlying
+ * {@link Consumer} instance.
+ */
+public interface ConsumerListener {
+
+    /**
+     * Creates a listener that does nothing.
+     */
+    static ConsumerListener noOp() {
+        return new ConsumerListener() {};
+    }
+
+    /**
+     * Creates a listener that will seek to the specified offset on the provided partition the
+     * first time this partition is assigned.
+     */
+    static ConsumerListener seekOnce(TopicPartition topicPartition, long offset) {
+        return doOnPartitionsAssignedOnce((consumer, partitions) -> {
+            if (partitions.contains(topicPartition)) {
+                consumer.seek(topicPartition, offset);
+            }
+        });
+    }
+
+    /**
+     * Creates a listener that will seek to the beginning offset of any given partition the first
+     * time it is assigned.
+     */
+    static ConsumerListener seekToBeginningOnce() {
+        return doOnPartitionsAssignedOnce(Consumer::seekToBeginning);
+    }
+
+    /**
+     * Creates a listener that will perform some action on any given partition the first time it is
+     * assigned.
+     */
+    static ConsumerListener doOnPartitionsAssignedOnce(BiConsumer<Consumer<?, ?>, Collection<TopicPartition>> action) {
+        Set<TopicPartition> actioned = new HashSet<>();
+        return new ConsumerListener() {
+            @Override
+            public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+                Collection<TopicPartition> actionable = partitions.stream()
+                    .filter(it -> !actioned.contains(it))
+                    .collect(Collectors.toList());
+                if (!actionable.isEmpty()) {
+                    action.accept(consumer, actionable);
+                    actioned.addAll(actionable);
+                }
+            }
+        };
+    }
+
+    /**
+     * Creates a listener that allows subscribing to closure event.
+     */
+    static Closure closure() {
+        return new Closure();
+    }
+
+    /**
+     * Callback invoked when it has been detected that the provided partitions have been lost.
+     *
+     * @param consumer   Consumer handle on which it is safe to invoke blocking calls
+     * @param partitions The partitions that have been lost
+     * @see org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsLost(Collection)
+     */
+    default void onPartitionsLost(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+        onPartitionsRevoked(consumer, partitions);
+    }
+
+    /**
+     * Callback invoked when the provided partitions have been revoked.
+     *
+     * @param consumer   Consumer handle on which it is safe to invoke blocking calls
+     * @param partitions The partitions that have been revoked
+     * @see org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsRevoked(Collection)
+     */
+    default void onPartitionsRevoked(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+
+    }
+
+    /**
+     * Callback invoked when the provided partitions have been assigned.
+     *
+     * @param consumer   Consumer handle on which it is safe to invoke blocking calls
+     * @param partitions The partitions that have been assigned
+     * @see org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsAssigned(Collection)
+     */
+    default void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+
+    }
+
+    /**
+     * Callback invoked when the provided consumer is about to be closed.
+     */
+    default void onClose(Consumer<?, ?> consumer) {
+
+    }
+
+    /**
+     * Callback invoked after the associated consumer has been closed.
+     */
+    default void close() {
+
+    }
+
+    final class Closure implements ConsumerListener {
+
+        private final Sinks.Empty<Void> closed = Sinks.empty();
+
+        private Closure() {
+
+        }
+
+        @Override
+        public void close() {
+            closed.tryEmitEmpty();
+        }
+
+        public Mono<Void> closed() {
+            return closed.asMono();
+        }
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/ConsumerListenerFactory.java
+++ b/kafka/src/main/java/io/atleon/kafka/ConsumerListenerFactory.java
@@ -1,0 +1,29 @@
+package io.atleon.kafka;
+
+/**
+ * Factory that provides instances of {@link ConsumerListener} upon beginning the consumption of
+ * records from Kafka.
+ */
+public interface ConsumerListenerFactory {
+
+    /**
+     * Creates a factory that always returns a no-op listener.
+     */
+    static ConsumerListenerFactory noOp() {
+        return singleton(ConsumerListener.noOp());
+    }
+
+    /**
+     * Creates a factory that will always return the provided listener instance for each
+     * consumption process.
+     */
+    static ConsumerListenerFactory singleton(ConsumerListener listener) {
+        return __ -> listener;
+    }
+
+    /**
+     * Create a new listener with access to the active consumer instance via
+     * {@link ConsumerInvocable} API.
+     */
+    ConsumerListener create(ConsumerInvocable invocable);
+}

--- a/kafka/src/main/java/io/atleon/kafka/ConsumptionSpec.java
+++ b/kafka/src/main/java/io/atleon/kafka/ConsumptionSpec.java
@@ -1,0 +1,32 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collection;
+import java.util.regex.Pattern;
+
+/**
+ * Interface used to specify what topic(s) or partition(s) to request for consumption, with
+ * callbacks for handling the lifecycle of assignment(s).
+ */
+interface ConsumptionSpec {
+
+    static ConsumptionSpec subscribe(Collection<String> topics) {
+        return (consumer, rebalanceListener) -> consumer.subscribe(topics, rebalanceListener);
+    }
+
+    static ConsumptionSpec subscribe(Pattern topicsPattern) {
+        return (consumer, rebalanceListener) -> consumer.subscribe(topicsPattern, rebalanceListener);
+    }
+
+    static ConsumptionSpec assign(Collection<TopicPartition> topicPartitions) {
+        return (consumer, rebalanceListener) -> {
+            consumer.assign(topicPartitions);
+            rebalanceListener.onPartitionsAssigned(topicPartitions);
+        };
+    }
+
+    void apply(Consumer<?, ?> consumer, ConsumerRebalanceListener rebalanceListener);
+}

--- a/kafka/src/main/java/io/atleon/kafka/EmittableRecord.java
+++ b/kafka/src/main/java/io/atleon/kafka/EmittableRecord.java
@@ -1,0 +1,30 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Optional;
+
+/**
+ * A received {@link ConsumerRecord} that is eligible for downstream emission, but has not been
+ * emitted yet.
+ */
+final class EmittableRecord<K, V> {
+
+    private final ActivePartition activePartition;
+
+    private final ConsumerRecord<K, V> consumerRecord;
+
+    public EmittableRecord(ActivePartition activePartition, ConsumerRecord<K, V> consumerRecord) {
+        this.activePartition = activePartition;
+        this.consumerRecord = consumerRecord;
+    }
+
+    public Optional<KafkaReceiverRecord<K, V>> activateForProcessing() {
+        return activePartition.activateForProcessing(consumerRecord);
+    }
+
+    public TopicPartition topicPartition() {
+        return activePartition.topicPartition();
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/KafkaErrors.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaErrors.java
@@ -1,0 +1,39 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.RetriableCommitFailedException;
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.errors.OutOfOrderSequenceException;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.RebalanceInProgressException;
+import org.apache.kafka.common.errors.UnsupportedForMessageFormatException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+
+/**
+ * Utility methods concerned with identifying/handling Kafka-specific errors.
+ */
+final class KafkaErrors {
+
+    private KafkaErrors() {
+
+    }
+
+    public static boolean isRetriableCommitFailure(Exception exception) {
+        return exception instanceof RetriableCommitFailedException
+            || exception instanceof RebalanceInProgressException;
+    }
+
+    public static boolean isFatalSendFailure(Exception exception) {
+        // All known fatal send failures are a subset of fatal Producer errors, which will result
+        // in the underlying Producer being closed. Upon closure, all following errors will be
+        // of type IllegalStateException indicating closed state, so this can be our only check.
+        return exception instanceof IllegalStateException;
+    }
+
+    public static boolean isFatalProducerException(Throwable error) {
+        return error instanceof ProducerFencedException
+            || error instanceof OutOfOrderSequenceException
+            || error instanceof AuthenticationException
+            || error instanceof UnsupportedVersionException
+            || error instanceof UnsupportedForMessageFormatException;
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/KafkaReceiver.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaReceiver.java
@@ -1,0 +1,256 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
+
+import java.util.Collection;
+import java.util.regex.Pattern;
+
+/**
+ * A reactive receiver of Kafka {@link ConsumerRecord records}, which may be wrapped as
+ * {@link KafkaReceiverRecord}. A new Kafka {@link Consumer} is associated with each receiver
+ * subscription, and closed if/when that subscription is canceled or errored out. Each reception
+ * subscription takes care of keeping track of the records that have been emitted and acknowledged
+ * on a per-partition, per-assignment basis, and will only make any given record's offset available
+ * for commitment (triggered by periodic or batch sizing) if/when that record and all the records
+ * that came before it in the same actively assigned partition have been acknowledged. It is
+ * therefore important that every emitted record be either positively acknowledged when its
+ * processing completes normally, or negatively acknowledged ("nacknowledged"), in the case of
+ * processing failure.
+ * <p>
+ * <b>Reception Modes: </b> This receiver provides the following modes of reception:
+ * <ul>
+ * <li><b>Periodic Commit:</b> The default reception mode uses a periodic commit strategy, where
+ * acknowledged offsets are committed either after acknowledging a configurable number of records
+ * or after a configurable amount of time has passed after acknowledging an uncommitted offset.
+ * Upon "deactivation" of any assigned partition, whether through typical revocation from a
+ * rebalance, reception error, or downstream cancellation, a strong effort is made to ensure that
+ * any offsets which can be committed are done so synchronously. The only case in which this is not
+ * true is if partitions are signaled to have been "lost", which can happen if/when a consumer is
+ * unexpectedly removed from its group (i.e. due to session timeout). For revocation due to typical
+ * rebalance, a grace period is configurable, which sets a maximum amount of time that will be
+ * awaited for in-flight records to be acknowledged before attempting final commitment and
+ * releasing any assigned partition(s). This grace period can be set to zero such that only record
+ * offsets acknowledged at the immediate time of partition deactivation will be committed, which
+ * makes rebalancing faster at the cost of higher reprocessing likelihood. Periodic commit
+ * reception mode plays well with cooperative rebalancing by allowing polling and processing to
+ * continue during a cooperative rebalance, and taking care of cleanup if/when such rebalancing
+ * results in partition revocation.</li>
+ * <li><b>Transactional:</b> When configured for transactional polling (using a receiveTx method
+ * and {@link KafkaTxManager}), each emission cycle is managed within a transaction. Records are
+ * polled and emitted within transaction sessions, and their offsets are sent as part of the
+ * transaction before committing. The transaction is only committed when all records in the session
+ * have been acknowledged. If reception is canceled, an error occurs, or if a partition is
+ * lost, any open transaction is aborted. This allows for exactly-once processing semantics for
+ * records and their offsets. The size of each transaction session (in terms of record count) and
+ * commit interval are configurable, and transactional state is managed per subscription.
+ * Transactional polling guarantees that offsets are only committed if all records emitted in the
+ * transaction have been successfully processed and acknowledged.</li>
+ * </ul>
+ * <p>
+ * <b>Emission Acknowledgement Modes:</b> There are two modes of acknowledgement for emitted
+ * records:
+ * <ul>
+ * <li><b>Manual Acknowledgement:</b> This is the default acknowledgement mode. Every emitted
+ * record <i>must</i> be acknowledged either positively or negatively after emission.</li>
+ * <li><b>Auto Acknowledgement:</b> This emission mode provides simplified processing by
+ * automatically acknowledging records upon successful completion of downstream <i>emission</i>.
+ * Each {@link ConsumerRecord} is wrapped in a {@link Mono} that automatically triggers
+ * acknowledgement when the Mono completes normally (i.e., {@link SignalType#ON_COMPLETE}). This
+ * eliminates the need for explicit acknowledgement calls in application code, making it suitable
+ * for fire-and-forget processing patterns. However, this mode has important limitations: it does
+ * <i>not</i> guarantee at-least-once processing semantics in the presence of downstream
+ * asynchronous boundaries (such as {@code flatMap}, {@code publishOn}, or other operators that
+ * introduce asynchrony), since acknowledgement occurs based on Mono completion rather than actual
+ * processing completion. For reliable processing with async operations, use manual
+ * acknowledgement.</li>
+ * </ul>
+ * <p>
+ * <b>Acknowledgement Queueing Modes:</b> This receiver maintains acknowledgement queues to ensure
+ * proper offset commitment ordering within each topic-partition. Two modes control how
+ * acknowledged offsets become eligible for commitment (both maintain identical at-least-once
+ * delivery semantics and ensure that no offset is made eligible for commitment until all preceding
+ * records in the actively assigned partition have been acknowledged):
+ * <ul>
+ * <li><b>STRICT Mode:</b> The default mode where each acknowledged record's offset becomes
+ * eligible for commitment individually.</li>
+ * <li><b>COMPACT Mode:</b> An optimization where acknowledgement tracking may be consolidated when
+ * multiple sequential records are acknowledged but not yet eligible for commitment, reducing the
+ * granularity of offset eligibility tracking. This mode is particularly beneficial for
+ * high-throughput, high-concurrency scenarios (such as work queue processing) where
+ * acknowledgements are likely to occur out of order. Note that this mode removes the strong
+ * coupling of record processing to commit batch sizing (since this is based on the number of
+ * offsets made eligible for commitment), so it is rather recommended to depend on time-based
+ * commit triggering when using this mode.</li>
+ * </ul>
+ * <p>
+ * <b>Polling Strategies:</b> This receiver supports configurable polling strategies to optimize
+ * partition selection during consumer poll invocations. The polling strategy determines which
+ * assigned partitions are polled in each polling cycle, enabling fine-tuned control over partition
+ * consumption. There are a few built-in polling strategies available:
+ * <ul>
+ * <li><b>Natural (Default):</b> Polls from all assigned (and non-externally paused) partitions
+ * using default Kafka consumer behavior. This strategy makes no guarantees about consumption bias
+ * or fairness</li>
+ * <li><b>Binary Strides:</b> A balanced strategy that polls approximately half of assigned
+ * partitions per cycle using binary striding selection. This creates more even consumption across
+ * partitions and can reduce the likelihood or performance impacts caused by one or two highly
+ * lagging assigned partitions.</li>
+ * <li><b>Greatest Batch Lag:</b> Prioritizes partitions with the highest lag in units of the
+ * polling batch size. This strategy is useful when prioritizing uniform lag across all assigned
+ * partitions</li>
+ * </ul>
+ * <p>
+ * Polling strategies can be configured via 
+ * {@link KafkaReceiverOptions.Builder#pollStrategyFactory(PollStrategyFactory)}. Custom strategies
+ * can be implemented by providing a {@link PollStrategyFactory} that creates instances of
+ * {@link PollStrategy}.
+ *
+ * @param <K> The type of keys in records emitted by this receiver
+ * @param <V> The type of values in records emitted by this receiver
+ */
+public final class KafkaReceiver<K, V> {
+
+    private final PollingSubscriptionFactory<K, V> subscriptionFactory;
+
+    private KafkaReceiver(KafkaReceiverOptions<K, V> options) {
+        this.subscriptionFactory = new PollingSubscriptionFactory<>(options);
+    }
+
+    public static <K, V> KafkaReceiver<K, V> create(KafkaReceiverOptions<K, V> options) {
+        return new KafkaReceiver<>(options);
+    }
+
+    /**
+     * Receive records from the specified topics with automatic acknowledgment.
+     * <p>
+     * Each {@link ConsumerRecord} is wrapped as a {@link Mono}, which, upon successful emission
+     * completion (i.e., {@link reactor.core.publisher.SignalType#ON_COMPLETE}), will result in
+     * automatically acknowledging the originating {@link KafkaReceiverRecord}. Note that
+     * downstream errors typically result in cancellation.
+     * <p>
+     * <b>Important</b>: This mode of reception does <i>not</i> guarantee processing (at least
+     * once) in the presence of downstream asynchronous boundaries.
+     *
+     * @param topics The collection of topic names to subscribe to
+     * @return A {@link Flux} of {@link Mono} instances, each wrapping a {@link ConsumerRecord}
+     * with automatic acknowledgment behavior
+     */
+    public Flux<Mono<ConsumerRecord<K, V>>> receiveAutoAck(Collection<String> topics) {
+        return receiveAutoAck(ConsumptionSpec.subscribe(topics));
+    }
+
+    /**
+     * Receive records from topics matching the given pattern with automatic acknowledgment.
+     * <p>
+     * Each {@link ConsumerRecord} is wrapped as a {@link Mono}, which, upon successful emission
+     * completion (i.e., {@link reactor.core.publisher.SignalType#ON_COMPLETE}), will result in
+     * automatically acknowledging the originating {@link KafkaReceiverRecord}. Note that
+     * downstream errors typically result in cancellation.
+     * <p>
+     * <b>Important</b>: This mode of reception does <i>not</i> guarantee processing (at least
+     * once) in the presence of downstream asynchronous boundaries.
+     *
+     * @param topicPattern The pattern to match topic names for subscription
+     * @return A {@link Flux} of {@link Mono} instances, each wrapping a {@link ConsumerRecord}
+     * with automatic acknowledgment behavior
+     */
+    public Flux<Mono<ConsumerRecord<K, V>>> receiveAutoAck(Pattern topicPattern) {
+        return receiveAutoAck(ConsumptionSpec.subscribe(topicPattern));
+    }
+
+    /**
+     * Receive records from the specified partitions with automatic acknowledgment.
+     * <p>
+     * Each {@link ConsumerRecord} is wrapped as a {@link Mono}, which, upon successful emission
+     * completion (i.e., {@link reactor.core.publisher.SignalType#ON_COMPLETE}), will result in
+     * automatically acknowledging the originating {@link KafkaReceiverRecord}. Note that
+     * downstream errors typically result in cancellation.
+     * <p>
+     * <b>Important</b>: This mode of reception does <i>not</i> guarantee processing (at least
+     * once) in the presence of downstream asynchronous boundaries.
+     *
+     * @param topicPartitions The collection of specific topic partitions to assign
+     * @return A {@link Flux} of {@link Mono} instances, each wrapping a {@link ConsumerRecord}
+     * with automatic acknowledgment behavior
+     */
+    public Flux<Mono<ConsumerRecord<K, V>>> receiveAutoAckWithAssignment(Collection<TopicPartition> topicPartitions) {
+        return receiveAutoAck(ConsumptionSpec.assign(topicPartitions));
+    }
+
+    /**
+     * Receive records from the given topics with manual acknowledgment control.
+     *
+     * @param topics The topics to subscribe to
+     * @return A stream of records that require manual acknowledgment
+     */
+    public Flux<KafkaReceiverRecord<K, V>> receiveManual(Collection<String> topics) {
+        return receiveManual(ConsumptionSpec.subscribe(topics));
+    }
+
+    /**
+     * Receive records from topics matching the given pattern with manual acknowledgment control.
+     *
+     * @param topicsPattern The pattern to match topics to subscribe to
+     * @return A stream of records that require manual acknowledgment
+     */
+    public Flux<KafkaReceiverRecord<K, V>> receiveManual(Pattern topicsPattern) {
+        return receiveManual(ConsumptionSpec.subscribe(topicsPattern));
+    }
+
+    /**
+     * Receive records from the given topics with manual acknowledgment, using a provided
+     * transaction manager to ensure records are processed and committed with a transaction.
+     *
+     * @param txManager The manager to use for transactional processing
+     * @param topics    The topics to subscribe to
+     * @return A stream of records that require manual acknowledgment
+     */
+    public Flux<KafkaReceiverRecord<K, V>> receiveTxManual(
+        Publisher<? extends KafkaTxManager> txManager,
+        Collection<String> topics
+    ) {
+        return Mono.from(txManager).flatMapMany(it -> receiveTxManual(it, ConsumptionSpec.subscribe(topics)));
+    }
+
+    /**
+     * Receive records from the given topics with manual acknowledgment, using a provided
+     * transaction manager to ensure records are processed and committed with a transaction.
+     *
+     * @param txManager     The manager to use for transactional processing
+     * @param topicsPattern The pattern to match topics to subscribe to
+     * @return A stream of records that require manual acknowledgment
+     */
+    public Flux<KafkaReceiverRecord<K, V>> receiveTxManual(
+        Publisher<? extends KafkaTxManager> txManager,
+        Pattern topicsPattern
+    ) {
+        return Mono.from(txManager).flatMapMany(it -> receiveTxManual(it, ConsumptionSpec.subscribe(topicsPattern)));
+    }
+
+    private Flux<Mono<ConsumerRecord<K, V>>> receiveAutoAck(ConsumptionSpec consumptionSpec) {
+        return receiveManual(consumptionSpec).map(receiverRecord -> {
+            Runnable acknowledger = receiverRecord.acknowledger();
+            return Mono.just(receiverRecord.consumerRecord()).doFinally(signalType -> {
+                if (signalType == SignalType.ON_COMPLETE) {
+                    acknowledger.run();
+                }
+            });
+        });
+    }
+
+    @SuppressWarnings("ReactiveStreamsPublisherImplementation")
+    private Flux<KafkaReceiverRecord<K, V>> receiveManual(ConsumptionSpec consumptionSpec) {
+        return Flux.from(it -> it.onSubscribe(subscriptionFactory.periodicCommit(consumptionSpec, it)));
+    }
+
+    @SuppressWarnings("ReactiveStreamsPublisherImplementation")
+    private Flux<KafkaReceiverRecord<K, V>> receiveTxManual(KafkaTxManager txManager, ConsumptionSpec consumptionSpec) {
+        return Flux.from(it -> it.onSubscribe(subscriptionFactory.transactional(txManager, consumptionSpec, it)));
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/KafkaReceiverOptions.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaReceiverOptions.java
@@ -1,0 +1,530 @@
+package io.atleon.kafka;
+
+import io.atleon.core.AcknowledgementQueueMode;
+import io.atleon.util.ConfigLoading;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Options used to configure the reactive reception of records from Kafka.
+ *
+ * @param <K> The type of keys in received records
+ * @param <V> The type of values in received records
+ */
+public final class KafkaReceiverOptions<K, V> {
+
+    private static final Duration DEFAULT_POLL_TIMEOUT = Duration.ofMillis(100L);
+
+    private static final int DEFAULT_MAX_FULL_POLL_RECORDS_PREFETCH = 2;
+
+    private static final long DEFAULT_MAX_ACTIVE_IN_FLIGHT = 4096;
+
+    private static final Duration DEFAULT_COMMIT_INTERVAL = Duration.ofSeconds(5L); // Kafka default
+
+    private static final int DEFAULT_MAX_COMMIT_ATTEMPTS = 100;
+
+    private static final Duration DEFAULT_REVOCATION_GRACE_PERIOD = Duration.ofSeconds(15L);
+
+    private static final Duration DEFAULT_CLOSE_TIMEOUT = Duration.ofSeconds(30L); // Kafka default
+
+    private final Function<Map<String, Object>, Consumer<K, V>> consumerFactory;
+
+    private final ConsumerListenerFactory consumerListenerFactory;
+
+    private final ReceptionListenerFactory receptionListenerFactory;
+
+    private final PollStrategyFactory pollStrategyFactory;
+
+    private final Supplier<Scheduler> auxiliarySchedulerSupplier;
+
+    private final Map<String, Object> consumerProperties;
+
+    private final int fullPollRecordsPrefetch;
+
+    private final long maxActiveInFlight;
+
+    private final Duration pollTimeout;
+
+    private final AcknowledgementQueueMode acknowledgementQueueMode;
+
+    private final int commitBatchSize;
+
+    private final Duration commitPeriod;
+
+    private final int maxCommitAttempts;
+
+    private final boolean commitlessOffsets;
+
+    private final Duration revocationGracePeriod;
+
+    private final Duration closeTimeout;
+
+    private KafkaReceiverOptions(
+        Function<Map<String, Object>, Consumer<K, V>> consumerFactory,
+        ConsumerListenerFactory consumerListenerFactory,
+        ReceptionListenerFactory receptionListenerFactory,
+        PollStrategyFactory pollStrategyFactory,
+        Supplier<Scheduler> auxiliarySchedulerSupplier,
+        Map<String, Object> consumerProperties,
+        int fullPollRecordsPrefetch,
+        long maxActiveInFlight,
+        Duration pollTimeout,
+        AcknowledgementQueueMode acknowledgementQueueMode,
+        int commitBatchSize,
+        Duration commitPeriod,
+        int maxCommitAttempts,
+        boolean commitlessOffsets,
+        Duration revocationGracePeriod,
+        Duration closeTimeout
+    ) {
+        this.consumerFactory = consumerFactory;
+        this.consumerListenerFactory = consumerListenerFactory;
+        this.receptionListenerFactory = receptionListenerFactory;
+        this.pollStrategyFactory = pollStrategyFactory;
+        this.auxiliarySchedulerSupplier = auxiliarySchedulerSupplier;
+        this.consumerProperties = consumerProperties;
+        this.fullPollRecordsPrefetch = fullPollRecordsPrefetch;
+        this.maxActiveInFlight = maxActiveInFlight;
+        this.pollTimeout = pollTimeout;
+        this.acknowledgementQueueMode = acknowledgementQueueMode;
+        this.commitBatchSize = commitBatchSize;
+        this.commitPeriod = commitPeriod;
+        this.maxCommitAttempts = maxCommitAttempts;
+        this.commitlessOffsets = commitlessOffsets;
+        this.revocationGracePeriod = revocationGracePeriod;
+        this.closeTimeout = closeTimeout;
+        validate();
+    }
+
+    public static <K, V> KafkaReceiverOptions<K, V> defaultOptions() {
+        return KafkaReceiverOptions.<K, V>newBuilder().build();
+    }
+
+    public static <K, V> KafkaReceiverOptions.Builder<K, V> newBuilder() {
+        return KafkaReceiverOptions.newBuilder(KafkaConsumer::new);
+    }
+
+    /**
+     * Creates a new builder that will use the provided factory to create Consumer instances on a
+     * per-reception, per-subscription basis.
+     */
+    public static <K, V> KafkaReceiverOptions.Builder<K, V> newBuilder(
+        Function<Map<String, Object>, Consumer<K, V>> consumerFactory
+    ) {
+        return new Builder<>(consumerFactory);
+    }
+
+    /**
+     * Creates a new Consumer instance that will be used when subscribing to receiver records.
+     */
+    public Consumer<K, V> createConsumer() {
+        Map<String, Object> sanitized = new LinkedHashMap<>(consumerProperties);
+        // We take control of offset committing, so force (or at least attempt to force) the native
+        // periodic commit to be disabled.
+        sanitized.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        return consumerFactory.apply(sanitized);
+    }
+
+    /**
+     * Creates a new {@link ConsumerListener} based on a reactive handle to the active Consumer
+     * instance.
+     */
+    public ConsumerListener createConsumerListener(ConsumerInvocable invocable) {
+        return consumerListenerFactory.create(invocable);
+    }
+
+    /**
+     * @see Builder#receptionListenerFactory(ReceptionListenerFactory)
+     */
+    public ReceptionListener createReceptionListener() {
+        return receptionListenerFactory.create();
+    }
+
+    /**
+     * @see Builder#pollStrategyFactory(PollStrategyFactory)
+     */
+    public PollStrategy createPollStrategy() {
+        return pollStrategyFactory.create();
+    }
+
+    /**
+     * @see Builder#auxiliarySchedulerSupplier(Supplier)
+     */
+    public Scheduler createAuxiliaryScheduler() {
+        return auxiliarySchedulerSupplier.get();
+    }
+
+    public String loadConsumerTaskLoopName() {
+        return "atleon-kafka-receive-consumer-" + loadClientId();
+    }
+
+    public String loadClientId() {
+        return ConfigLoading.loadStringOrThrow(consumerProperties, CommonClientConfigs.CLIENT_ID_CONFIG);
+    }
+
+    /**
+     * @see Builder#fullPollRecordsPrefetch(int)
+     */
+    public int calculateMaxRecordsPrefetch() {
+        return loadMaxPollRecords() * fullPollRecordsPrefetch;
+    }
+
+    public int loadMaxPollRecords() {
+        return ConfigLoading.loadInt(consumerProperties, ConsumerConfig.MAX_POLL_RECORDS_CONFIG)
+            .orElse(ConsumerConfig.DEFAULT_MAX_POLL_RECORDS);
+    }
+
+    /**
+     * @see Builder#fullPollRecordsPrefetch(int)
+     */
+    public int fullPollRecordsPrefetch() {
+        return fullPollRecordsPrefetch;
+    }
+
+    /**
+     * @see Builder#maxActiveInFlight(long)
+     */
+    public long maxActiveInFlight() {
+        return maxActiveInFlight;
+    }
+
+    /**
+     * @see Builder#pollTimeout(Duration)
+     */
+    public Duration pollTimeout() {
+        return pollTimeout;
+    }
+
+    /**
+     * @see Builder#acknowledgementQueueMode(AcknowledgementQueueMode)
+     */
+    public AcknowledgementQueueMode acknowledgementQueueMode() {
+        return acknowledgementQueueMode;
+    }
+
+    /**
+     * @see Builder#commitBatchSize(int)
+     */
+    public int commitBatchSize() {
+        return commitBatchSize;
+    }
+
+    /**
+     * @see Builder#commitPeriod(Duration)
+     */
+    public Duration commitPeriod() {
+        return commitPeriod;
+    }
+
+    /**
+     * @see Builder#maxCommitAttempts(int)
+     */
+    public int maxCommitAttempts() {
+        return maxCommitAttempts;
+    }
+
+    /**
+     * @see Builder#commitlessOffsets(boolean)
+     */
+    public boolean commitlessOffsets() {
+        return commitlessOffsets;
+    }
+
+    /**
+     * @see Builder#revocationGracePeriod(Duration)
+     */
+    public Duration revocationGracePeriod() {
+        return revocationGracePeriod;
+    }
+
+    /**
+     * @see Builder#closeTimeout(Duration)
+     */
+    public Duration closeTimeout() {
+        return closeTimeout;
+    }
+
+    private void validate() {
+        validatePositive(fullPollRecordsPrefetch, "fullPollRecordsPrefetch");
+        validatePositive(maxActiveInFlight, "maxActiveInFlight");
+        validatePositive(commitBatchSize, "commitBatchSize");
+        validatePositive(commitPeriod, "commitPeriod");
+        validatePositive(maxCommitAttempts, "maxCommitAttempts");
+        validateNonNegative(revocationGracePeriod, "revocationGracePeriod");
+
+        if (revocationGracePeriod.compareTo(closeTimeout) > 0) {
+            throw new IllegalArgumentException("revocationGracePeriod must be less than or equal to closeTimeout");
+        }
+    }
+
+    private static void validateNonNegative(Duration value, String name) {
+        if (value.isNegative()) {
+            throw new IllegalArgumentException(name + " must be non-negative");
+        }
+    }
+
+    private static void validatePositive(Duration value, String name) {
+        if (value.isZero() || value.isNegative()) {
+            throw new IllegalArgumentException(name + " must be positive");
+        }
+    }
+
+    private static void validatePositive(long value, String name) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(name + " must be positive");
+        }
+    }
+
+    public static final class Builder<K, V> {
+
+        private final Function<Map<String, Object>, Consumer<K, V>> consumerFactory;
+
+        private ConsumerListenerFactory consumerListenerFactory = ConsumerListenerFactory.noOp();
+
+        private ReceptionListenerFactory receptionListenerFactory = ReceptionListenerFactory.noOp();
+
+        private PollStrategyFactory pollStrategyFactory = PollStrategyFactory.natural();
+
+        private Supplier<Scheduler> auxiliarySchedulerSupplier = Schedulers::parallel;
+
+        private Map<String, Object> consumerProperties = Collections.emptyMap();
+
+        private int fullPollRecordsPrefetch = DEFAULT_MAX_FULL_POLL_RECORDS_PREFETCH;
+
+        private long maxActiveInFlight = DEFAULT_MAX_ACTIVE_IN_FLIGHT;
+
+        private Duration pollTimeout = DEFAULT_POLL_TIMEOUT;
+
+        private AcknowledgementQueueMode acknowledgementQueueMode = AcknowledgementQueueMode.STRICT;
+
+        private int commitBatchSize = Integer.MAX_VALUE;
+
+        private Duration commitPeriod = DEFAULT_COMMIT_INTERVAL;
+
+        private int maxCommitAttempts = DEFAULT_MAX_COMMIT_ATTEMPTS;
+
+        private boolean commitlessOffsets = false;
+
+        private Duration revocationGracePeriod = DEFAULT_REVOCATION_GRACE_PERIOD;
+
+        private Duration closeTimeout = DEFAULT_CLOSE_TIMEOUT;
+
+        private Builder(Function<Map<String, Object>, Consumer<K, V>> consumerFactory) {
+            this.consumerFactory = consumerFactory;
+        }
+
+        /**
+         * Configures a singleton {@link ConsumerListenerFactory} that wraps the provided
+         * listener.
+         */
+        public Builder<K, V> consumerListener(ConsumerListener listener) {
+            return consumerListenerFactory(ConsumerListenerFactory.singleton(listener));
+        }
+
+        /**
+         * Configures the factory that's used to create {@link ConsumerListener} instances on a
+         * per-reception, per-subscription basis. Defaults to no-op.
+         */
+        public Builder<K, V> consumerListenerFactory(ConsumerListenerFactory consumerListenerFactory) {
+            this.consumerListenerFactory = consumerListenerFactory;
+            return this;
+        }
+
+        /**
+         * Configures a singleton {@link ReceptionListenerFactory} that wraps the provided
+         * listener.
+         */
+        public Builder<K, V> receptionListener(ReceptionListener listener) {
+            return receptionListenerFactory(ReceptionListenerFactory.singleton(listener));
+        }
+
+        /**
+         * Configures the factory that's used to create {@link ReceptionListener} instances on a
+         * per-reception, per-subscription basis. Defaults to no-op.
+         */
+        public Builder<K, V> receptionListenerFactory(ReceptionListenerFactory receptionListenerFactory) {
+            this.receptionListenerFactory = receptionListenerFactory;
+            return this;
+        }
+
+        /**
+         * Configures the factory that's used to create a {@link PollStrategy} on a per-reception,
+         * per-subscription basis. It can be useful to configure fair or sophisticated dynamic
+         * strategies in order to guard against natural poll biases or to implement poll
+         * prioritization. Defaults to "natural", where all assigned partitions are polled on each
+         * polling cycle.
+         */
+        public Builder<K, V> pollStrategyFactory(PollStrategyFactory pollStrategyFactory) {
+            this.pollStrategyFactory = pollStrategyFactory;
+            return this;
+        }
+
+        /**
+         * Configures the supplier of an "auxiliary" {@link Scheduler}, which is created and used
+         * for non-blocking periodic and timeout tasks (and therefore must be time-capable).
+         */
+        public Builder<K, V> auxiliarySchedulerSupplier(Supplier<Scheduler> auxiliarySchedulerSupplier) {
+            this.auxiliarySchedulerSupplier = auxiliarySchedulerSupplier;
+            return this;
+        }
+
+        /**
+         * Sets a single native {@link ConsumerConfig Kafka Consumer property} used to configure
+         * created Consumer instances.
+         */
+        public Builder<K, V> consumerProperty(String key, Object value) {
+            Map<String, Object> consumerProperties = new HashMap<>(this.consumerProperties);
+            consumerProperties.put(key, value);
+            return consumerProperties(consumerProperties);
+        }
+
+        /**
+         * Sets the native {@link ConsumerConfig Kafka Consumer properites} that are used to
+         * configure created Consumer instances.
+         */
+        public Builder<K, V> consumerProperties(Map<String, Object> consumerProperties) {
+            this.consumerProperties = consumerProperties;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of "full" polled record batches that may be prefetched (awaiting
+         * emission). The notion of "full" batches is related to
+         * {@link ConsumerConfig#MAX_POLL_RECORDS_CONFIG} and is decoupled from the size of batches
+         * actually polled, since it is common that such polled batches are not full. Therefore,
+         * these two configurations are multiplied by each other to calculate the maximum total
+         * number of records that may be prefetched. Defaults to 2.
+         */
+        public Builder<K, V> fullPollRecordsPrefetch(int fullPollRecordsPrefetch) {
+            this.fullPollRecordsPrefetch = fullPollRecordsPrefetch;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of records that are allowed to have been activated and emitted
+         * for downstream consumption and not yet acknowledged (positively or negatively).
+         */
+        public Builder<K, V> maxActiveInFlight(long maxActiveInFlight) {
+            this.maxActiveInFlight = maxActiveInFlight;
+            return this;
+        }
+
+        /**
+         * Sets the timeout used on invocations to {@link Consumer#poll(Duration)}.
+         */
+        public Builder<K, V> pollTimeout(Duration pollTimeout) {
+            this.pollTimeout = pollTimeout;
+            return this;
+        }
+
+        /**
+         * Sets the mode of acknowledgement queuing for offsets that are allowed to be committed.
+         * In STRICT mode, every offset of every received record is made eligible for commit. In
+         * COMPACT mode, commitment of any given record's offset may be skipped if a record that is
+         * sequentially after it has already been acknowledged.
+         */
+        public Builder<K, V> acknowledgementQueueMode(AcknowledgementQueueMode acknowledgementQueueMode) {
+            this.acknowledgementQueueMode = acknowledgementQueueMode;
+            return this;
+        }
+
+        /**
+         * Sets a number of record acknowledgements that will trigger offset commit scheduling.
+         * Defaults to {@link Integer#MAX_VALUE} (so commits solely happen periodically).
+         */
+        public Builder<K, V> commitBatchSize(int commitBatchSize) {
+            this.commitBatchSize = commitBatchSize;
+            return this;
+        }
+
+        /**
+         * Sets the period of processing acknowledgement after which records acknowledged during a
+         * given period will be committed. Every commit period starts with the (positive)
+         * acknowledgement of a record and will terminate after the provided period has elapsed, at
+         * which point any partitions with records acknowledged during the period will have the
+         * latest acknowledged offsets committed. The next period begins with the next
+         * acknowledgement of a record, and the process repeats. Note that longer periods may
+         * result in higher re-processing likelihood on rebalance(s), whereas as shorter periods
+         * may cause observable Consumer overhead due to frequent commits. Defaults to 5 seconds.
+         */
+        public Builder<K, V> commitPeriod(Duration commitPeriod) {
+            this.commitPeriod = commitPeriod;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of attempts that will be made to acknowledge offsets for any
+         * given assigned partition. This is a consecutive commit attempt measurement, so upon
+         * successful offset committing, the attempt count for the associated partition(s) is
+         * reset.
+         */
+        public Builder<K, V> maxCommitAttempts(int maxCommitAttempts) {
+            this.maxCommitAttempts = maxCommitAttempts;
+            return this;
+        }
+
+        /**
+         * Configures whether offset commitment is disabled, which can be useful for stateless
+         * consumption.
+         */
+        public Builder<K, V> commitlessOffsets(boolean commitlessOffsets) {
+            this.commitlessOffsets = commitlessOffsets;
+            return this;
+        }
+
+        /**
+         * Configures the maximum amount of time that will be awaited for in-flight records to be
+         * acknowledged from a partition whose assignment is being revoked. The latest acknowledged
+         * offsets from such a partition are then used to issue one last commit before
+         * processing/rebalancing is allowed to continue. Note that if it is intended for record
+         * acknowledgements to be skipped, this should be set to {@link Duration#ZERO zero} such
+         * that consumption continuation does not wait on acknowledgement(s) that will never
+         * happen.
+         */
+        public Builder<K, V> revocationGracePeriod(Duration revocationGracePeriod) {
+            this.revocationGracePeriod = revocationGracePeriod;
+            return this;
+        }
+
+        /**
+         * Configures the timeout used on invocations to {@link Consumer#close(Duration)}, which is
+         * invoked upon either downstream cancellation or reception errors.
+         */
+        public Builder<K, V> closeTimeout(Duration closeTimeout) {
+            this.closeTimeout = closeTimeout;
+            return this;
+        }
+
+        public KafkaReceiverOptions<K, V> build() {
+            return new KafkaReceiverOptions<>(
+                consumerFactory,
+                consumerListenerFactory,
+                receptionListenerFactory,
+                pollStrategyFactory,
+                auxiliarySchedulerSupplier,
+                consumerProperties,
+                fullPollRecordsPrefetch,
+                maxActiveInFlight,
+                pollTimeout,
+                acknowledgementQueueMode,
+                commitBatchSize,
+                commitPeriod,
+                maxCommitAttempts,
+                commitlessOffsets,
+                revocationGracePeriod,
+                closeTimeout);
+        }
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/KafkaReceiverRecord.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaReceiverRecord.java
@@ -1,0 +1,72 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.function.Consumer;
+
+/**
+ * A wrapper around a received Kafka {@link ConsumerRecord} that has been emitted and should be
+ * acknowledged, either positively or negatively (with a {@link Throwable} error).
+ *
+ * @param <K> The type of key contained in this record's ConsumerRecord
+ * @param <V> The type of value contained in this record's ConsumerRecord
+ */
+public final class KafkaReceiverRecord<K, V> {
+
+    private final ConsumerRecord<K, V> consumerRecord;
+
+    private final Runnable acknowledger;
+
+    private final Consumer<Throwable> nacknowledger;
+
+    private KafkaReceiverRecord(
+        ConsumerRecord<K, V> consumerRecord,
+        Runnable acknowledger,
+        Consumer<Throwable> nacknowledger
+    ) {
+        this.consumerRecord = consumerRecord;
+        this.acknowledger = acknowledger;
+        this.nacknowledger = nacknowledger;
+    }
+
+    public static <K, V> KafkaReceiverRecord<K, V> create(
+        ConsumerRecord<K, V> consumerRecord,
+        Runnable acknowledger,
+        Consumer<Throwable> nacknowledger
+    ) {
+        return new KafkaReceiverRecord<>(consumerRecord, acknowledger, nacknowledger);
+    }
+
+    public TopicPartition topicPartition() {
+        return ConsumerRecordExtraction.topicPartition(consumerRecord);
+    }
+
+    public K key() {
+        return consumerRecord.key();
+    }
+
+    public V value() {
+        return consumerRecord.value();
+    }
+
+    public ConsumerRecord<K, V> consumerRecord() {
+        return consumerRecord;
+    }
+
+    public void acknowledge() {
+        acknowledger.run();
+    }
+
+    public Runnable acknowledger() {
+        return acknowledger;
+    }
+
+    public void nacknowledge(Throwable error) {
+        nacknowledger.accept(error);
+    }
+
+    public Consumer<Throwable> nacknowledger() {
+        return nacknowledger;
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/KafkaSender.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaSender.java
@@ -1,0 +1,176 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+
+import java.util.Map;
+
+/**
+ * A reactive sender for Kafka {@link org.apache.kafka.clients.producer.ProducerRecord records},
+ * wrapped as {@link KafkaSenderRecord}. This class provides a high-level API for producing records
+ * to Kafka topics in a non-blocking, asynchronous, and backpressure-aware manner using Reactor.
+ * <p>
+ * Each instance of {@code KafkaSender} manages its own Kafka
+ * {@link org.apache.kafka.clients.producer.Producer}. Records can be sent with or without custom
+ * correlation metadata, and results are emitted as {@link KafkaSenderResult} objects, which
+ * provide access to Kafka metadata and any error that occurred during sending.
+ * <p>
+ * This sender supports transactional sending when configured appropriately (setting
+ * {@link org.apache.kafka.clients.producer.ProducerConfig#TRANSACTIONAL_ID_CONFIG}), allowing
+ * for atomic writes of multiple records (and offset commits if/when transaction manager is also
+ * used for reception).
+ *
+ * @param <K> The type of keys in records produced by this sender
+ * @param <V> The type of values in records produced by this sender
+ */
+public final class KafkaSender<K, V> {
+
+    private final KafkaSenderOptions<K, V> options;
+
+    private final Mono<SendingProducer<K, V>> futureProducer;
+
+    private final Sinks.Many<Long> closeSink = Sinks.many().multicast().directBestEffort();
+
+    private KafkaSender(KafkaSenderOptions<K, V> options) {
+        this.options = options;
+        this.futureProducer = Mono.fromSupplier(() -> new SendingProducer<>(options))
+            .cacheInvalidateWhen(
+                it -> Mono.firstWithSignal(it.closed(), closeSink.asFlux().next().then()),
+                SendingProducer::closeSafelyAsync);
+    }
+
+    public static <K, V> KafkaSender<K, V> create(KafkaSenderOptions<K, V> options) {
+        return new KafkaSender<>(options);
+    }
+
+    /**
+     * Sends a single {@link KafkaSenderRecord} to Kafka. The resulting Mono will either emit an
+     * error if the send operation fails, or a {@link KafkaSenderResult} if the send operation
+     * succeeds.
+     *
+     * @param senderRecord The record to send
+     * @param <T>          The type of correlation metadata
+     * @return a {@link Mono} emitting the result of the send operation
+     */
+    public <T> Mono<KafkaSenderResult<T>> send(KafkaSenderRecord<K, V, T> senderRecord) {
+        return Mono.just(senderRecord).as(this::send).single();
+    }
+
+    /**
+     * Sends a stream of {@link KafkaSenderRecord}s to Kafka and emits results for each record as
+     * they are returned from the underlying producer. Errors are propagated immediately and
+     * terminate the stream.
+     *
+     * @param senderRecords The publisher of records to send
+     * @param <T>           The type of correlation metadata
+     * @return a {@link Flux} emitting (successful) results for each sent record
+     */
+    public <T> Flux<KafkaSenderResult<T>> send(Publisher<KafkaSenderRecord<K, V, T>> senderRecords) {
+        return futureProducer.flatMapMany(producer -> SendPublisher.immediateError(options, producer, senderRecords));
+    }
+
+    /**
+     * Sends a stream of {@link KafkaSenderRecord}s to Kafka and emits results for each record as
+     * they are returned from the underlying producer. Errors are delegated to the client for
+     * handling by encapsulating both send failures and successes in emitted results.
+     *
+     * @param senderRecords The publisher of records to send
+     * @param <T>           The type of correlation metadata
+     * @return a {@link Flux} emitting results for each sent record, with errors delegated per record
+     */
+    public <T> Flux<KafkaSenderResult<T>> sendDelegateError(Publisher<KafkaSenderRecord<K, V, T>> senderRecords) {
+        return futureProducer.flatMapMany(producer -> SendPublisher.delegateError(options, producer, senderRecords));
+    }
+
+    /**
+     * Sends a stream of {@link KafkaSenderRecord}s to Kafka and emits results for each record as
+     * they are returned from the producer. Errors are delayed until all records have been
+     * processed, after which the first-occurring send error is propagated as an error signal.
+     *
+     * @param senderRecords The publisher of records to send
+     * @param <T>           The type of correlation metadata
+     * @return a {@link Flux} emitting results for each sent record
+     */
+    public <T> Flux<KafkaSenderResult<T>> sendDelayError(Publisher<KafkaSenderRecord<K, V, T>> senderRecords) {
+        return futureProducer.flatMapMany(producer -> SendPublisher.delayError(options, producer, senderRecords));
+    }
+
+    /**
+     * Sends batches of records to Kafka in separate transactions, ensuring atomicity per batch.
+     * Each inner {@link Publisher} represents a batch of records sent in a single transaction
+     * session.
+     *
+     * @param batches A publisher of record batches, each sent in separate transaction sessions
+     * @param <T>     The type of correlation metadata
+     * @return a {@link Flux} emitting results for each sent record
+     */
+    public <T> Flux<KafkaSenderResult<T>> sendTransactional(
+        Publisher<? extends Publisher<KafkaSenderRecord<K, V, T>>> batches
+    ) {
+        return futureProducer
+            .delayUntil(SendingProducer::initTransactions)
+            .flatMapMany(producer -> Flux.from(batches).concatMap(batch -> sendTransactional(producer, batch)));
+    }
+
+    /**
+     * Provides a transaction manager that facilitates transaction operations on the underlying
+     * Kafka producer. This manager can be used to begin, commit, and abort transactions, ensuring
+     * atomicity and consistency when producing records to Kafka. When combined with transactional
+     * reception from Kafka, this can be used to accomplish exactly-once processing semantics.
+     *
+     * @return a {@link Mono} that will emit an initialized transaction manager
+     */
+    public Mono<KafkaTxManager> txManager() {
+        return futureProducer.delayUntil(SendingProducer::initTransactions).map(ProducerTxManager::new);
+    }
+
+    public void close() {
+        closeSink.tryEmitNext(System.currentTimeMillis());
+    }
+
+    private <T> Flux<KafkaSenderResult<T>> sendTransactional(
+        SendingProducer<K, V> producer,
+        Publisher<KafkaSenderRecord<K, V, T>> senderRecords
+    ) {
+        return Flux.usingWhen(
+            producer.beginTransaction().thenReturn(producer),
+            transactionalProducer -> SendPublisher.immediateError(options, transactionalProducer, senderRecords),
+            SendingProducer::commitTransaction,
+            (transactionalProducer, error) -> transactionalProducer.abortTransaction(),
+            SendingProducer::abortTransaction);
+    }
+
+    private static final class ProducerTxManager implements KafkaTxManager {
+
+        private final SendingProducer<?, ?> producer;
+
+        public ProducerTxManager(SendingProducer<?, ?> producer) {
+            this.producer = producer;
+        }
+
+        @Override
+        public Mono<Void> begin() {
+            return producer.beginTransaction();
+        }
+
+        @Override
+        public Mono<Void> sendOffsets(Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata metadata) {
+            return producer.sendOffsetsToTransaction(offsets, metadata);
+        }
+
+        @Override
+        public Mono<Void> commit() {
+            return producer.commitTransaction();
+        }
+
+        @Override
+        public Mono<Void> abort() {
+            return producer.abortTransaction();
+        }
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/KafkaSenderOptions.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaSenderOptions.java
@@ -1,0 +1,223 @@
+package io.atleon.kafka;
+
+import io.atleon.util.ConfigLoading;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import reactor.util.concurrent.Queues;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Options used to configure the reactive sending of records to Kafka.
+ *
+ * @param <K> The type of keys in sent records
+ * @param <V> The type of values in sent records
+ */
+public final class KafkaSenderOptions<K, V> {
+
+    private static final Duration DEFAULT_CLOSE_TIMEOUT = Duration.ofSeconds(30L); // Kafka default
+
+    private final Function<Map<String, Object>, Producer<K, V>> producerFactory;
+
+    private final ProducerListenerFactory producerListenerFactory;
+
+    private final Map<String, Object> producerProperties;
+
+    private final int maxInFlight;
+
+    private final boolean sendImmediate;
+
+    private final Duration closeTimeout;
+
+    private KafkaSenderOptions(
+        Function<Map<String, Object>, Producer<K, V>> producerFactory,
+        ProducerListenerFactory producerListenerFactory,
+        Map<String, Object> producerProperties,
+        int maxInFlight,
+        boolean sendImmediate,
+        Duration closeTimeout
+    ) {
+        this.producerFactory = producerFactory;
+        this.producerListenerFactory = producerListenerFactory;
+        this.producerProperties = producerProperties;
+        this.maxInFlight = maxInFlight;
+        this.sendImmediate = sendImmediate;
+        this.closeTimeout = closeTimeout;
+        validate();
+    }
+
+    public static <K, V> KafkaSenderOptions<K, V> defaultOptions() {
+        return KafkaSenderOptions.<K, V>newBuilder().build();
+    }
+
+    public static <K, V> Builder<K, V> newBuilder() {
+        return new Builder<>(KafkaProducer::new);
+    }
+
+    /**
+     * Creates a new builder that will use the provided factory to create Consumer instances on a
+     * per-sender basis.
+     */
+    public static <K, V> Builder<K, V> newBuilder(Function<Map<String, Object>, Producer<K, V>> producerFactory) {
+        return new Builder<>(producerFactory);
+    }
+
+    /**
+     * Creates a new Producer instance that will be used to send records to Kafka.
+     */
+    public Producer<K, V> createProducer() {
+        return producerFactory.apply(producerProperties);
+    }
+
+    /**
+     * Creates a new {@link ProducerListener} based on a reactive handle to the active Producer
+     * instance.
+     */
+    public ProducerListener createProducerListener(ProducerInvocable invocable) {
+        return producerListenerFactory.create(invocable);
+    }
+
+    public String loadProducerTaskLoopName() {
+        return "atleon-kafka-send-producer-" + loadClientId();
+    }
+
+    public String loadClientId() {
+        return ConfigLoading.loadStringOrThrow(producerProperties, CommonClientConfigs.CLIENT_ID_CONFIG);
+    }
+
+    /**
+     * @see Builder#maxInFlight(int)
+     */
+    public int maxInFlight() {
+        return maxInFlight;
+    }
+
+    /**
+     * @see Builder#sendImmediate(boolean)
+     */
+    public boolean sendImmediate() {
+        return sendImmediate;
+    }
+
+    /**
+     * @see Builder#closeTimeout(Duration)
+     */
+    public Duration closeTimeout() {
+        return closeTimeout;
+    }
+
+    private void validate() {
+        if (maxInFlight <= 0) {
+            throw new IllegalArgumentException("maxInFlight must be positive");
+        }
+    }
+
+    public static final class Builder<K, V> {
+
+        private final Function<Map<String, Object>, Producer<K, V>> producerFactory;
+
+        private ProducerListenerFactory producerListenerFactory = ProducerListenerFactory.noOp();
+
+        private Map<String, Object> producerProperties = Collections.emptyMap();
+
+        private int maxInFlight = Queues.SMALL_BUFFER_SIZE;
+
+        private boolean sendImmediate = false;
+
+        private Duration closeTimeout = DEFAULT_CLOSE_TIMEOUT;
+
+        private Builder(Function<Map<String, Object>, Producer<K, V>> producerFactory) {
+            this.producerFactory = producerFactory;
+        }
+
+        /**
+         * Configures a singleton {@link ProducerListenerFactory} that wraps the provided
+         * listener.
+         */
+        public Builder<K, V> producerListener(ProducerListener producerListener) {
+            return producerListenerFactory(ProducerListenerFactory.singleton(producerListener));
+        }
+
+        /**
+         * Configures the factory that's used to create {@link ProducerListener} instances on a
+         * per-sender basis. Defaults to no-op.
+         */
+        public Builder<K, V> producerListenerFactory(ProducerListenerFactory producerListenerFactory) {
+            this.producerListenerFactory = producerListenerFactory;
+            return this;
+        }
+
+        /**
+         * Sets a single native {@link ProducerConfig Kafka Producer property} used to configure
+         * created Producer instances.
+         */
+        public Builder<K, V> producerProperty(String key, Object value) {
+            Map<String, Object> consumerProperties = new HashMap<>(this.producerProperties);
+            consumerProperties.put(key, value);
+            return producerProperties(consumerProperties);
+        }
+
+        /**
+         * Sets the native {@link ProducerConfig Kafka Producer properites} that are used to
+         * configure created Producer instances.
+         */
+        public Builder<K, V> producerProperties(Map<String, Object> producerProperties) {
+            this.producerProperties = producerProperties;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of records that are allowed to have their sending initiated, and
+         * for which we are awaiting a result (of either success or failure).
+         */
+        public Builder<K, V> maxInFlight(int maxInFlight) {
+            this.maxInFlight = maxInFlight;
+            return this;
+        }
+
+        /**
+         * By default, invocations of {@link Producer#send(ProducerRecord, Callback)} have their
+         * execution serialized (using a single-threaded {@link java.util.concurrent.Executor})
+         * in a Producer-specific task loop. In general, this isolation is desirable because it is
+         * possible for send invocations to block. For example:
+         * - Waiting on metadata (for up to {@link ProducerConfig#MAX_BLOCK_MS_CONFIG})
+         * - I/O-bound serialization (e.g. Avro schema registry integration)
+         * - Waiting to append to outbound record buffer
+         * In some cases, it may be safe and optimal to skip the task loop and immediately invoke
+         * send(s) on sending/publishing threads, for example if those threads are already amenable
+         * to blocking (i.e. "elastic" threads). This optimization may increase throughput capacity
+         * by leveraging the underlying Producer's ability to support multithreaded invocation.
+         */
+        public Builder<K, V> sendImmediate(boolean sendImmediate) {
+            this.sendImmediate = sendImmediate;
+            return this;
+        }
+
+        /**
+         * Sets the timeout used on invocations to {@link Producer#close(Duration)}.
+         */
+        public Builder<K, V> closeTimeout(Duration closeTimeout) {
+            this.closeTimeout = closeTimeout;
+            return this;
+        }
+
+        public KafkaSenderOptions<K, V> build() {
+            return new KafkaSenderOptions<>(
+                producerFactory,
+                producerListenerFactory,
+                producerProperties,
+                maxInFlight,
+                sendImmediate,
+                closeTimeout
+            );
+        }
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/KafkaSenderRecord.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaSenderRecord.java
@@ -1,0 +1,82 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Header;
+
+/**
+ * An extension of {@link ProducerRecord} that can be sent reactively.
+ *
+ * @param <K> The type of keys in this record
+ * @param <V> The type of values in this record
+ */
+public final class KafkaSenderRecord<K, V, T> extends ProducerRecord<K, V> {
+
+    private final T correlationMetadata;
+
+    private KafkaSenderRecord(
+        String topic,
+        Integer partition,
+        Long timestamp,
+        K key,
+        V value,
+        Iterable<Header> headers,
+        T correlationMetadata
+    ) {
+        super(topic, partition, timestamp, key, value, headers);
+        this.correlationMetadata = correlationMetadata;
+    }
+
+    public static <K, V, T> KafkaSenderRecord<K, V, T> create(
+        ProducerRecord<K, V> producerRecord,
+        T correlationMetadata
+    ) {
+        return new KafkaSenderRecord<>(
+            producerRecord.topic(),
+            producerRecord.partition(),
+            producerRecord.timestamp(),
+            producerRecord.key(),
+            producerRecord.value(),
+            producerRecord.headers(),
+            correlationMetadata
+        );
+    }
+
+    public static <K, V, T> KafkaSenderRecord<K, V, T> create(String topic, K key, V value, T correlationMetadata) {
+        return new KafkaSenderRecord<>(topic, null, null, key, value, null, correlationMetadata);
+    }
+
+    public static <K, V, T> KafkaSenderRecord<K, V, T> create(
+        String topic,
+        K key,
+        V value,
+        Iterable<Header> headers,
+        T correlationMetadata
+    ) {
+        return new KafkaSenderRecord<>(topic, null, null, key, value, headers, correlationMetadata);
+    }
+
+    public static <K, V, T> KafkaSenderRecord<K, V, T> create(
+        String topic,
+        Integer partition,
+        K key,
+        V value,
+        T correlationMetadata
+    ) {
+        return new KafkaSenderRecord<>(topic, partition, null, key, value, null, correlationMetadata);
+    }
+
+    public static <K, V, T> KafkaSenderRecord<K, V, T> create(
+        String topic,
+        Integer partition,
+        K key,
+        V value,
+        Iterable<Header> headers,
+        T correlationMetadata
+    ) {
+        return new KafkaSenderRecord<>(topic, partition, null, key, value, headers, correlationMetadata);
+    }
+
+    public T correlationMetadata() {
+        return correlationMetadata;
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/KafkaTxManager.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaTxManager.java
@@ -1,0 +1,22 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+/**
+ * A Kafka-specific manager of transactions.
+ */
+public interface KafkaTxManager {
+
+    Mono<Void> begin();
+
+    Mono<Void> sendOffsets(Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata metadata);
+
+    Mono<Void> commit();
+
+    Mono<Void> abort();
+}

--- a/kafka/src/main/java/io/atleon/kafka/PollManager.java
+++ b/kafka/src/main/java/io/atleon/kafka/PollManager.java
@@ -1,0 +1,206 @@
+package io.atleon.kafka;
+
+import io.atleon.util.Collecting;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import java.util.function.IntSupplier;
+import java.util.stream.Collectors;
+
+/**
+ * Resource through which management of polling state and polling invocation are delegated. Takes
+ * care of managing access to actively assigned partitions (with the ability to map some type of
+ * resource to each active assignment), managing pause state, and encapsulating poll
+ * quality-of-service, which includes timeout, batch size
+ * ({@link org.apache.kafka.clients.consumer.ConsumerConfig#MAX_POLL_RECORDS_CONFIG}), and
+ * delegating to a configured {@link PollStrategy} for selecting what partitions to poll per cycle.
+ *
+ * @param <T> the type of resource maintained per active assignment
+ */
+final class PollManager<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PollManager.class);
+
+    private final PollStrategy pollStrategy;
+
+    private final int maxPollRecords;
+
+    private final Duration pollTimeout;
+
+    private final AtomicBoolean pausedDueToBackpressure = new AtomicBoolean(false);
+
+    private final Set<TopicPartition> forcePaused = ConcurrentHashMap.newKeySet();
+
+    private final Map<TopicPartition, T> assignments = new ConcurrentHashMap<>();
+
+    public PollManager(PollStrategy pollStrategy, int maxPollRecords, Duration pollTimeout) {
+        this.pollStrategy = pollStrategy;
+        this.maxPollRecords = maxPollRecords;
+        this.pollTimeout = pollTimeout;
+    }
+
+    public void activateAssigned(
+        Consumer<?, ?> consumer,
+        Collection<TopicPartition> partitions,
+        Function<TopicPartition, T> activator
+    ) {
+        partitions.forEach(partition -> {
+            if (assignments.containsKey(partition)) {
+                throw new IllegalStateException("TopicPartition already assigned: " + partition);
+            }
+            assignments.put(partition, activator.apply(partition));
+        });
+
+        // Newly assigned partitions may either be paused due to external control, or need pausing
+        // because there isn't enough outstanding downstream demand (back-pressure). There is no
+        // need to let the poll strategy know about these partitions, since polling them is
+        // prohibited anyway, and even if they were permitted in the past, they MUST have been
+        // previously prohibited due to unassignment (or else exception would be thrown above). Do,
+        // however, let the strategy know about newly-assigned poll-permitted partitions.
+        Map<Boolean, ? extends Collection<TopicPartition>> permissibility = partitionByPollPermissibility(partitions);
+        Collection<TopicPartition> prohibitedPartitions = permissibility.get(false);
+        if (!prohibitedPartitions.isEmpty()) {
+            consumer.pause(prohibitedPartitions);
+        }
+        Collection<TopicPartition> permittedPartitions = permissibility.get(true);
+        if (!permittedPartitions.isEmpty()) {
+            pollStrategy.onPollingPermitted(permittedPartitions);
+        }
+    }
+
+    public Collection<T> unassigned(Collection<TopicPartition> partitions) {
+        Map<TopicPartition, T> unassigned = partitions.stream()
+            .filter(assignments::containsKey)
+            .collect(Collectors.toMap(Function.identity(), assignments::remove));
+        pollStrategy.onPollingProhibited(unassigned.keySet());
+        return unassigned.values();
+    }
+
+    public <K, V> ConsumerRecords<K, V> pollWakeably(
+        Consumer<K, V> consumer,
+        IntSupplier freeCapacitySupplier,
+        BooleanSupplier mayResumeAndPollOnWakeup
+    ) {
+        boolean shouldBePausedDueToBackpressure = freeCapacitySupplier.getAsInt() < maxPollRecords;
+        boolean backpressureStateChange = shouldBePausedDueToBackpressure != pausedDueToBackpressure.get();
+        try {
+            // Prepare for polling by letting the strategy know if we're about to perform a poll
+            // in the absence of a pause due to back-pressure. Else ensure that all assigned
+            // partitions are paused if we are transitioning to pause state due to back-pressure,
+            // and forego letting the strategy know (since empty preparation would be wasteful).
+            if (!shouldBePausedDueToBackpressure) {
+                pollStrategy.prepareForPoll(new ConsumerPollSelectionContext(consumer));
+            } else if (backpressureStateChange) {
+                consumer.pause(assignments.keySet());
+            }
+
+            // After successful preparation, ensure back-pressure pause state is updated if needed.
+            if (backpressureStateChange) {
+                pausedDueToBackpressure.set(shouldBePausedDueToBackpressure);
+                LOGGER.debug("{} back-pressure", shouldBePausedDueToBackpressure ? "Paused due to" : "Resumed from");
+            }
+
+            return consumer.poll(pollTimeout);
+        } catch (WakeupException wakeup) {
+            LOGGER.debug("Consumer polling woken");
+            // Check if wakeup was likely caused by freeing up capacity, and if so, retry
+            return mayResumeAndPollOnWakeup.getAsBoolean() && freeCapacitySupplier.getAsInt() >= maxPollRecords
+                ? pollWakeably(consumer, freeCapacitySupplier, mayResumeAndPollOnWakeup)
+                : ConsumerRecords.empty();
+        }
+    }
+
+    public boolean shouldWakeupOnSingularCapacityReclamation(int updatedCapacity) {
+        return updatedCapacity == maxPollRecords && pausedDueToBackpressure.get();
+    }
+
+    public void forcePause(Collection<TopicPartition> partitions) {
+        pollStrategy.onPollingProhibited(partitions);
+        forcePaused.addAll(partitions);
+    }
+
+    public void allowResumption(Collection<TopicPartition> partitions) {
+        pollStrategy.onPollingPermitted(partitions);
+        forcePaused.removeAll(partitions);
+    }
+
+    public T activated(TopicPartition topicPartition) {
+        return assignments.get(topicPartition);
+    }
+
+    private Map<Boolean, ? extends Collection<TopicPartition>> partitionByPollPermissibility(
+        Collection<TopicPartition> partitions
+    ) {
+        if (pausedDueToBackpressure.get()) {
+            Map<Boolean, Collection<TopicPartition>> result = new HashMap<>();
+            result.put(false, partitions);
+            result.put(true, Collections.emptyList());
+            return result;
+        } else if (forcePaused.isEmpty()) {
+            Map<Boolean, Collection<TopicPartition>> result = new HashMap<>();
+            result.put(false, Collections.emptyList());
+            result.put(true, partitions);
+            return result;
+        } else {
+            return partitions.stream().collect(Collectors.partitioningBy(it -> !forcePaused.contains(it)));
+        }
+    }
+
+    private final class ConsumerPollSelectionContext implements PollSelectionContext {
+
+        private final Consumer<?, ?> consumer;
+
+        private ConsumerPollSelectionContext(Consumer<?, ?> consumer) {
+            this.consumer = consumer;
+        }
+
+        @Override
+        public void selectExclusively(Set<TopicPartition> partitions) {
+            if (!forcePaused.isEmpty() && partitions.stream().anyMatch(forcePaused::contains)) {
+                throw new IllegalArgumentException("Cannot select prohibited partitions: " + partitions);
+            }
+
+            consumer.pause(Collecting.difference(assignments.keySet(), partitions));
+            consumer.resume(partitions);
+        }
+
+        @Override
+        public void selectNaturally() {
+            if (forcePaused.isEmpty()) {
+                consumer.resume(assignments.keySet());
+            } else {
+                consumer.pause(forcePaused);
+                consumer.resume(Collecting.difference(assignments.keySet(), forcePaused));
+            }
+        }
+
+        @Override
+        public Map<TopicPartition, Long> currentBatchLag(Set<TopicPartition> partitions, long defaultValue) {
+            if (!forcePaused.isEmpty() && partitions.stream().anyMatch(forcePaused::contains)) {
+                throw new IllegalArgumentException("Cannot request metadata for prohibited partitions: " + partitions);
+            }
+
+            return partitions.stream()
+                .collect(Collectors.toMap(Function.identity(), it -> currentBatchLag(it, defaultValue)));
+        }
+
+        private long currentBatchLag(TopicPartition topicPartition, long defaultValue) {
+            long currentLag = consumer.currentLag(topicPartition).orElse(Long.MAX_VALUE);
+            return currentLag == Long.MAX_VALUE ? defaultValue : (currentLag / maxPollRecords);
+        }
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/PollSelectionContext.java
+++ b/kafka/src/main/java/io/atleon/kafka/PollSelectionContext.java
@@ -1,0 +1,48 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Interface through which {@link PollStrategy} implementations may select partitions for polling
+ * and access relevant consumer metadata.
+ */
+public interface PollSelectionContext {
+
+    /**
+     * Configures the consumer to poll exclusively from the specified partitions, pausing all other
+     * assigned partitions for the subsequent poll operation.
+     *
+     * @param partitions the set of topic partitions to poll exclusively
+     */
+    void selectExclusively(Set<TopicPartition> partitions);
+
+    /**
+     * Configures the consumer to use natural partition selection for the next poll operation,
+     * allowing the consumer to poll from all assigned (and non-externally paused) partitions based
+     * on the default Kafka consumer behavior.
+     */
+    void selectNaturally();
+
+    /**
+     * Retrieves current lag in terms of the number of logical batches (as configured by
+     * {@link org.apache.kafka.clients.consumer.ConsumerConfig#MAX_POLL_RECORDS_CONFIG}) for the
+     * provided partitions. This method will return immediately, and is backed by cached metadata
+     * in the underlying consumer. It is therefore possible that not every provided partition will
+     * have lag metadata immediately available. In this case, the provided default value will be
+     * returned for each partition that does not (yet) have metadata. Note that the freshness of
+     * the underlying metadata is controlled by the consumer, and may become relatively stale for
+     * any partition that has not been actively polled for a significant period of time. It is
+     * therefore recommended that attention is given to the configuration of
+     * {@link org.apache.kafka.clients.CommonClientConfigs#METADATA_MAX_AGE_CONFIG} such as to
+     * potentially limit the max staleness of lag metadata.
+     *
+     * @param partitions   the set of partitions for which to get lag measurements
+     * @param defaultValue the default value to use when lag metadata is not immediately available
+     * @return a map of partitions to their current batch lag values
+     * @see org.apache.kafka.clients.consumer.Consumer#currentLag(TopicPartition)
+     */
+    Map<TopicPartition, Long> currentBatchLag(Set<TopicPartition> partitions, long defaultValue);
+}

--- a/kafka/src/main/java/io/atleon/kafka/PollStrategy.java
+++ b/kafka/src/main/java/io/atleon/kafka/PollStrategy.java
@@ -1,0 +1,178 @@
+package io.atleon.kafka;
+
+import io.atleon.util.Collecting;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.Supplier;
+
+/**
+ * Interface through which selection of Kafka partitions from which to poll are selected.
+ * Implementations of this interface are kept apprised of "permitted" and (subsequently)
+ * "prohibited" partitions available for polling. A request for "preparation" is performed before
+ * the invocation of every un-paused (i.e. not paused due to back-pressure) polling cycle.
+ * "Preparation" should invoke some selection of "permitted" partitions on the provided
+ * {@link PollSelectionContext}. A "permitted" partition is one that is currently assigned and not
+ * forcefully/externally paused, and a "prohibited" partition is any partition that does not meet
+ * that criteria. Note that the methods invoked on this interface are always done so via the
+ * underlying consumer polling thread, and as such, implementations need <i>not</i> be
+ * <i>thread-safe</i> nor <i>thread-compatible</i>.
+ */
+public interface PollStrategy {
+
+    /**
+     * Creates a strategy that allows the Kafka consumer to poll from all assigned and un-paused
+     * partitions using the default consumer behavior.
+     */
+    static PollStrategy natural() {
+        return new Natural();
+    }
+
+    /**
+     * Creates "balanced" polling strategy that aims to poll about half of assigned partitions on
+     * each polling cycle. The selection of partitions is based on "binary striding", which first
+     * starts by selecting every other partition, then the complement of that selection, followed
+     * by doubling the "block size" (from 1 to 2) and repeating the process to select every other
+     * two-consecutive elements, followed by complement, then doubling again such as to select
+     * every other four-consecutive elements, and so on. This process re-loops if/when doubling the
+     * block size would result in a block that is greater than the number of permitted partitions.
+     *
+     * @see io.atleon.util.Collecting#binaryStrides(Collection, Supplier)
+     */
+    static PollStrategy binaryStrides() {
+        return new BinaryStrides();
+    }
+
+    /**
+     * Creates a polling strategy that prioritizes selecting partitions with the highest lag in
+     * units of the polling batch size.
+     *
+     * @see PollSelectionContext#currentBatchLag(Set, long)
+     */
+    static PollStrategy greatestBatchLag() {
+        return new GreatestBatchLag();
+    }
+
+    /**
+     * Called when partitions become permissible for polling. This allows the strategy to update
+     * its internal state to include the newly permitted partitions.
+     *
+     * @param partitions the collection of partitions that are now permitted for polling
+     */
+    default void onPollingPermitted(Collection<TopicPartition> partitions) {
+
+    }
+
+    /**
+     * Called when partitions are no longer permissible for polling. This allows the strategy to
+     * update its internal state to exclude the prohibited partitions.
+     *
+     * @param partitions the collection of partitions that are now prohibited from polling
+     */
+    default void onPollingProhibited(Collection<TopicPartition> partitions) {
+
+    }
+
+    /**
+     * Prepares the consumer for the next poll operation by selecting which partitions should be
+     * polled based on the strategy's algorithm. This method is called before each consumer poll
+     * operation, and it is <i>highly recommended</i> that <i>some</i> selection of partitions is
+     * made.
+     *
+     * @param context the context providing access to partition selection and consumer metadata
+     */
+    void prepareForPoll(PollSelectionContext context);
+
+    final class Natural implements PollStrategy {
+
+        private Natural() {
+
+        }
+
+        @Override
+        public void prepareForPoll(PollSelectionContext context) {
+            context.selectNaturally();
+        }
+    }
+
+    final class BinaryStrides implements PollStrategy {
+
+        private final SortedSet<TopicPartition> sortedPartitions =
+            new TreeSet<>(Comparator.comparing(TopicPartition::topic).thenComparing(TopicPartition::partition));
+
+        private List<Set<TopicPartition>> selections = Collections.emptyList();
+
+        private int cycle = 0;
+
+        private BinaryStrides() {
+
+        }
+
+        @Override
+        public void onPollingPermitted(Collection<TopicPartition> partitions) {
+            if (sortedPartitions.addAll(partitions)) {
+                reset();
+            }
+        }
+
+        @Override
+        public void onPollingProhibited(Collection<TopicPartition> partitions) {
+            if (sortedPartitions.removeAll(partitions)) {
+                reset();
+            }
+        }
+
+        @Override
+        public void prepareForPoll(PollSelectionContext context) {
+            if (sortedPartitions.size() <= 1) {
+                context.selectNaturally();
+            } else {
+                context.selectExclusively(selections.get(cycle));
+                cycle = (cycle + 1) % selections.size();
+            }
+        }
+
+        private void reset() {
+            selections = Collecting.binaryStrides(sortedPartitions, LinkedHashSet::new);
+            cycle %= selections.size();
+        }
+    }
+
+    final class GreatestBatchLag implements PollStrategy {
+
+        private final Set<TopicPartition> permittedPartitions = new LinkedHashSet<>();
+
+        private GreatestBatchLag() {
+
+        }
+
+        @Override
+        public void onPollingPermitted(Collection<TopicPartition> partitions) {
+            permittedPartitions.addAll(partitions);
+        }
+
+        @Override
+        public void onPollingProhibited(Collection<TopicPartition> partitions) {
+            permittedPartitions.removeAll(partitions);
+        }
+
+        @Override
+        public void prepareForPoll(PollSelectionContext context) {
+            if (permittedPartitions.size() <= 1) {
+                context.selectNaturally();
+            } else {
+                Map<TopicPartition, Long> lag = context.currentBatchLag(permittedPartitions, Long.MAX_VALUE);
+                context.selectExclusively(Collecting.greatest(permittedPartitions, lag::get, HashSet::new));
+            }
+        }
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/PollStrategyFactory.java
+++ b/kafka/src/main/java/io/atleon/kafka/PollStrategyFactory.java
@@ -1,0 +1,37 @@
+package io.atleon.kafka;
+
+/**
+ * Factory that provides instances of {@link PollStrategy} upon beginning the consumption of
+ * records from Kafka.
+ */
+public interface PollStrategyFactory {
+
+    /**
+     * Creates a factory that always returns a "natural" polling strategy.
+     *
+     * @see PollStrategy#natural()
+     */
+    static PollStrategyFactory natural() {
+        return PollStrategy::natural;
+    }
+
+    /**
+     * Creates a factory that always returns a "binary strides" polling strategy.
+     *
+     * @see PollStrategy#binaryStrides()
+     */
+    static PollStrategyFactory binaryStrides() {
+        return PollStrategy::binaryStrides;
+    }
+
+    /**
+     * Creates a factory that always returns a "greatest batch lag" polling strategy.
+     *
+     * @see PollStrategy#greatestBatchLag()
+     */
+    static PollStrategyFactory greatestBatchLag() {
+        return PollStrategy::greatestBatchLag;
+    }
+
+    PollStrategy create();
+}

--- a/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
+++ b/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
@@ -1,0 +1,758 @@
+package io.atleon.kafka;
+
+import io.atleon.core.SerialQueue;
+import io.atleon.core.ShouldBeTerminatedEmitFailureHandler;
+import io.atleon.util.Consuming;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Operators;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Scheduler;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+final class PollingSubscriptionFactory<K, V> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PollingSubscriptionFactory.class);
+
+    private final KafkaReceiverOptions<K, V> options;
+
+    public PollingSubscriptionFactory(KafkaReceiverOptions<K, V> options) {
+        this.options = options;
+    }
+
+    public Subscription periodicCommit(
+        ConsumptionSpec consumptionSpec,
+        Subscriber<? super KafkaReceiverRecord<K, V>> subscriber
+    ) {
+        return new PeriodicCommitPoller(consumptionSpec, subscriber);
+    }
+
+    public Subscription transactional(
+        KafkaTxManager txManager,
+        ConsumptionSpec consumptionSpec,
+        Subscriber<? super KafkaReceiverRecord<K, V>> subscriber
+    ) {
+        return new TransactionalPoller(txManager, consumptionSpec, subscriber);
+    }
+
+    private static void runSafely(Runnable task, String name) {
+        try {
+            task.run();
+        } catch (Exception e) {
+            LOGGER.error("Unexpected failure: name={}", name, e);
+        }
+    }
+
+    private static <T> Flux<T> mergeGreedily(Collection<? extends Publisher<? extends T>> sources) {
+        // Use merge method that takes explicit concurrency so that all provided publishers are
+        // immediately (i.e. "greedily") subscribed.
+        return Flux.merge(Flux.fromIterable(sources), sources.size());
+    }
+
+    private abstract class Poller implements Subscription, ReceivingConsumer.PartitionListener {
+
+        protected final ReceivingConsumer<K, V> receivingConsumer;
+
+        protected final Scheduler auxiliaryScheduler;
+
+        private final ConsumptionSpec consumptionSpec;
+
+        private final Subscriber<? super KafkaReceiverRecord<K, V>> subscriber;
+
+        private final ReceptionListener listener;
+
+        private final PollManager<ActivePartition> pollManager;
+
+        private final AtomicInteger freePrefetchCapacity = new AtomicInteger(options.calculateMaxRecordsPrefetch());
+
+        // This counter doubles as both our publishing state (via polarity: non-negative == ACTIVE,
+        // negative == TERMINABLE or TERMINATED) and (when non-negative) our count of activated
+        // in-flight records. As such, when this first becomes negative, it means we have entered a
+        // TERMINABLE state (error or cancellation). When it is set to Long.MIN_VALUE it means
+        // we've reached TERMINATED state and termination has been enqueued.
+        private final AtomicLong freeActiveInFlightCapacity = new AtomicLong(options.maxActiveInFlight());
+
+        // Initialized as negative to indicate "no initial request" (yet).
+        private final AtomicLong requested = new AtomicLong(Long.MIN_VALUE);
+
+        private final Queue<EmittableRecord<K, V>> emittableRecords = new ConcurrentLinkedQueue<>();
+
+        private final AtomicReference<Throwable> error = new AtomicReference<>();
+
+        private final AtomicInteger drainsInProgress = new AtomicInteger(0);
+
+        public Poller(ConsumptionSpec consumptionSpec, Subscriber<? super KafkaReceiverRecord<K, V>> subscriber) {
+            this.receivingConsumer = new ReceivingConsumer<>(options, this, this::failSafely);
+            this.auxiliaryScheduler = options.createAuxiliaryScheduler();
+            this.consumptionSpec = consumptionSpec;
+            this.subscriber = subscriber;
+            this.listener = options.createReceptionListener();
+            this.pollManager =
+                new PollManager<>(options.createPollStrategy(), options.loadMaxPollRecords(), options.pollTimeout());
+        }
+
+        @Override
+        public final void request(long n) {
+            if (!Operators.validate(n)) {
+                return;
+            }
+
+            long previousRequested = requested.getAndUpdate(it -> it == Long.MIN_VALUE ? n : Operators.addCap(it, n));
+            if (previousRequested == Long.MIN_VALUE) {
+                // Initial request, so subscribe and begin polling.
+                receivingConsumer.subscribe(consumptionSpec, this::pollAndDrain);
+            } else if (previousRequested == 0) {
+                // Request had been exhausted and could have been limiting emission, so must drain.
+                drain();
+            }
+        }
+
+        @Override
+        public final void cancel() {
+            if (freeActiveInFlightCapacity.getAndUpdate(it -> it >= 0 ? -1 : it) >= 0) {
+                drain();
+            }
+        }
+
+        @Override
+        public final void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+            pollManager.activateAssigned(consumer, partitions, partition -> {
+                ActivePartition activePartition = new ActivePartition(partition, options.acknowledgementQueueMode());
+                onPartitionActivated(consumer, activePartition);
+                listener.onPartitionActivated(partition);
+
+                activePartition.deactivatedRecordCounts()
+                    .subscribe(it -> handleRecordsDeactivated(partition, it), this::failSafely);
+
+                return activePartition;
+            });
+        }
+
+        @Override
+        public final void onPartitionsRevoked(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+            Collection<ActivePartition> revokedPartitions = pollManager.unassigned(partitions);
+
+            try {
+                onActivePartitionsRevoked(consumer, revokedPartitions);
+            } finally {
+                revokedPartitions.forEach(it -> listener.onPartitionDeactivated(it.topicPartition()));
+            }
+        }
+
+        @Override
+        public final void onPartitionsLost(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+            // No longer assigned, so impossible to commit, and all we can do is clean up.
+            Map<TopicPartition, Long> lostPartitionRecordCounts = pollManager.unassigned(partitions).stream()
+                .map(it -> it.deactivateForcefully().map(recordCount -> Tuples.of(it.topicPartition(), recordCount)))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), PollingSubscriptionFactory::mergeGreedily))
+                .collectMap(Tuple2::getT1, Tuple2::getT2)
+                .block();
+
+            try {
+                onActivePartitionsLost(lostPartitionRecordCounts);
+            } finally {
+                lostPartitionRecordCounts.keySet().forEach(listener::onPartitionDeactivated);
+            }
+        }
+
+        @Override
+        public final void onExternalPartitionsPauseRequested(Collection<TopicPartition> partitions) {
+            pollManager.forcePause(partitions);
+        }
+
+        @Override
+        public final void onExternalPartitionsResumeRequested(Collection<TopicPartition> partitions) {
+            pollManager.allowResumption(partitions);
+        }
+
+        protected abstract void onPartitionActivated(Consumer<?, ?> consumer, ActivePartition partition);
+
+        protected abstract void onActivePartitionsRevoked(
+            Consumer<?, ?> consumer,
+            Collection<ActivePartition> partitions
+        );
+
+        protected abstract void onActivePartitionsLost(Map<TopicPartition, Long> lostPartitionRecordCounts);
+
+        protected final void drain() {
+            if (drainsInProgress.getAndIncrement() != 0) {
+                return;
+            }
+
+            int missed = 1;
+            do {
+                // Handle onNext emission, update outstanding capacities, and re-trigger drain loop
+                // if we exhaust whatever resource first limits emission. This makes it such that
+                // we don't need to invoke drain every time a possibly-limiting resource is updated
+                // (request, active cap, etc.), unless/until it is updated from (or to) zero.
+                long maxToEmit = prepareForActiveEmit();
+                if (maxToEmit > 0) {
+                    long activeEmitted = emitActivatedRecords(maxToEmit);
+                    if (freeActiveInFlightCapacity.get() != Long.MAX_VALUE) {
+                        freeActiveInFlightCapacity.addAndGet(-activeEmitted);
+                    }
+                    if (requested.get() != Long.MAX_VALUE) {
+                        requested.addAndGet(-activeEmitted);
+                    }
+                    if (maxToEmit == activeEmitted) {
+                        drainsInProgress.incrementAndGet();
+                    }
+                }
+
+                // Handle termination if now is the time to do so. Don't need CAS here since this
+                // is the only place to transition to TERMINATED (Long.MIN_VALUE).
+                if (freeActiveInFlightCapacity.get() < 0 && freeActiveInFlightCapacity.get() != Long.MIN_VALUE) {
+                    terminateSafely();
+                    freeActiveInFlightCapacity.set(Long.MIN_VALUE);
+                    receivingConsumer.wakeupSafely();
+                }
+
+                missed = drainsInProgress.addAndGet(-missed);
+            } while (missed != 0);
+        }
+
+        protected long prepareForActiveEmit() {
+            return emittableRecords.isEmpty() ? 0L : Math.min(freeActiveInFlightCapacity.get(), requested.get());
+        }
+
+        protected boolean mayContinueActiveEmit() {
+            return active();
+        }
+
+        protected void handleRecordActivated(TopicPartition topicPartition) {
+            listener.onRecordsActivated(topicPartition, 1L);
+        }
+
+        protected boolean handleRecordsDeactivated(TopicPartition topicPartition, long count) {
+            listener.onRecordsDeactivated(topicPartition, count);
+            if (freeActiveInFlightCapacity.getAndUpdate(it -> it >= 0 && it != Long.MAX_VALUE ? it + count : it) == 0) {
+                drain();
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        protected abstract void terminate();
+
+        protected final void failSafely(Throwable failure) {
+            if (!active() || !error.compareAndSet(null, failure)) {
+                // Failures during termination and failures that don't initiate termination can be
+                // safely dropped.
+                LOGGER.info("Ignoring failure during termination", failure);
+            } else if (freeActiveInFlightCapacity.getAndUpdate(it -> it >= 0 ? -1 : it) >= 0) {
+                // Could be racing with cancellation, but it's not a spec violation if onError
+                // emission is concurrent with downstream cancellation.
+                drain();
+            }
+        }
+
+        private void pollAndDrain(Consumer<K, V> consumer) {
+            if (freeActiveInFlightCapacity.get() == Long.MIN_VALUE) {
+                return;
+            }
+
+            //FUTURE Could wrap this in protected "poll" method, override to support at-most-once
+            ConsumerRecords<K, V> consumerRecords =
+                pollManager.pollWakeably(consumer, freePrefetchCapacity::get, this::active);
+
+            int queuedForEmission = 0;
+            for (TopicPartition partition : consumerRecords.partitions()) {
+                ActivePartition activePartition = pollManager.activated(partition);
+                for (ConsumerRecord<K, V> consumerRecord : consumerRecords.records(partition)) {
+                    emittableRecords.add(new EmittableRecord<>(activePartition, consumerRecord));
+                    queuedForEmission++;
+                }
+            }
+
+            if (queuedForEmission > 0) {
+                freePrefetchCapacity.addAndGet(-queuedForEmission);
+                drain();
+            }
+
+            receivingConsumer.schedule(this::pollAndDrain);
+        }
+
+        private long emitActivatedRecords(long maxToEmit) {
+            long emitted = 0;
+            EmittableRecord<K, V> emittable;
+            while (emitted < maxToEmit && mayContinueActiveEmit() && (emittable = emittableRecords.poll()) != null) {
+                if (pollManager.shouldWakeupOnSingularCapacityReclamation(freePrefetchCapacity.incrementAndGet())) {
+                    receivingConsumer.wakeupSafely();
+                }
+
+                KafkaReceiverRecord<K, V> activated = emittable.activateForProcessing().orElse(null);
+                try {
+                    if (activated != null) {
+                        handleRecordActivated(emittable.topicPartition());
+                        subscriber.onNext(activated);
+                        emitted++;
+                    }
+                } catch (Throwable error) {
+                    LOGGER.error("Emission failure (§2.13)", error);
+                    failSafely(error);
+                }
+            }
+            return emitted;
+        }
+
+        private void terminateSafely() {
+            Throwable errorToEmit = error.get();
+            if (errorToEmit != null) {
+                runSafely(() -> subscriber.onError(errorToEmit), "subscriber::onError §2.13");
+                LOGGER.debug("Terminated due to error");
+            } else {
+                LOGGER.debug("Terminated due to cancel");
+            }
+
+            runSafely(this::terminate, "this::terminate");
+            receivingConsumer.closeSafely()
+                .doOnTerminate(() -> runSafely(listener::close, "listener::close"))
+                .doOnTerminate(() -> runSafely(auxiliaryScheduler::dispose, "periodicScheduler::dispose"))
+                .subscribe();
+        }
+
+        private boolean active() {
+            return freeActiveInFlightCapacity.get() >= 0;
+        }
+    }
+
+    private final class PeriodicCommitPoller extends Poller {
+
+        private final Disposable periodicCommit;
+
+        private final ReceptionSequenceSet sequenceSet = new ReceptionSequenceSet();
+
+        private final Sinks.Empty<Void> disposal = Sinks.empty();
+
+        private final Sinks.Many<CommittableOffset> committableOffsets =
+            Sinks.unsafe().many().unicast().onBackpressureError();
+
+        // Only reason emission failure could/should happen is if/when we're terminating with
+        // concurrent committable offset emission, hence provided failure handler.
+        private final SerialQueue<CommittableOffset> committableOffsetQueue =
+            SerialQueue.onEmitNext(committableOffsets, new ShouldBeTerminatedEmitFailureHandler(LOGGER));
+
+        public PeriodicCommitPoller(
+            ConsumptionSpec consumptionSpec,
+            Subscriber<? super KafkaReceiverRecord<K, V>> subscriber
+        ) {
+            super(consumptionSpec, subscriber);
+            this.periodicCommit = committableOffsets.asFlux()
+                .windowTimeout(options.commitBatchSize(), options.commitPeriod(), auxiliaryScheduler)
+                .concatMap(it -> it.collectMap(CommittableOffset::topicPartition, CommittableOffset::sequencedOffset))
+                .subscribe(this::scheduleCommit, this::failSafely);
+        }
+
+        @Override
+        protected void onPartitionActivated(Consumer<?, ?> consumer, ActivePartition partition) {
+            long assignmentSequence = sequenceSet.assigned(partition.topicPartition());
+            java.util.function.Consumer<AcknowledgedOffset> acknowledgedOffsetHandler = options.commitlessOffsets()
+                ? Consuming.noOp()
+                : it -> committableOffsetQueue.addAndDrain(new CommittableOffset(it, assignmentSequence));
+            partition.acknowledgedOffsets().subscribe(acknowledgedOffsetHandler, this::failSafely);
+        }
+
+        @Override
+        protected void onActivePartitionsRevoked(Consumer<?, ?> consumer, Collection<ActivePartition> partitions) {
+            // Get the latest committable offsets for the partitions that have been revoked (with
+            // possible grace period), such that we can commit them synchronously. Although it is
+            // possible that these offsets may have been previously committed, it is unlikely that
+            // this redundancy is significantly undesirable. Under low load, the overhead of a
+            // synchronous commit is not likely to meaningfully degrade already-low throughput. As
+            // load increases, so does the likelihood that there will be acknowledged uncommitted
+            // offsets, and it becomes more desirable to attempt to honor that progress.
+            Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = partitions.stream()
+                .map(it -> it.deactivateLatest(options.revocationGracePeriod(), auxiliaryScheduler, disposal.asMono()))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), PollingSubscriptionFactory::mergeGreedily))
+                .filter(it -> sequenceSet.getCommitRetry(it.topicPartition()) < options.maxCommitAttempts() - 1)
+                .collectMap(AcknowledgedOffset::topicPartition, AcknowledgedOffset::nextOffsetAndMetadata)
+                .block();
+
+            try {
+                if (!offsetsToCommit.isEmpty() && !options.commitlessOffsets()) {
+                    consumer.commitSync(offsetsToCommit);
+                }
+            } catch (WakeupException wakeup) {
+                // There are two possible causes for a wakeup during partition revocation:
+                //   1. Async emission of records freed up capacity for subsequent polling
+                //   2. Async termination (without poll invocation consuming wakeup signal)
+                // In order to attempt graceful handling of either scenario, we retry the commit.
+                // Although it is not likely, it is possible that both scenarios occur (in order),
+                // with the first retry attempt being woken by the second scenario. In this case,
+                // we retry one LAST time. We then re-emit the original wakeup signal so that the
+                // possible parent poll invocation knows about it.
+                try {
+                    consumer.commitSync(offsetsToCommit);
+                } catch (WakeupException __) {
+                    consumer.commitSync(offsetsToCommit);
+                }
+                throw wakeup;
+            } finally {
+                // Lastly, sanitize sequence counters to account for possible in-flight commits and
+                // potential future reassignment (and signal listener about deactivation).
+                partitions.forEach(it -> sequenceSet.unassigned(it.topicPartition()));
+            }
+        }
+
+        @Override
+        protected void onActivePartitionsLost(Map<TopicPartition, Long> lostPartitionRecordCounts) {
+            lostPartitionRecordCounts.keySet().forEach(sequenceSet::unassigned);
+        }
+
+        @Override
+        protected void terminate() {
+            // Stop commit scheduling, then force disposal of in-progress deactivations.
+            periodicCommit.dispose();
+            disposal.tryEmitEmpty();
+        }
+
+        private void scheduleCommit(Map<TopicPartition, SequencedOffset> assignedOffsets) {
+            // Calculate commit sequence numbers eagerly such that invalidation may happen quickly
+            // in the case that commits are being rapidly scheduled.
+            Map<TopicPartition, Long> commitSequences = assignedOffsets.keySet().stream()
+                .collect(Collectors.toMap(Function.identity(), sequenceSet::incrementAndGetCommit));
+            receivingConsumer.schedule(consumer -> {
+                // Only need to check assignment sequence number on initial commit attempt, because
+                // we are now executing on the polling thread, and therefore any assignment changes
+                // are guaranteed to visibly increase associated commit sequence counter(s), so we
+                // can rely on that for invalidation (i.e. on retries).
+                Map<TopicPartition, OffsetAndMetadata> validatedOffsets = assignedOffsets.entrySet().stream()
+                    .filter(it -> it.getValue().sequence() == sequenceSet.getAssignment(it.getKey()))
+                    .filter(it -> commitSequences.get(it.getKey()) == sequenceSet.getCommit(it.getKey()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, it -> it.getValue().offsetAndMetadata()));
+                commit(consumer, validatedOffsets, commitSequences);
+            });
+        }
+
+        private void commit(
+            Consumer<K, V> consumer,
+            Map<TopicPartition, OffsetAndMetadata> validatedOffsets,
+            Map<TopicPartition, Long> commitSequences
+        ) {
+            if (validatedOffsets.isEmpty()) {
+                return;
+            }
+
+            consumer.commitAsync(validatedOffsets, (offsets, exception) -> {
+                if (exception == null) {
+                    offsets.keySet().forEach(sequenceSet::resetCommitRetry);
+                    return;
+                } else if (!KafkaErrors.isRetriableCommitFailure(exception)) {
+                    failSafely(exception);
+                    return;
+                }
+
+                int maxRetryCount = offsets.keySet().stream()
+                    .mapToInt(sequenceSet::getCommitRetry)
+                    .reduce(0, Math::max);
+                int remainingAttempts = options.maxCommitAttempts() - maxRetryCount - 1;
+
+                if (remainingAttempts == 0) {
+                    failSafely(new KafkaException("Retries exhausted", exception));
+                } else {
+                    LOGGER.warn("Retrying failed commit (remaining: {}): {}", remainingAttempts, exception.toString());
+                    scheduleCommitRetry(offsets, commitSequences);
+                }
+            });
+        }
+
+        private void scheduleCommitRetry(
+            Map<TopicPartition, OffsetAndMetadata> offsets,
+            Map<TopicPartition, Long> commitSequences
+        ) {
+            receivingConsumer.schedule(consumer -> {
+                Map<TopicPartition, OffsetAndMetadata> validatedOffsets = offsets.entrySet().stream()
+                    .filter(it -> commitSequences.get(it.getKey()) == sequenceSet.getCommit(it.getKey()))
+                    .peek(it -> sequenceSet.incrementCommitRetry(it.getKey()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                commit(consumer, validatedOffsets, commitSequences);
+            });
+        }
+    }
+
+    private final class TransactionalPoller extends Poller {
+
+        private final KafkaTxManager txManager;
+
+        private final Disposable transactionalOffsetsSend;
+
+        // This keeps track of our transactional state as a representation of its (remaining)
+        // capacity. Special negative values are used to represent non-OPENED states. When
+        // positive, this indicates the number of remaining records that may be emitted in a
+        // currently open transaction (configurable via commitBatchSize). When zero, it indicates
+        // we are currently waiting for all previously emitted records in an open transaction to be
+        // deactivated (finish processing), before sending offsets and/or committing the
+        // transaction.
+        private final AtomicLong capState = new AtomicLong(TxCapStates.UNOPENED);
+
+        private final AtomicLong activeInTransaction = new AtomicLong(0L);
+
+        private final Sinks.Many<TxOffsetsState> offsetsStates =
+            Sinks.many().replay().latestOrDefault(TxOffsetsState.INACTIVE);
+
+        private final Sinks.Many<AcknowledgedOffset> acknowledgedOffsets =
+            Sinks.unsafe().many().unicast().onBackpressureError();
+
+        private final SerialQueue<AcknowledgedOffset> acknowledgedOffsetsQueue =
+            SerialQueue.onEmitNext(acknowledgedOffsets, new ShouldBeTerminatedEmitFailureHandler(LOGGER));
+
+        private ConsumerGroupMetadata groupMetadata = null;
+
+        public TransactionalPoller(
+            KafkaTxManager txManager,
+            ConsumptionSpec consumptionSpec,
+            Subscriber<? super KafkaReceiverRecord<K, V>> subscriber
+        ) {
+            super(consumptionSpec, subscriber);
+            this.txManager = txManager;
+            this.transactionalOffsetsSend = acknowledgedOffsets.asFlux()
+                .windowWhen(offsetsState(TxOffsetsState.PROCESSING), __ -> offsetsState(TxOffsetsState.COMMITTING))
+                .concatMap(it ->
+                    it.collectMap(AcknowledgedOffset::topicPartition, AcknowledgedOffset::nextOffsetAndMetadata))
+                .subscribe(this::maybeSendOffsetsInCurrentTransaction, this::failSafely);
+        }
+
+        @Override
+        protected void onPartitionActivated(Consumer<?, ?> consumer, ActivePartition partition) {
+            groupMetadata = consumer.groupMetadata();
+            partition.acknowledgedOffsets().subscribe(acknowledgedOffsetsQueue::addAndDrain, this::failSafely);
+        }
+
+        @Override
+        protected void onActivePartitionsRevoked(Consumer<?, ?> consumer, Collection<ActivePartition> partitions) {
+            groupMetadata = consumer.groupMetadata();
+            Mono<TxOffsetsState> txClosure = offsetsState(TxOffsetsState.INACTIVE).next().cache();
+            partitions.stream()
+                .map(it -> it.deactivateTimeout(options.revocationGracePeriod(), auxiliaryScheduler))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), PollingSubscriptionFactory::mergeGreedily))
+                .onErrorMap(TimeoutException.class, __ -> new TimeoutException("Timed out on revocation deactivation"))
+                .takeUntilOther(txClosure)
+                .then(txClosure.timeout(options.closeTimeout(), auxiliaryScheduler))
+                .block();
+        }
+
+        @Override
+        protected void onActivePartitionsLost(Map<TopicPartition, Long> lostPartitionRecordCounts) {
+            // Losing partitions during transactional reception almost certainly indicates some
+            // form of systemic processing degradation. However, it is conceivable that partitions
+            // might be signalled as "lost" without having any participation in a recent or ongoing
+            // transaction, in which case losing them isn't necessarily fatal, and we can continue,
+            // letting transaction(s) possibly fail asynchronously due to stale group metadata.
+            if (lostPartitionRecordCounts.values().stream().anyMatch(it -> it > 0)) {
+                failSafely(new IllegalStateException("Partitions lost during transactional reception"));
+            } else {
+                LOGGER.warn("Partitions lost during transactional reception");
+            }
+        }
+
+        @Override
+        protected long prepareForActiveEmit() {
+            long nvCapState = capState.get();
+            if (nvCapState > 0) {
+                return Math.min(super.prepareForActiveEmit(), nvCapState);
+            } else if (nvCapState == 0) {
+                if (activeInTransaction.get() == 0) {
+                    emitOffsetsState(TxOffsetsState.COMMITTING);
+                }
+                return 0L;
+            } else if (nvCapState == TxCapStates.COMMITTABLE) {
+                maybeCommitCurrentTransaction();
+                return 0L;
+            } else if (nvCapState == TxCapStates.UNOPENED) {
+                if (super.prepareForActiveEmit() > 0) {
+                    maybeOpenNewTransaction();
+                }
+                return 0L;
+            } else {
+                // Note that it is impossible for current state to be ABORTABLE here, since the
+                // only way to reach that state is due to termination invocation (which is invoked
+                // from drain loop). Therefore, we don't need to worry about invoking transaction
+                // abortion from here.
+                return 0L;
+            }
+        }
+
+        @Override
+        protected boolean mayContinueActiveEmit() {
+            return super.mayContinueActiveEmit() && capState.get() > 0;
+        }
+
+        @Override
+        protected void handleRecordActivated(TopicPartition topicPartition) {
+            activeInTransaction.incrementAndGet();
+            super.handleRecordActivated(topicPartition);
+
+            if (capState.getAndUpdate(it -> Math.max(0, it - 1)) == 1) {
+                // When the capState reaches zero, we need to decrement our count of active
+                // "entities" in the transaction, since the transaction itself is included in that
+                // count. This completes transition of transaction state from ACTIVE to PENDING.
+                activeInTransaction.decrementAndGet();
+            }
+        }
+
+        @Override
+        protected boolean handleRecordsDeactivated(TopicPartition topicPartition, long count) {
+            long nowActive = activeInTransaction.addAndGet(-count);
+            boolean drained = super.handleRecordsDeactivated(topicPartition, count);
+            if (!drained && nowActive == 0) {
+                drain();
+                return true;
+            } else {
+                return drained;
+            }
+        }
+
+        @Override
+        protected void terminate() {
+            transactionalOffsetsSend.dispose();
+
+            long previousState =
+                capState.getAndUpdate(it -> it > TxCapStates.UNOPENED ? TxCapStates.ABORTABLE : TxCapStates.TERMINATED);
+            if (previousState > TxCapStates.UNOPENED) {
+                maybeAbortCurrentTransaction();
+            } else {
+                completeTermination();
+            }
+        }
+
+        private void maybeOpenNewTransaction() {
+            if (capState.compareAndSet(TxCapStates.UNOPENED, TxCapStates.OPENING)) {
+                transact(KafkaTxManager::begin, () -> {
+                    // We initialize the count of active "entities" in our transaction to 1, in
+                    // order to include the transaction itself in the count. Then, when either the
+                    // batch size is reached or the period elapses, that count is removed, which
+                    // then allows for it to hit zero, signalling commit eligibility.
+                    activeInTransaction.set(1);
+                    emitOffsetsState(TxOffsetsState.PROCESSING);
+
+                    if (capState.compareAndSet(TxCapStates.OPENING, options.commitBatchSize())) {
+                        Mono.delay(options.commitPeriod(), auxiliaryScheduler)
+                            .takeUntilOther(offsetsStates.asFlux().filter(it -> it != TxOffsetsState.PROCESSING))
+                            .filter(__ -> capState.getAndUpdate(it -> Math.min(0, it)) > 0)
+                            .doOnNext(__ -> activeInTransaction.decrementAndGet())
+                            .subscribe(__ -> drain());
+
+                        drain();
+                    }
+                });
+            }
+        }
+
+        private void maybeSendOffsetsInCurrentTransaction(Map<TopicPartition, OffsetAndMetadata> offsets) {
+            if (capState.compareAndSet(0, TxCapStates.OFFSETTING)) {
+                if (!options.commitlessOffsets()) {
+                    transact(it -> it.sendOffsets(offsets, groupMetadata), () -> {
+                        if (capState.compareAndSet(TxCapStates.OFFSETTING, TxCapStates.COMMITTABLE)) {
+                            drain();
+                        }
+                    });
+                } else if (capState.compareAndSet(TxCapStates.OFFSETTING, TxCapStates.COMMITTABLE)) {
+                    drain(); // Use drain over direct commit to ensure serial offsets state
+                }
+            }
+        }
+
+        private void maybeCommitCurrentTransaction() {
+            if (capState.compareAndSet(TxCapStates.COMMITTABLE, TxCapStates.COMMITTING)) {
+                transact(KafkaTxManager::commit, () -> {
+                    emitOffsetsState(TxOffsetsState.INACTIVE);
+                    if (capState.compareAndSet(TxCapStates.COMMITTING, TxCapStates.UNOPENED)) {
+                        drain();
+                    }
+                });
+            }
+        }
+
+        private void maybeAbortCurrentTransaction() {
+            if (capState.compareAndSet(TxCapStates.ABORTABLE, TxCapStates.ABORTING)) {
+                txManager.abort().doOnTerminate(this::completeTermination).subscribe(__ -> {}, this::failSafely);
+            }
+        }
+
+        private void transact(Function<KafkaTxManager, Mono<Void>> invocation, Runnable onSuccess) {
+            invocation.apply(txManager).subscribe(__ -> {}, this::failSafely, onSuccess);
+        }
+
+        private void completeTermination() {
+            emitOffsetsState(TxOffsetsState.INACTIVE);
+            capState.set(TxCapStates.TERMINATED);
+        }
+
+        private void emitOffsetsState(TxOffsetsState state) {
+            try {
+                offsetsStates.emitNext(state, Sinks.EmitFailureHandler.FAIL_FAST);
+            } catch (Sinks.EmissionException e) {
+                // This really shouldn't happen unless something has gone wrong with our state
+                // management. This method is only callable from either the drain loop or the
+                // transaction thread. Either has a guarantee of serial execution, and our state
+                // transition predicates should ensure mutual exclusion of emission access. Still,
+                // cover our bases and let ourselves know if such failure occurs.
+                failSafely(e);
+            }
+        }
+
+        private Flux<TxOffsetsState> offsetsState(TxOffsetsState state) {
+            return offsetsStates.asFlux().filter(it -> it == state);
+        }
+    }
+
+    private static final class TxCapStates {
+
+        // Transaction usage has been aborted and/or deactivated for future use
+        public static final long TERMINATED = Long.MIN_VALUE;
+
+        // Transaction abortion has been invoked and not yet completed
+        public static final long ABORTING = Long.MIN_VALUE + 1;
+
+        // Transaction abortion has been requested and awaiting execution
+        public static final long ABORTABLE = Long.MIN_VALUE + 2;
+
+        // Transaction is inactive and eligible to be opened
+        public static final long UNOPENED = Long.MIN_VALUE + 3;
+
+        // Transaction commitment has been invoked and not yet completed
+        public static final long COMMITTING = Long.MIN_VALUE + 4;
+
+        // Transaction commitment has been requested and awaiting execution
+        public static final long COMMITTABLE = Long.MIN_VALUE + 5;
+
+        // Transaction offset sending has been requested and awaiting execution
+        public static final long OFFSETTING = Long.MIN_VALUE + 6;
+
+        // A new transaction has been requested for opening and awaiting completion
+        public static final long OPENING = Long.MIN_VALUE + 7;
+
+        private TxCapStates() {
+
+        }
+    }
+
+    private enum TxOffsetsState {INACTIVE, PROCESSING, COMMITTING}
+}

--- a/kafka/src/main/java/io/atleon/kafka/ProducerInvocable.java
+++ b/kafka/src/main/java/io/atleon/kafka/ProducerInvocable.java
@@ -1,0 +1,23 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.producer.Producer;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * A facade around an active {@link Producer} instance that allows safely invoking (allowed)
+ * methods.
+ */
+public interface ProducerInvocable {
+
+    default Mono<Void> invoke(Consumer<Producer<?, ?>> invocation) {
+        return invokeAndGet(producer -> {
+            invocation.accept(producer);
+            return null;
+        });
+    }
+
+    <T> Mono<T> invokeAndGet(Function<? super Producer<?, ?>, T> invocation);
+}

--- a/kafka/src/main/java/io/atleon/kafka/ProducerListener.java
+++ b/kafka/src/main/java/io/atleon/kafka/ProducerListener.java
@@ -1,0 +1,60 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.producer.Producer;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+
+/**
+ * A listener interface for callbacks associated with the lifecycle of Kafka record production.
+ * Instances are created from {@link ProducerListenerFactory#create(ProducerInvocable)}, which
+ * allows for implementations to be constructed with an on-demand handle to the underlying
+ * {@link Producer} instance.
+ */
+public interface ProducerListener {
+
+    /**
+     * Creates a listener that does nothing.
+     */
+    static ProducerListener noOp() {
+        return new ProducerListener() {};
+    }
+
+    /**
+     * Creates a listener that allows subscribing to closure event.
+     */
+    static Closure closure() {
+        return new Closure();
+    }
+
+    /**
+     * Callback invoked when the provided producer is about to be closed.
+     */
+    default void onClose(Producer<?, ?> producer) {
+
+    }
+
+    /**
+     * Callback invoked after the associated producer has been closed.
+     */
+    default void close() {
+
+    }
+
+    final class Closure implements ProducerListener {
+
+        private final Sinks.Empty<Void> closed = Sinks.empty();
+
+        private Closure() {
+
+        }
+
+        @Override
+        public void close() {
+            closed.tryEmitEmpty();
+        }
+
+        public Mono<Void> closed() {
+            return closed.asMono();
+        }
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/ProducerListenerFactory.java
+++ b/kafka/src/main/java/io/atleon/kafka/ProducerListenerFactory.java
@@ -1,0 +1,29 @@
+package io.atleon.kafka;
+
+/**
+ * Factory that provides instances of {@link ProducerListener} upon beginning the production of
+ * records to Kafka.
+ */
+public interface ProducerListenerFactory {
+
+    /**
+     * Creates a factory that always returns a no-op listener.
+     */
+    static ProducerListenerFactory noOp() {
+        return singleton(ProducerListener.noOp());
+    }
+
+    /**
+     * Creates a factory that will always return the provided listener instance for each production
+     * process.
+     */
+    static ProducerListenerFactory singleton(ProducerListener listener) {
+        return __ -> listener;
+    }
+
+    /**
+     * Create a new listener with access to the active consumer instance via
+     * {@link ProducerInvocable} API.
+     */
+    ProducerListener create(ProducerInvocable invocable);
+}

--- a/kafka/src/main/java/io/atleon/kafka/ReceivingConsumer.java
+++ b/kafka/src/main/java/io/atleon/kafka/ReceivingConsumer.java
@@ -1,0 +1,192 @@
+package io.atleon.kafka;
+
+import io.atleon.core.TaskLoop;
+import io.atleon.util.Proxying;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/**
+ * A facade around an active {@link Consumer} being used for reception.
+ *
+ * @param <K> The type of keys in records polled by this consumer
+ * @param <V> The type of values in records polled by this consumer
+ */
+final class ReceivingConsumer<K, V> implements ConsumerRebalanceListener, ConsumerInvocable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReceivingConsumer.class);
+
+    private static final Set<String> ALLOWED_EXTERNAL_CONSUMER_INVOCATIONS = new HashSet<>(Arrays.asList(
+        "assignment",
+        "beginningOffsets",
+        "clientInstanceId",
+        "committed",
+        "currentLag",
+        "endOffsets",
+        "groupMetadata",
+        "listTopics",
+        "metrics",
+        "offsetsForTimes",
+        "partitionsFor",
+        "pause",
+        "paused",
+        "position",
+        "resume",
+        "seek",
+        "seekToBeginning",
+        "seekToEnd",
+        "subscription"
+    ));
+
+    private final Consumer<K, V> consumer;
+
+    private final Consumer<K, V> externalConsumerProxy;
+
+    private final PartitionListener partitionListener;
+
+    private final TaskLoop taskLoop;
+
+    private final ConsumerListener consumerListener;
+
+    private final Duration closeTimeout;
+
+    public ReceivingConsumer(
+        KafkaReceiverOptions<K, V> options,
+        PartitionListener partitionListener,
+        java.util.function.Consumer<Throwable> errorHandler
+    ) {
+        this.consumer = options.createConsumer();
+        this.externalConsumerProxy = Proxying.interfaceMethods(Consumer.class, this::invokeConsumerFromExternal);
+        this.partitionListener = partitionListener;
+        this.taskLoop = TaskLoop.start(options.loadConsumerTaskLoopName(), it -> runSafely(it, errorHandler));
+        this.consumerListener = options.createConsumerListener(this);
+        this.closeTimeout = options.closeTimeout();
+    }
+
+    @Override
+    public void onPartitionsLost(Collection<TopicPartition> partitions) {
+        onRebalance(partitionListener::onPartitionsLost, consumerListener::onPartitionsLost, partitions);
+    }
+
+    @Override
+    public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+        onRebalance(partitionListener::onPartitionsRevoked, consumerListener::onPartitionsRevoked, partitions);
+    }
+
+    @Override
+    public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+        onRebalance(partitionListener::onPartitionsAssigned, consumerListener::onPartitionsAssigned, partitions);
+    }
+
+    @Override
+    public <T> Mono<T> invokeAndGet(Function<? super Consumer<?, ?>, T> invocation) {
+        if (taskLoop.isSourceOfCurrentThread()) {
+            throw new UnsupportedOperationException("ConsumerInvocable::invokeAndGet must not be called from the" +
+                " polling thread. It should rather be the case that the Consumer is directly passed to the call site" +
+                " in some way, for example with ConsumerListener::onPartitionsAssigned.");
+        }
+        return Mono.create(sink -> taskLoop.schedule(() -> {
+            try {
+                sink.success(invocation.apply(externalConsumerProxy));
+            } catch (Throwable e) {
+                sink.error(e);
+            }
+        }));
+    }
+
+    public void subscribe(ConsumptionSpec consumptionSpec, java.util.function.Consumer<Consumer<K, V>> andThen) {
+        taskLoop.schedule(() -> {
+            consumptionSpec.apply(consumer, this);
+            andThen.accept(consumer);
+        });
+    }
+
+    public Mono<Void> closeSafely() {
+        return Mono.create(sink -> taskLoop.schedule(() -> {
+            runSafely(() -> consumerListener.onClose(consumer), "consumerListener::onClose");
+            runSafely(() -> consumer.close(closeTimeout), "consumer::close");
+            runSafely(consumerListener::close, "consumerListener::close");
+            taskLoop.disposeSafely();
+            sink.success();
+        }));
+    }
+
+    public void wakeupSafely() {
+        // It does not make sense to call wakeup if we know we're executing on the only thread that
+        // could execute a long-running call (i.e. poll), so avoid unnecessary interrupt.
+        if (!taskLoop.isSourceOfCurrentThread()) {
+            runSafely(consumer::wakeup, "consumer::wakeup");
+        }
+    }
+
+    public void schedule(java.util.function.Consumer<Consumer<K, V>> task) {
+        taskLoop.schedule(() -> task.accept(consumer));
+    }
+
+    private void onRebalance(
+        BiConsumer<Consumer<?, ?>, Collection<TopicPartition>> internalHandler,
+        BiConsumer<Consumer<?, ?>, Collection<TopicPartition>> externalHandler,
+        Collection<TopicPartition> partitions
+    ) {
+        internalHandler.accept(consumer, partitions);
+
+        // Not wrapping with try-catch. If user does something naughty, let the error be emitted.
+        externalHandler.accept(externalConsumerProxy, partitions);
+    }
+
+    private Object invokeConsumerFromExternal(Method method, Object[] args) throws ReflectiveOperationException {
+        if (!taskLoop.isSourceOfCurrentThread()) {
+            throw new UnsupportedOperationException("Kafka Consumer must be invoked from polling thread");
+        }
+        if (!ALLOWED_EXTERNAL_CONSUMER_INVOCATIONS.contains(method.getName())) {
+            throw new UnsupportedOperationException("Kafka Consumer method is not supported: " + method);
+        }
+
+        if (method.getName().equals("pause")) {
+            partitionListener.onExternalPartitionsPauseRequested((Collection<TopicPartition>) args[0]);
+            return null;
+        } else if (method.getName().equals("resume")) {
+            partitionListener.onExternalPartitionsResumeRequested((Collection<TopicPartition>) args[0]);
+            return null;
+        } else {
+            return method.invoke(consumer, args);
+        }
+    }
+
+    private static void runSafely(Runnable task, String name) {
+        runSafely(task, error -> LOGGER.error("Unexpected failure: name={}", name, error));
+    }
+
+    private static void runSafely(Runnable task, java.util.function.Consumer<Throwable> errorHandler) {
+        try {
+            task.run();
+        } catch (Throwable e) {
+            errorHandler.accept(e);
+        }
+    }
+
+    public interface PartitionListener {
+
+        void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions);
+
+        void onPartitionsRevoked(Consumer<?, ?> consumer, Collection<TopicPartition> partitions);
+
+        void onPartitionsLost(Consumer<?, ?> consumer, Collection<TopicPartition> partitions);
+
+        void onExternalPartitionsPauseRequested(Collection<TopicPartition> partitions);
+
+        void onExternalPartitionsResumeRequested(Collection<TopicPartition> partitions);
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/ReceptionListener.java
+++ b/kafka/src/main/java/io/atleon/kafka/ReceptionListener.java
@@ -1,0 +1,65 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * A listener interface for callbacks associated with the activation and deactivation of partitions
+ * from which Kafka records may be received, as well as the activation and deactivation of records
+ * received and emitted downstream. This can be useful for implementing observability around the
+ * status of assignable partitions, and the number of in-flight records for a given reception
+ * process.
+ */
+public interface ReceptionListener {
+
+    /**
+     * Creates a listener that does nothing.
+     */
+    static ReceptionListener noOp() {
+        return new ReceptionListener() {};
+    }
+
+    /**
+     * Invoked when a partition has been assigned and from which records may now be received.
+     */
+    default void onPartitionActivated(TopicPartition partition) {
+
+    }
+
+    /**
+     * Invoked when a partition has been revoked or lost, and any remaining activated records from
+     * that partition have also been deactivated.
+     */
+    default void onPartitionDeactivated(TopicPartition partition) {
+
+    }
+
+    /**
+     * Invoked when records have been received from the given partition and activated for
+     * downstream processing.
+     *
+     * @param partition The active partition from which records have been activated
+     * @param count     The number of records that have been activated
+     */
+    default void onRecordsActivated(TopicPartition partition, long count) {
+
+    }
+
+    /**
+     * Invoked when activated records which have been emitted downstream have either had their
+     * processing been completed (via positive or negative acknowledgement), or forcefully
+     * deactivated, either due to reception error downstream cancellation.
+     *
+     * @param partition The active partition from which records have been deactivated
+     * @param count     The number of records that have been deactivated
+     */
+    default void onRecordsDeactivated(TopicPartition partition, long count) {
+
+    }
+
+    /**
+     * Invoked once the reception process has been terminated.
+     */
+    default void close() {
+
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/ReceptionListenerFactory.java
+++ b/kafka/src/main/java/io/atleon/kafka/ReceptionListenerFactory.java
@@ -1,0 +1,25 @@
+package io.atleon.kafka;
+
+/**
+ * Factory that provides instances of {@link ReceptionListener} upon beginning the reception of
+ * records from Kafka.
+ */
+public interface ReceptionListenerFactory {
+
+    /**
+     * Creates a factory that always returns a no-op listener.
+     */
+    static ReceptionListenerFactory noOp() {
+        return singleton(ReceptionListener.noOp());
+    }
+
+    /**
+     * Creates a factory that will always return the provided listener instance for each
+     * consumption process.
+     */
+    static ReceptionListenerFactory singleton(ReceptionListener receptionListener) {
+        return () -> receptionListener;
+    }
+
+    ReceptionListener create();
+}

--- a/kafka/src/main/java/io/atleon/kafka/ReceptionSequenceSet.java
+++ b/kafka/src/main/java/io/atleon/kafka/ReceptionSequenceSet.java
@@ -1,0 +1,74 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Sequence counter(s) for operations on partitions that have been assigned at some point during
+ * reception.
+ */
+final class ReceptionSequenceSet {
+
+    // Monotonically increasing assignment sequence numbers. Newer sequence numbers invalidate
+    // committable offsets with older sequence numbers.
+    private final Map<TopicPartition, AtomicLong> assignments = new ConcurrentHashMap<>();
+
+    // Monotonically increasing commit sequence numbers. Newer sequence numbers invalidate offsets
+    // whose commitment is in-flight with older sequence numbers.
+    private final Map<TopicPartition, AtomicLong> commits = new ConcurrentHashMap<>();
+
+    // Consecutive commit retry sequence numbers.
+    private final Map<TopicPartition, AtomicInteger> commitRetries = new ConcurrentHashMap<>();
+
+    public long assigned(TopicPartition partition) {
+        AtomicLong assignment = assignments.computeIfAbsent(partition, __ -> new AtomicLong(0));
+        commits.computeIfAbsent(partition, __ -> new AtomicLong(0));
+        commitRetries.computeIfAbsent(partition, __ -> new AtomicInteger(0));
+        return assignment.incrementAndGet();
+    }
+
+    public void unassigned(TopicPartition partition) {
+        // For a partition that is no longer assigned, increment its assignment sequence such that
+        // emitted offsets for which commitment has not yet been attempted are invalidated,
+        // increment its commit sequence such that any offsets for which commitment is currently
+        // being attempted/retried are invalidated, and reset its commit retry count. Keep the
+        // entries for this partition around, though, in case it is quickly reassigned, which could
+        // theoretically happen while there is still an in-flight commit from previous assignment.
+        // Note that this method is always invoked from the polling thread, and the Kafka client
+        // takes care of invoking this after clearing out any in-flight asynchronous commit
+        // invocations, so none should be concurrently executing at this point. Also note that this
+        // method is only called when it is known that the provided partition was previously
+        // assigned (so no null-check is necessary).
+        assignments.get(partition).incrementAndGet();
+        incrementAndGetCommit(partition);
+        resetCommitRetry(partition);
+    }
+
+    public long getAssignment(TopicPartition partition) {
+        return assignments.get(partition).get();
+    }
+
+    public long incrementAndGetCommit(TopicPartition partition) {
+        return commits.get(partition).incrementAndGet();
+    }
+
+    public long getCommit(TopicPartition partition) {
+        return commits.get(partition).get();
+    }
+
+    public int getCommitRetry(TopicPartition partition) {
+        return commitRetries.get(partition).get();
+    }
+
+    public void incrementCommitRetry(TopicPartition partition) {
+        commitRetries.get(partition).incrementAndGet();
+    }
+
+    public void resetCommitRetry(TopicPartition partition) {
+        commitRetries.get(partition).set(0);
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/SendPublisher.java
+++ b/kafka/src/main/java/io/atleon/kafka/SendPublisher.java
@@ -1,0 +1,317 @@
+package io.atleon.kafka;
+
+import io.atleon.core.SerialQueue;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Operators;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+final class SendPublisher<K, V, T> implements Publisher<KafkaSenderResult<T>> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SendPublisher.class);
+
+    private final Publisher<? extends KafkaSenderRecord<K, V, T>> source;
+
+    private final Function<Subscriber<? super KafkaSenderResult<T>>, ? extends Send<K, V, T>> sender;
+
+    private SendPublisher(
+        Publisher<? extends KafkaSenderRecord<K, V, T>> source,
+        Function<Subscriber<? super KafkaSenderResult<T>>, ? extends Send<K, V, T>> sender
+    ) {
+        this.source = source;
+        this.sender = sender;
+    }
+
+    public static <K, V, T> SendPublisher<K, V, T> immediateError(
+        KafkaSenderOptions<K, V> options,
+        SendingProducer<K, V> producer,
+        Publisher<KafkaSenderRecord<K, V, T>> senderRecords
+    ) {
+        return new SendPublisher<>(senderRecords, it -> new CompletingSend<>(options, producer, it, false));
+    }
+
+    public static <K, V, T> SendPublisher<K, V, T> delegateError(
+        KafkaSenderOptions<K, V> options,
+        SendingProducer<K, V> producer,
+        Publisher<KafkaSenderRecord<K, V, T>> senderRecords
+    ) {
+        return new SendPublisher<>(senderRecords, it -> new CompletingSend<>(options, producer, it, true));
+    }
+
+    public static <K, V, T> SendPublisher<K, V, T> delayError(
+        KafkaSenderOptions<K, V> options,
+        SendingProducer<K, V> producer,
+        Publisher<KafkaSenderRecord<K, V, T>> senderRecords
+    ) {
+        return new SendPublisher<>(senderRecords, it -> new ErrorDelayingSend<>(options, producer, it));
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super KafkaSenderResult<T>> actual) {
+        source.subscribe(sender.apply(actual));
+    }
+
+    private static void runSafely(Runnable task, String name) {
+        try {
+            task.run();
+        } catch (Exception e) {
+            LOGGER.error("Unexpected failure: name={}", name, e);
+        }
+    }
+
+    private static abstract class Send<K, V, T> implements CoreSubscriber<KafkaSenderRecord<K, V, T>>, Subscription {
+
+        private enum State {ACTIVE, TERMINABLE, TERMINATED}
+
+        private static final AtomicLongFieldUpdater<Send> IN_FLIGHT =
+            AtomicLongFieldUpdater.newUpdater(Send.class, "inFlight");
+
+        private static final AtomicLongFieldUpdater<Send> REQUESTED =
+            AtomicLongFieldUpdater.newUpdater(Send.class, "requested");
+
+        private static final AtomicReferenceFieldUpdater<Send, State> SUBSCRIPTION_STATE =
+            AtomicReferenceFieldUpdater.newUpdater(Send.class, State.class, "subscriptionState");
+
+        private static final AtomicIntegerFieldUpdater<Send> SUBSCRIPTION_DRAINS_IN_PROGRESS =
+            AtomicIntegerFieldUpdater.newUpdater(Send.class, "subscriptionDrainsInProgress");
+
+        private final KafkaSenderOptions<K, V> options;
+
+        private final SendingProducer<K, V> producer;
+
+        private final SerialQueue<Consumer<Subscriber<? super KafkaSenderResult<T>>>> emissionQueue;
+
+        private Subscription parent;
+
+        // This counter doubles as both our publishing state (via polarity: positive == ACTIVE,
+        // negative == TERMINABLE, zero == TERMINATED) and our count of in-flight sent records (via
+        // magnitude: subtract 1 if positive, negate if negative). The extra/initializing count of
+        // 1 is in reserve for termination of this subscriber (self). As such, when this becomes
+        // non-positive, it means a terminating signal has been received from upstream OR a fatal
+        // error has been encountered on sending. When it becomes zero, it means termination has
+        // been enqueued to the downstream subscriber.
+        private volatile long inFlight = 1;
+
+        private volatile long requested = 0;
+
+        private volatile State subscriptionState = State.ACTIVE;
+
+        private volatile int subscriptionDrainsInProgress = 0;
+
+        protected Send(
+            KafkaSenderOptions<K, V> options,
+            SendingProducer<K, V> producer,
+            Subscriber<? super KafkaSenderResult<T>> actual
+        ) {
+            this.options = options;
+            this.producer = producer;
+            this.emissionQueue = SerialQueue.on(actual);
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            parent = s;
+            emissionQueue.addAndDrain(subscriber -> subscriber.onSubscribe(this));
+        }
+
+        @Override
+        public void onNext(KafkaSenderRecord<K, V, T> senderRecord) {
+            if (IN_FLIGHT.getAndUpdate(this, it -> it > 0 ? it + 1 : it) <= 0) {
+                return;
+            }
+
+            T correlationMetadata = senderRecord.correlationMetadata();
+            producer.sendSafely(senderRecord, () -> subscriptionState == State.ACTIVE, (recordMetadata, exception) -> {
+                if (exception == null) {
+                    enqueueNext(KafkaSenderResult.success(recordMetadata, correlationMetadata));
+                } else if (shouldEmitFailureAsResult(exception) && !KafkaErrors.isFatalSendFailure(exception)) {
+                    enqueueNext(KafkaSenderResult.failure(exception, correlationMetadata));
+                } else if (subscriptionState == State.ACTIVE) {
+                    cancel();
+                    onError(exception);
+                }
+            });
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (IN_FLIGHT.getAndSet(this, 0) != 0) {
+                enqueueTermination(subscriber -> subscriber.onError(t));
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (IN_FLIGHT.getAndUpdate(this, it -> it > 0 ? 1 - it : it) == 1) {
+                enqueueTermination(completionTerminator());
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            if (Operators.validate(n)) {
+                Operators.addCap(REQUESTED, this, n);
+                drainSubscription();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            if (SUBSCRIPTION_STATE.compareAndSet(this, State.ACTIVE, State.TERMINABLE)) {
+                drainSubscription();
+            }
+        }
+
+        protected abstract boolean shouldEmitFailureAsResult(Exception failure);
+
+        protected abstract Consumer<Subscriber<?>> completionTerminator();
+
+        private void enqueueNext(KafkaSenderResult<T> result) {
+            emissionQueue.addAndDrain(subscriber -> {
+                if (inFlight == 0 || subscriptionState != State.ACTIVE) {
+                    return;
+                }
+
+                try {
+                    subscriber.onNext(result);
+                } catch (Throwable error) {
+                    LOGGER.error("Emission failure (§2.13)", error);
+                    cancel();
+                    onError(error);
+                    return;
+                }
+
+                long previousInFlight = IN_FLIGHT.getAndUpdate(this, count -> {
+                    if (count > 0) {
+                        return count - 1;
+                    } else if (count == 0) {
+                        return count;
+                    } else {
+                        return count + 1;
+                    }
+                });
+
+                // If the previous in-flight count was positive, then we are not yet eligible for
+                // termination, and we should ensure that any capacity freed by emitting the last
+                // result is reflected by upstream demand. Only if the previous count was exactly
+                // -1 do we know that we are eligible for termination, and that this was the last
+                // in-flight result to emit, so we can emit termination. Note that because onError
+                // and onComplete immediately make the in-flight count non-positive, it will never
+                // be those calling threads that could also invoke drainSubscription (which would
+                // be a violation of §2.3).
+                if (previousInFlight > 0) {
+                    drainSubscription();
+                } else if (previousInFlight == -1 && subscriptionState == State.ACTIVE) {
+                    enqueueTermination(completionTerminator());
+                }
+            });
+        }
+
+        private void enqueueTermination(Consumer<Subscriber<?>> terminator) {
+            // This is only ever invoked at-most-once after termination has been signalled from
+            // upstream AND inFlight has reached zero. This could race with cancellation, but it's
+            // not a spec violation if upstream termination is concurrent with downstream cancel.
+            emissionQueue.addAndDrain(subscriber -> runSafely(() -> terminator.accept(subscriber), "Termination"));
+        }
+
+        private void drainSubscription() {
+            if (subscriptionState == State.TERMINATED || SUBSCRIPTION_DRAINS_IN_PROGRESS.getAndIncrement(this) != 0) {
+                return;
+            }
+
+            int missed = 1;
+            do {
+                if (subscriptionState == State.ACTIVE) {
+                    long toRequest = Math.min(freeInFlightSendCapacity(), requested);
+
+                    if (toRequest > 0L) {
+                        if (requested != Long.MAX_VALUE) {
+                            REQUESTED.addAndGet(this, -toRequest);
+                        }
+                        runSafely(() -> parent.request(toRequest), "parent::request");
+                    }
+                } else if (SUBSCRIPTION_STATE.compareAndSet(this, State.TERMINABLE, State.TERMINATED)) {
+                    runSafely(parent::cancel, "parent::cancel");
+                }
+
+                missed = SUBSCRIPTION_DRAINS_IN_PROGRESS.addAndGet(this, -missed);
+            } while (missed != 0);
+        }
+
+        private long freeInFlightSendCapacity() {
+            if (options.maxInFlight() == Integer.MAX_VALUE) {
+                return Long.MAX_VALUE;
+            } else {
+                long nvInFlight = inFlight;
+                // When the in-flight count is positive, it means there is still an extra count of
+                // 1 to represent the current publishing state of ACTIVE, so we need to add that
+                // back after subtracting from the max in-flight. When non-positive, the extra
+                // count has already been removed and the total count has been negated, so we just
+                // need to add.
+                return nvInFlight > 0 ? (options.maxInFlight() - nvInFlight + 1) : (options.maxInFlight() + nvInFlight);
+            }
+        }
+    }
+
+    private static final class CompletingSend<K, V, T> extends Send<K, V, T> {
+
+        private final boolean emitFailuresAsResults;
+
+        public CompletingSend(
+            KafkaSenderOptions<K, V> options,
+            SendingProducer<K, V> producer,
+            Subscriber<? super KafkaSenderResult<T>> actual,
+            boolean emitFailuresAsResults
+        ) {
+            super(options, producer, actual);
+            this.emitFailuresAsResults = emitFailuresAsResults;
+        }
+
+        @Override
+        protected boolean shouldEmitFailureAsResult(Exception failure) {
+            return emitFailuresAsResults;
+        }
+
+        @Override
+        protected Consumer<Subscriber<?>> completionTerminator() {
+            return Subscriber::onComplete;
+        }
+    }
+
+    private static final class ErrorDelayingSend<K, V, T> extends Send<K, V, T> {
+
+        private static final AtomicReferenceFieldUpdater<ErrorDelayingSend, Exception> FIRST_FAILURE =
+            AtomicReferenceFieldUpdater.newUpdater(ErrorDelayingSend.class, Exception.class, "firstFailure");
+
+        private volatile Exception firstFailure;
+
+        public ErrorDelayingSend(
+            KafkaSenderOptions<K, V> options,
+            SendingProducer<K, V> producer,
+            Subscriber<? super KafkaSenderResult<T>> actual
+        ) {
+            super(options, producer, actual);
+        }
+
+        @Override
+        protected boolean shouldEmitFailureAsResult(Exception failure) {
+            FIRST_FAILURE.compareAndSet(this, null, failure);
+            return true;
+        }
+
+        @Override
+        protected Consumer<Subscriber<?>> completionTerminator() {
+            Exception nvFirstFailure = firstFailure;
+            return nvFirstFailure != null ? subscriber -> subscriber.onError(nvFirstFailure) : Subscriber::onComplete;
+        }
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/SendingProducer.java
+++ b/kafka/src/main/java/io/atleon/kafka/SendingProducer.java
@@ -1,0 +1,206 @@
+package io.atleon.kafka;
+
+import io.atleon.core.TaskLoop;
+import io.atleon.util.Proxying;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Signal;
+import reactor.core.publisher.Sinks;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * A facade around an active {@link Producer} being used for sending.
+ *
+ * @param <K> The type of keys in records sent by this producer
+ * @param <V> The type of values in records sent by this producer
+ */
+final class SendingProducer<K, V> implements ProducerInvocable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SendingProducer.class);
+
+    private static final Set<String> ALLOWED_EXTERNAL_PRODUCER_INVOCATIONS = new HashSet<>(Arrays.asList(
+        "clientInstanceId",
+        "metrics",
+        "partitionsFor"
+    ));
+
+    private final Producer<K, V> producer;
+
+    private final Producer<K, V> externalProducerProxy;
+
+    private final TaskLoop taskLoop;
+
+    private final ProducerListener producerListener;
+
+    private final boolean sendImmediate;
+
+    private final Duration closeTimeout;
+
+    private final Sinks.Empty<Void> closed = Sinks.unsafe().empty();
+
+    // Only cache first success. Until then, let client know about errors
+    private final Mono<Void> initTransactionsCache = cacheSuccess(doOnProducer(Producer::initTransactions));
+
+    public SendingProducer(KafkaSenderOptions<K, V> options) {
+        this.producer = options.createProducer();
+        this.externalProducerProxy = Proxying.interfaceMethods(Producer.class, this::invokeProducerFromExternal);
+        this.taskLoop = TaskLoop.start(options.loadProducerTaskLoopName(), this::runProducerTaskSafely);
+        this.producerListener = options.createProducerListener(this);
+        this.sendImmediate = options.sendImmediate();
+        this.closeTimeout = options.closeTimeout();
+    }
+
+    @Override
+    public <T> Mono<T> invokeAndGet(Function<? super Producer<?, ?>, T> invocation) {
+        if (taskLoop.isSourceOfCurrentThread()) {
+            throw new UnsupportedOperationException("ProducerInvocable::invokeAndGet should not be called from Kafka" +
+                " worker thread. It should rather be the case that the Producer is directly passed to the call site" +
+                " in some way, for example with ProducerListener::onClose.");
+        }
+        return Mono.create(sink -> taskLoop.schedule(() -> {
+            try {
+                sink.success(invocation.apply(externalProducerProxy));
+            } catch (Throwable e) {
+                sink.error(e);
+            }
+        }));
+    }
+
+    public Mono<Void> initTransactions() {
+        return initTransactionsCache;
+    }
+
+    public Mono<Void> beginTransaction() {
+        return doOnProducer(Producer::beginTransaction);
+    }
+
+    public Mono<Void> sendOffsetsToTransaction(
+        Map<TopicPartition, OffsetAndMetadata> offsets,
+        ConsumerGroupMetadata metadata
+    ) {
+        return doOnProducer(it -> it.sendOffsetsToTransaction(offsets, metadata));
+    }
+
+    public Mono<Void> commitTransaction() {
+        return doOnProducer(Producer::commitTransaction);
+    }
+
+    public Mono<Void> abortTransaction() {
+        return doOnProducer(Producer::abortTransaction);
+    }
+
+    public void sendSafely(ProducerRecord<K, V> producerRecord, BooleanSupplier producePredicate, Callback callback) {
+        if (sendImmediate) {
+            send(producerRecord, producePredicate, callback);
+        } else {
+            taskLoop.schedule(() -> send(producerRecord, producePredicate, callback));
+        }
+    }
+
+    public void closeSafelyAsync() {
+        closeSafely().subscribe();
+    }
+
+    public Mono<Void> closeSafely() {
+        return Mono.create(sink -> taskLoop.schedule(() -> {
+            runSafely(() -> producerListener.onClose(externalProducerProxy), "producerListener::onClose");
+            runSafely(() -> producer.close(closeTimeout), "producer::close");
+            closed.tryEmitEmpty();
+            runSafely(producerListener::close, "producerListener::close");
+            taskLoop.disposeSafely();
+            sink.success();
+        }));
+    }
+
+    public Mono<Void> closed() {
+        return closed.asMono();
+    }
+
+    private Mono<Void> doOnProducer(Consumer<Producer<?, ?>> task) {
+        return Mono.create(sink -> taskLoop.schedule(() -> {
+            try {
+                task.accept(producer);
+                sink.success();
+            } catch (Throwable e) {
+                onProducerTaskFailure(e);
+                sink.error(e);
+            }
+        }));
+    }
+
+    private void send(ProducerRecord<K, V> producerRecord, BooleanSupplier producePredicate, Callback callback) {
+        try {
+            if (producePredicate.getAsBoolean()) {
+                producer.send(producerRecord, callback);
+            }
+        } catch (Exception error) {
+            onProducerTaskFailure(error);
+            callback.onCompletion(null, error);
+        }
+    }
+
+    private Object invokeProducerFromExternal(Method method, Object[] args) throws ReflectiveOperationException {
+        if (!taskLoop.isSourceOfCurrentThread()) {
+            throw new UnsupportedOperationException("Kafka Producer must be invoked from task thread");
+        }
+        if (!ALLOWED_EXTERNAL_PRODUCER_INVOCATIONS.contains(method.getName())) {
+            throw new UnsupportedOperationException("Kafka Producer method is not supported: " + method);
+        }
+
+        try {
+            return method.invoke(producer, args);
+        } catch (RuntimeException e) {
+            onProducerTaskFailure(e);
+            throw e;
+        }
+    }
+
+    private void runProducerTaskSafely(Runnable task) {
+        try {
+            task.run();
+        } catch (Throwable error) {
+            onProducerTaskFailure(error);
+        }
+    }
+
+    private void onProducerTaskFailure(Throwable error) {
+        if (KafkaErrors.isFatalProducerException(error)) {
+            LOGGER.warn("Encountered fatal producer exception. Producer will be closed.", error);
+            closeSafelyAsync();
+        } else {
+            LOGGER.debug("Encountered non-fatal producer exception.", error);
+        }
+    }
+
+    private static void runSafely(Runnable task, String name) {
+        runSafely(task, error -> LOGGER.error("Unexpected failure: name={}", name, error));
+    }
+
+    private static void runSafely(Runnable task, Consumer<Throwable> errorHandler) {
+        try {
+            task.run();
+        } catch (Throwable e) {
+            errorHandler.accept(e);
+        }
+    }
+
+    private static <T> Mono<T> cacheSuccess(Mono<T> mono) {
+        return mono.materialize().cacheInvalidateIf(Signal::hasError).dematerialize();
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/SequencedOffset.java
+++ b/kafka/src/main/java/io/atleon/kafka/SequencedOffset.java
@@ -1,0 +1,26 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+
+/**
+ * An {@link OffsetAndMetadata} that is associated with some sequence number.
+ */
+final class SequencedOffset {
+
+    private final OffsetAndMetadata offsetAndMetadata;
+
+    private final long sequence;
+
+    public SequencedOffset(OffsetAndMetadata offsetAndMetadata, long sequence) {
+        this.offsetAndMetadata = offsetAndMetadata;
+        this.sequence = sequence;
+    }
+
+    public OffsetAndMetadata offsetAndMetadata() {
+        return offsetAndMetadata;
+    }
+
+    public long sequence() {
+        return sequence;
+    }
+}

--- a/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
@@ -1,0 +1,448 @@
+package io.atleon.kafka;
+
+import io.atleon.core.AcknowledgementQueueMode;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Schedulers;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class ActivePartitionTest {
+
+    private static final TopicPartition TOPIC_PARTITION = new TopicPartition("topic", 0);
+
+    @Test
+    public void activateForProcessing_givenActive_expectsRegisteredReceiverRecord() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        List<Long> deactivatedRecordCounts = new ArrayList<>();
+
+        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
+        activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
+
+        Optional<KafkaReceiverRecord<String, String>> activated =
+            activePartition.activateForProcessing(newConsumerRecord(0));
+
+        assertTrue(activated.isPresent());
+        assertTrue(acknowledgedOffsets.isEmpty());
+        assertTrue(deactivatedRecordCounts.isEmpty());
+    }
+
+    @Test
+    public void activateForProcessing_givenDeactivated_expectsNoReceiverRecord() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        List<Long> deactivatedRecordCounts = new ArrayList<>();
+
+        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
+        activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
+
+        Long deactivatedRecordCount = activePartition.deactivateForcefully().block();
+
+        Optional<KafkaReceiverRecord<String, String>> activated =
+            activePartition.activateForProcessing(newConsumerRecord(0));
+
+        assertEquals(0L, deactivatedRecordCount);
+        assertFalse(activated.isPresent());
+        assertTrue(acknowledgedOffsets.isEmpty());
+        assertTrue(deactivatedRecordCounts.isEmpty());
+    }
+
+    @Test
+    public void acknowledge_givenActivatedRecordIsAcknowledged_expectsCorrectAcknowledgements() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        List<Long> deactivatedRecordCounts = new ArrayList<>();
+
+        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
+        activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
+
+        ConsumerRecord<String, String> consumerRecord = newConsumerRecord(0);
+        activePartition.activateForProcessing(consumerRecord).ifPresent(KafkaReceiverRecord::acknowledge);
+
+        assertEquals(1, acknowledgedOffsets.size());
+        assertEquals(TOPIC_PARTITION, acknowledgedOffsets.get(0).topicPartition());
+        assertEquals(consumerRecord.offset() + 1, acknowledgedOffsets.get(0).nextOffsetAndMetadata().offset());
+        assertEquals(Collections.singletonList(1L), deactivatedRecordCounts);
+    }
+
+    @Test
+    public void acknowledge_givenMultipleActivatedRecordsAreAcknowledged_expectsCorrectAcknowledgements() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        List<Long> deactivatedRecordCounts = new ArrayList<>();
+
+        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
+        activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
+
+        KafkaReceiverRecord<String, String> receiverRecord1 =
+            activePartition.activateForProcessing(newConsumerRecord(0)).get();
+        KafkaReceiverRecord<String, String> receiverRecord2 =
+            activePartition.activateForProcessing(newConsumerRecord(1)).get();
+        KafkaReceiverRecord<String, String> receiverRecord3 =
+            activePartition.activateForProcessing(newConsumerRecord(2)).get();
+
+        receiverRecord3.acknowledge();
+        receiverRecord1.acknowledge();
+        receiverRecord2.acknowledge();
+
+        assertEquals(3, acknowledgedOffsets.size());
+        assertEquals(TOPIC_PARTITION, acknowledgedOffsets.get(0).topicPartition());
+        assertEquals(TOPIC_PARTITION, acknowledgedOffsets.get(1).topicPartition());
+        assertEquals(TOPIC_PARTITION, acknowledgedOffsets.get(2).topicPartition());
+        assertEquals(
+            receiverRecord1.consumerRecord().offset() + 1,
+            acknowledgedOffsets.get(0).nextOffsetAndMetadata().offset());
+        assertEquals(
+            receiverRecord2.consumerRecord().offset() + 1,
+            acknowledgedOffsets.get(1).nextOffsetAndMetadata().offset());
+        assertEquals(
+            receiverRecord3.consumerRecord().offset() + 1,
+            acknowledgedOffsets.get(2).nextOffsetAndMetadata().offset());
+        assertEquals(Arrays.asList(1L, 2L), deactivatedRecordCounts);
+    }
+
+    @Test
+    public void nacknowledge_givenActivatedRecordIsNacknowledged_expectsErrorEmission() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        AtomicReference<Throwable> acknowledgedOffsetsError = new AtomicReference<>();
+        List<Long> deactivatedRecordCounts = new ArrayList<>();
+        AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
+        AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
+
+        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        activePartition.acknowledgedOffsets()
+            .subscribe(acknowledgedOffsets::add, acknowledgedOffsetsError::set);
+        activePartition.deactivatedRecordCounts().subscribe(
+            deactivatedRecordCounts::add,
+            deactivatedRecordCountsError::set,
+            () -> deactivatedRecordCountsCompleted.set(true));
+
+        ConsumerRecord<String, String> consumerRecord = newConsumerRecord(0);
+        activePartition.activateForProcessing(consumerRecord)
+            .ifPresent(it -> it.nacknowledge(new IllegalStateException("Boom")));
+
+        assertTrue(acknowledgedOffsets.isEmpty());
+        assertInstanceOf(IllegalStateException.class, acknowledgedOffsetsError.get());
+        assertEquals(Collections.singletonList(1L), deactivatedRecordCounts);
+        assertNull(deactivatedRecordCountsError.get());
+        assertTrue(deactivatedRecordCountsCompleted.get());
+    }
+
+    @Test
+    public void nacknowledge_givenMultipleActivatedRecordsAreNacknowledged_expectsCorrectEmissions() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        AtomicReference<Throwable> acknowledgedOffsetsError = new AtomicReference<>();
+        List<Long> deactivatedRecordCounts = new ArrayList<>();
+        AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
+        AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
+
+        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        activePartition.acknowledgedOffsets()
+            .subscribe(acknowledgedOffsets::add, acknowledgedOffsetsError::set);
+        activePartition.deactivatedRecordCounts().subscribe(
+            deactivatedRecordCounts::add,
+            deactivatedRecordCountsError::set,
+            () -> deactivatedRecordCountsCompleted.set(true));
+
+        KafkaReceiverRecord<String, String> receiverRecord1 =
+            activePartition.activateForProcessing(newConsumerRecord(0)).get();
+        KafkaReceiverRecord<String, String> receiverRecord2 =
+            activePartition.activateForProcessing(newConsumerRecord(1)).get();
+        KafkaReceiverRecord<String, String> receiverRecord3 =
+            activePartition.activateForProcessing(newConsumerRecord(2)).get();
+        KafkaReceiverRecord<String, String> receiverRecord4 =
+            activePartition.activateForProcessing(newConsumerRecord(2)).get();
+
+        receiverRecord3.acknowledge();
+        receiverRecord4.nacknowledge(new UnsupportedOperationException("Boom"));
+        receiverRecord1.acknowledge();
+        receiverRecord2.nacknowledge(new IllegalStateException("Boom"));
+
+        assertEquals(1, acknowledgedOffsets.size());
+        assertEquals(
+            receiverRecord1.consumerRecord().offset() + 1,
+            acknowledgedOffsets.get(0).nextOffsetAndMetadata().offset());
+        assertInstanceOf(IllegalStateException.class, acknowledgedOffsetsError.get());
+        assertEquals(Arrays.asList(1L, 3L), deactivatedRecordCounts);
+        assertNull(deactivatedRecordCountsError.get());
+        assertTrue(deactivatedRecordCountsCompleted.get());
+    }
+
+    @Test
+    public void deactivateLatest_givenNoInFlightRecords_expectsTerminationWithLastAcknowledgedOffset() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        AtomicReference<Throwable> acknowledgedOffsetsError = new AtomicReference<>();
+        AtomicBoolean acknowledgedOffsetsCompleted = new AtomicBoolean(false);
+        List<Long> deactivatedRecordCounts = new ArrayList<>();
+        AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
+        AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
+
+        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        activePartition.acknowledgedOffsets().subscribe(
+            acknowledgedOffsets::add,
+            acknowledgedOffsetsError::set,
+            () -> acknowledgedOffsetsCompleted.set(true));
+        activePartition.deactivatedRecordCounts().subscribe(
+            deactivatedRecordCounts::add,
+            deactivatedRecordCountsError::set,
+            () -> deactivatedRecordCountsCompleted.set(true));
+
+        KafkaReceiverRecord<String, String> receiverRecord =
+            activePartition.activateForProcessing(newConsumerRecord(0)).get();
+
+        receiverRecord.acknowledge();
+
+        AcknowledgedOffset lastAcknowledgedOffset =
+            activePartition.deactivateLatest(Duration.ofDays(1), Schedulers.parallel(), Mono.never()).block();
+
+        assertNotNull(lastAcknowledgedOffset);
+        assertEquals(Collections.singletonList(lastAcknowledgedOffset), acknowledgedOffsets);
+        assertNull(acknowledgedOffsetsError.get());
+        assertTrue(acknowledgedOffsetsCompleted.get());
+        assertEquals(Collections.singletonList(1L), deactivatedRecordCounts);
+        assertNull(deactivatedRecordCountsError.get());
+        assertTrue(deactivatedRecordCountsCompleted.get());
+    }
+
+    @Test
+    public void deactivateLatest_givenGracePeriod_expectsTerminationAfterLastAcknowledgement() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        AtomicReference<Throwable> acknowledgedOffsetsError = new AtomicReference<>();
+        AtomicBoolean acknowledgedOffsetsCompleted = new AtomicBoolean(false);
+        List<Long> deactivatedRecordCounts = new ArrayList<>();
+        AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
+        AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
+
+        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        activePartition.acknowledgedOffsets().subscribe(
+            acknowledgedOffsets::add,
+            acknowledgedOffsetsError::set,
+            () -> acknowledgedOffsetsCompleted.set(true));
+        activePartition.deactivatedRecordCounts().subscribe(
+            deactivatedRecordCounts::add,
+            deactivatedRecordCountsError::set,
+            () -> deactivatedRecordCountsCompleted.set(true));
+
+        KafkaReceiverRecord<String, String> receiverRecord1 =
+            activePartition.activateForProcessing(newConsumerRecord(0)).get();
+        KafkaReceiverRecord<String, String> receiverRecord2 =
+            activePartition.activateForProcessing(newConsumerRecord(0)).get();
+
+        AtomicReference<AcknowledgedOffset> lastAcknowledgedOffset = new AtomicReference<>();
+        activePartition.deactivateLatest(Duration.ofDays(1), Schedulers.parallel(), Mono.never())
+            .subscribe(lastAcknowledgedOffset::set);
+
+        assertTrue(acknowledgedOffsets.isEmpty());
+        assertTrue(deactivatedRecordCounts.isEmpty());
+
+        receiverRecord1.acknowledge();
+        receiverRecord2.acknowledge();
+
+        assertNotNull(lastAcknowledgedOffset.get());
+        assertEquals(2, acknowledgedOffsets.size());
+        assertEquals(
+            receiverRecord1.consumerRecord().offset() + 1,
+            acknowledgedOffsets.get(0).nextOffsetAndMetadata().offset());
+        assertEquals(
+            receiverRecord2.consumerRecord().offset() + 1,
+            acknowledgedOffsets.get(1).nextOffsetAndMetadata().offset());
+        assertEquals(lastAcknowledgedOffset.get(), acknowledgedOffsets.get(1));
+        assertNull(acknowledgedOffsetsError.get());
+        assertTrue(acknowledgedOffsetsCompleted.get());
+        assertEquals(Arrays.asList(1L, 1L), deactivatedRecordCounts);
+        assertNull(deactivatedRecordCountsError.get());
+        assertTrue(deactivatedRecordCountsCompleted.get());
+    }
+
+    @Test
+    public void deactivateLatest_givenManualTimeout_expectsImmediateTerminationWithLastAcknowledgedOffset() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        AtomicReference<Throwable> acknowledgedOffsetsError = new AtomicReference<>();
+        AtomicBoolean acknowledgedOffsetsCompleted = new AtomicBoolean(false);
+        List<Long> deactivatedRecordCounts = new ArrayList<>();
+        AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
+        AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
+
+        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        activePartition.acknowledgedOffsets().subscribe(
+            acknowledgedOffsets::add,
+            acknowledgedOffsetsError::set,
+            () -> acknowledgedOffsetsCompleted.set(true));
+        activePartition.deactivatedRecordCounts().subscribe(
+            deactivatedRecordCounts::add,
+            deactivatedRecordCountsError::set,
+            () -> deactivatedRecordCountsCompleted.set(true));
+
+        KafkaReceiverRecord<String, String> receiverRecord1 =
+            activePartition.activateForProcessing(newConsumerRecord(0)).get();
+        KafkaReceiverRecord<String, String> receiverRecord2 =
+            activePartition.activateForProcessing(newConsumerRecord(1)).get();
+
+        Sinks.Empty<Void> disposal = Sinks.one();
+        AtomicReference<AcknowledgedOffset> lastAcknowledgedOffset = new AtomicReference<>();
+        activePartition.deactivateLatest(Duration.ofDays(1), Schedulers.parallel(), disposal.asMono())
+            .subscribe(lastAcknowledgedOffset::set);
+        receiverRecord1.acknowledge();
+        disposal.tryEmitEmpty();
+        receiverRecord2.acknowledge();
+
+        assertNotNull(lastAcknowledgedOffset.get());
+        assertEquals(Collections.singletonList(lastAcknowledgedOffset.get()), acknowledgedOffsets);
+        assertNull(acknowledgedOffsetsError.get());
+        assertTrue(acknowledgedOffsetsCompleted.get());
+        assertEquals(Arrays.asList(1L, 1L), deactivatedRecordCounts);
+        assertNull(deactivatedRecordCountsError.get());
+        assertTrue(deactivatedRecordCountsCompleted.get());
+    }
+
+    @Test
+    public void deactivateLatest_givenNoGracePeriod_expectsImmediateTerminationWithLastAcknowledgedOffset() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        AtomicReference<Throwable> acknowledgedOffsetsError = new AtomicReference<>();
+        AtomicBoolean acknowledgedOffsetsCompleted = new AtomicBoolean(false);
+        List<Long> deactivatedRecordCounts = new ArrayList<>();
+        AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
+        AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
+
+        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        activePartition.acknowledgedOffsets().subscribe(
+            acknowledgedOffsets::add,
+            acknowledgedOffsetsError::set,
+            () -> acknowledgedOffsetsCompleted.set(true));
+        activePartition.deactivatedRecordCounts().subscribe(
+            deactivatedRecordCounts::add,
+            deactivatedRecordCountsError::set,
+            () -> deactivatedRecordCountsCompleted.set(true));
+
+        KafkaReceiverRecord<String, String> receiverRecord1 =
+            activePartition.activateForProcessing(newConsumerRecord(0)).get();
+        KafkaReceiverRecord<String, String> receiverRecord2 =
+            activePartition.activateForProcessing(newConsumerRecord(1)).get();
+        KafkaReceiverRecord<String, String> receiverRecord3 =
+            activePartition.activateForProcessing(newConsumerRecord(2)).get();
+
+        receiverRecord3.acknowledge();
+        receiverRecord1.acknowledge();
+
+        AtomicReference<AcknowledgedOffset> lastAcknowledgedOffset = new AtomicReference<>();
+        activePartition.deactivateLatest(Duration.ZERO, Schedulers.parallel(), Mono.never())
+            .subscribe(lastAcknowledgedOffset::set);
+        receiverRecord2.acknowledge();
+
+        assertNotNull(lastAcknowledgedOffset.get());
+        assertEquals(Collections.singletonList(lastAcknowledgedOffset.get()), acknowledgedOffsets);
+        assertNull(acknowledgedOffsetsError.get());
+        assertTrue(acknowledgedOffsetsCompleted.get());
+        assertEquals(Arrays.asList(1L, 2L), deactivatedRecordCounts);
+        assertNull(deactivatedRecordCountsError.get());
+        assertTrue(deactivatedRecordCountsCompleted.get());
+    }
+
+    @Test
+    public void deactivateTimeout_givenNoGracePeriodAndNothingInFlight_expectsSuccessfulCompletion() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        AtomicReference<Throwable> acknowledgedOffsetsError = new AtomicReference<>();
+        AtomicBoolean acknowledgedOffsetsCompleted = new AtomicBoolean(false);
+        List<Long> deactivatedRecordCounts = new ArrayList<>();
+        AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
+        AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
+
+        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        activePartition.acknowledgedOffsets().subscribe(
+            acknowledgedOffsets::add,
+            acknowledgedOffsetsError::set,
+            () -> acknowledgedOffsetsCompleted.set(true));
+        activePartition.deactivatedRecordCounts().subscribe(
+            deactivatedRecordCounts::add,
+            deactivatedRecordCountsError::set,
+            () -> deactivatedRecordCountsCompleted.set(true));
+
+        activePartition.deactivateTimeout(Duration.ofSeconds(-1), Schedulers.immediate()).block();
+
+        assertTrue(acknowledgedOffsets.isEmpty());
+        assertNull(acknowledgedOffsetsError.get());
+        assertTrue(acknowledgedOffsetsCompleted.get());
+        assertTrue(deactivatedRecordCounts.isEmpty());
+        assertNull(deactivatedRecordCountsError.get());
+        assertTrue(deactivatedRecordCountsCompleted.get());
+    }
+
+    @Test
+    public void deactivateForcefully_givenInFlightRecords_expectsImmediateTermination() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        AtomicReference<Throwable> acknowledgedOffsetsError = new AtomicReference<>();
+        CountDownLatch acknowledgedOffsetsCompletionLatch = new CountDownLatch(1);
+        CompletableFuture<Void> acknowledgedOffsetsCompletion = new CompletableFuture<>();
+        List<Long> deactivatedRecordCounts = new ArrayList<>();
+        AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
+        CompletableFuture<Void> deactivatedRecordCountsCompletion = new CompletableFuture<>();
+
+        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        activePartition.acknowledgedOffsets().publishOn(Schedulers.boundedElastic()).subscribe(
+            acknowledgedOffsets::add,
+            acknowledgedOffsetsError::set,
+            () -> {
+                try {
+                    acknowledgedOffsetsCompletionLatch.await();
+                } catch (InterruptedException e) {
+                    fail("Interrupted while awaiting acknowledged offsets completion");
+                }
+                acknowledgedOffsetsCompletion.complete(null);
+            });
+        activePartition.deactivatedRecordCounts().subscribe(
+            deactivatedRecordCounts::add,
+            deactivatedRecordCountsError::set,
+            () -> deactivatedRecordCountsCompletion.complete(null));
+
+        KafkaReceiverRecord<String, String> receiverRecord1 =
+            activePartition.activateForProcessing(newConsumerRecord(0)).get();
+        KafkaReceiverRecord<String, String> receiverRecord2 =
+            activePartition.activateForProcessing(newConsumerRecord(1)).get();
+        KafkaReceiverRecord<String, String> receiverRecord3 =
+            activePartition.activateForProcessing(newConsumerRecord(2)).get();
+
+        receiverRecord3.acknowledge();
+        receiverRecord1.acknowledge();
+
+        assertEquals(2L, activePartition.deactivateForcefully().block());
+
+        receiverRecord2.acknowledge();
+        acknowledgedOffsetsCompletionLatch.countDown();
+        acknowledgedOffsetsCompletion.join();
+        deactivatedRecordCountsCompletion.join();
+
+        assertEquals(TOPIC_PARTITION, activePartition.topicPartition());
+        assertEquals(1, acknowledgedOffsets.size());
+        assertEquals(
+            receiverRecord1.consumerRecord().offset() + 1,
+            acknowledgedOffsets.get(0).nextOffsetAndMetadata().offset());
+        assertNull(acknowledgedOffsetsError.get());
+        assertEquals(Arrays.asList(1L, 2L), deactivatedRecordCounts);
+        assertNull(deactivatedRecordCountsError.get());
+    }
+
+    private static ConsumerRecord<String, String> newConsumerRecord(int offset) {
+        return new ConsumerRecord<>(TOPIC_PARTITION.topic(), TOPIC_PARTITION.partition(), offset, "key", "value");
+    }
+}

--- a/kafka/src/test/java/io/atleon/kafka/KafkaReceiverTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/KafkaReceiverTest.java
@@ -1,0 +1,490 @@
+package io.atleon.kafka;
+
+import io.atleon.kafka.embedded.EmbeddedKafka;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class KafkaReceiverTest {
+
+    private static final String BOOTSTRAP_CONNECT = EmbeddedKafka.startAndGetBootstrapServersConnect(10092);
+
+    @Test
+    public void receiveAutoAck_givenSuccessfulProcessing_expectsProcessingContinuation() {
+        String topic = UUID.randomUUID().toString();
+
+        KafkaSenderRecord<String, String, Object> senderRecord1 =
+            KafkaSenderRecord.create(topic, "key", "value1", null);
+        KafkaSenderRecord<String, String, Object> senderRecord2 =
+            KafkaSenderRecord.create(topic, "key", "value2", null);
+
+        send(senderRecord1, senderRecord2);
+
+        ConsumerListener.Closure closureListener = ConsumerListener.closure();
+        KafkaReceiverOptions<String, String> receiverOptions = newReceiverOptionsBuilder()
+            .consumerListener(closureListener)
+            .build();
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveAutoAck(Collections.singletonList(topic))
+            .take(1)
+            .concatMap(Function.identity())
+            .as(StepVerifier::create)
+            .consumeNextWith(it -> assertEquals(senderRecord1.value(), it.value()))
+            .expectComplete()
+            .verify();
+
+        assertNull(closureListener.closed().block());
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveAutoAck(Collections.singletonList(topic))
+            .concatMap(Function.identity())
+            .as(StepVerifier::create)
+            .consumeNextWith(it -> assertEquals(senderRecord2.value(), it.value()))
+            .thenCancel()
+            .verify();
+    }
+
+    @Test
+    public void receiveAutoAck_givenFailedProcessing_expectsReprocessing() {
+        String topic = UUID.randomUUID().toString();
+
+        KafkaSenderRecord<String, String, Object> senderRecord =
+            KafkaSenderRecord.create(topic, "key", "value1", null);
+
+        send(senderRecord);
+
+        ConsumerListener.Closure closureListener = ConsumerListener.closure();
+        KafkaReceiverOptions<String, String> receiverOptions = newReceiverOptionsBuilder()
+            .consumerListener(closureListener)
+            .build();
+
+        Flux<?> flux = KafkaReceiver.create(receiverOptions)
+            .receiveAutoAck(Collections.singletonList(topic))
+            .doOnNext(it -> {
+                throw new UnsupportedOperationException("Boom");
+            });
+
+        assertThrows(UnsupportedOperationException.class, flux::blockLast);
+        assertNull(closureListener.closed().block());
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveAutoAck(Collections.singletonList(topic))
+            .concatMap(Function.identity())
+            .as(StepVerifier::create)
+            .consumeNextWith(it -> assertEquals(senderRecord.value(), it.value()))
+            .thenCancel()
+            .verify();
+    }
+
+    @Test
+    public void receiveAutoAck_givenCommitlessOffsets_expectsStatelessProcessing() {
+        String topic = UUID.randomUUID().toString();
+
+        KafkaSenderRecord<String, String, Object> senderRecord1 =
+            KafkaSenderRecord.create(topic, "key", "value1", null);
+
+        send(senderRecord1);
+
+        ConsumerListener.Closure closureListener = ConsumerListener.closure();
+        KafkaReceiverOptions<String, String> receiverOptions = newReceiverOptionsBuilder()
+            .consumerListener(closureListener)
+            .commitlessOffsets(true)
+            .build();
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveAutoAck(Collections.singletonList(topic))
+            .concatMap(Function.identity())
+            .as(StepVerifier::create)
+            .consumeNextWith(it -> assertEquals(senderRecord1.value(), it.value()))
+            .thenCancel()
+            .verify();
+
+        assertNull(closureListener.closed().block());
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveAutoAck(Collections.singletonList(topic))
+            .concatMap(Function.identity())
+            .as(StepVerifier::create)
+            .consumeNextWith(it -> assertEquals(senderRecord1.value(), it.value()))
+            .thenCancel()
+            .verify();
+    }
+
+    @Test
+    public void receiveManual_givenUnacknowledgedRecord_expectsReprocessing() {
+        String topic = UUID.randomUUID().toString();
+
+        KafkaSenderRecord<String, String, Object> senderRecord =
+            KafkaSenderRecord.create(topic, "key", "value", null);
+
+        send(senderRecord);
+
+        ConsumerListener.Closure closureListener = ConsumerListener.closure();
+        KafkaReceiverOptions<String, String> receiverOptions = newReceiverOptionsBuilder()
+            .consumerListener(closureListener)
+            .build();
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveManual(Collections.singletonList(topic))
+            .as(StepVerifier::create)
+            .expectNextMatches(it -> it.consumerRecord().key().equals(senderRecord.key()))
+            .thenCancel()
+            .verify();
+
+        assertNull(closureListener.closed().block());
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveManual(Collections.singletonList(topic))
+            .as(StepVerifier::create)
+            .expectNextMatches(it -> it.consumerRecord().key().equals(senderRecord.key()))
+            .thenCancel()
+            .verify();
+    }
+
+    @Test
+    public void receiveManual_givenAcknowledgedRecord_expectsProcessingContinuation() {
+        String topic = UUID.randomUUID().toString();
+
+        KafkaSenderRecord<String, String, Object> senderRecord1 =
+            KafkaSenderRecord.create(topic, "key", "value1", null);
+        KafkaSenderRecord<String, String, Object> senderRecord2 =
+            KafkaSenderRecord.create(topic, "key", "value2", null);
+
+        send(senderRecord1, senderRecord2);
+
+        ConsumerListener.Closure closureListener = ConsumerListener.closure();
+        KafkaReceiverOptions<String, String> receiverOptions = newReceiverOptionsBuilder()
+            .consumerListener(closureListener)
+            .build();
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveManual(Collections.singletonList(topic))
+            .doOnNext(KafkaReceiverRecord::acknowledge)
+            .as(StepVerifier::create)
+            .expectNextMatches(it -> it.consumerRecord().key().equals(senderRecord1.key()))
+            .thenCancel()
+            .verify();
+
+        assertNull(closureListener.closed().block());
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveManual(Collections.singletonList(topic))
+            .as(StepVerifier::create)
+            .expectNextMatches(it -> it.consumerRecord().key().equals(senderRecord2.key()))
+            .thenCancel()
+            .verify();
+    }
+
+    @Test
+    public void receiveManual_givenNegativelyAcknowledgedRecord_expectsErrorAndReprocessing() {
+        String topic = UUID.randomUUID().toString();
+
+        KafkaSenderRecord<String, String, Object> senderRecord1 =
+            KafkaSenderRecord.create(topic, "key", "value1", null);
+        KafkaSenderRecord<String, String, Object> senderRecord2 =
+            KafkaSenderRecord.create(topic, "key", "value2", null);
+
+        send(senderRecord1, senderRecord2);
+
+        ConsumerListener.Closure closureListener = ConsumerListener.closure();
+        KafkaReceiverOptions<String, String> receiverOptions = newReceiverOptionsBuilder()
+            .consumerListener(closureListener)
+            .build();
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveManual(Collections.singletonList(topic))
+            .as(StepVerifier::create)
+            .consumeNextWith(KafkaReceiverRecord::acknowledge)
+            .consumeNextWith(it -> it.nacknowledge(new UnsupportedOperationException("Boom")))
+            .expectError(UnsupportedOperationException.class)
+            .verify();
+
+        assertNull(closureListener.closed().block());
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveManual(Collections.singletonList(topic))
+            .as(StepVerifier::create)
+            .expectNextMatches(it -> it.consumerRecord().key().equals(senderRecord2.key()))
+            .thenCancel()
+            .verify();
+    }
+
+    @Test
+    public void receiveManual_givenOutOfOrderAcknowledgements_expectsCorrectProcessingContinuation() {
+        String topic = UUID.randomUUID().toString();
+
+        KafkaSenderRecord<String, String, Object> senderRecord1 =
+            KafkaSenderRecord.create(topic, "key", "value1", null);
+        KafkaSenderRecord<String, String, Object> senderRecord2 =
+            KafkaSenderRecord.create(topic, "key", "value2", null);
+        KafkaSenderRecord<String, String, Object> senderRecord3 =
+            KafkaSenderRecord.create(topic, "key", "value3", null);
+
+        send(senderRecord1, senderRecord2, senderRecord3);
+
+        ConsumerListener.Closure closureListener = ConsumerListener.closure();
+        KafkaReceiverOptions<String, String> receiverOptions = newReceiverOptionsBuilder()
+            .consumerListener(closureListener)
+            .build();
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveManual(Collections.singletonList(topic))
+            .as(StepVerifier::create)
+            .consumeNextWith(KafkaReceiverRecord::acknowledge)
+            .expectNextMatches(it -> it.consumerRecord().key().equals(senderRecord2.key()))
+            .consumeNextWith(KafkaReceiverRecord::acknowledge)
+            .thenCancel()
+            .verify();
+
+        assertNull(closureListener.closed().block());
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveManual(Collections.singletonList(topic))
+            .as(StepVerifier::create)
+            .expectNextMatches(it -> it.consumerRecord().key().equals(senderRecord2.key()))
+            .thenCancel()
+            .verify();
+    }
+
+    @Test
+    public void receiveManual_givenTooManyUnacknowledgedRecords_expectsPausedEmission() {
+        String topic = UUID.randomUUID().toString();
+
+        send(
+            KafkaSenderRecord.create(topic, "key", "value1", null),
+            KafkaSenderRecord.create(topic, "key", "value2", null));
+
+        KafkaReceiverOptions<String, String> receiverOptions = KafkaReceiverOptions.<String, String>newBuilder()
+            .consumerProperties(newConsumerProperties(UUID.randomUUID().toString()))
+            .maxActiveInFlight(1)
+            .build();
+
+        AtomicReference<KafkaReceiverRecord<String, String>> firstRecord = new AtomicReference<>();
+        KafkaReceiver.create(receiverOptions)
+            .receiveManual(Collections.singletonList(topic))
+            .as(StepVerifier::create)
+            .consumeNextWith(firstRecord::set)
+            .expectNoEvent(receiverOptions.pollTimeout().multipliedBy(2))
+            .then(() -> firstRecord.get().acknowledge())
+            .expectNextMatches(it -> it.value().equals("value2"))
+            .thenCancel()
+            .verify();
+    }
+
+    @Test
+    public void receiveManual_givenCommitTriggering_expectsCommittedOffsets() {
+        String topic = UUID.randomUUID().toString();
+        String groupId = UUID.randomUUID().toString();
+
+        send(
+            KafkaSenderRecord.create(topic, "key", "value1", null),
+            KafkaSenderRecord.create(topic, "key", "value2", null));
+
+        KafkaReceiverOptions<String, String> receiverOptions = KafkaReceiverOptions.<String, String>newBuilder()
+            .consumerProperties(newConsumerProperties(groupId))
+            .commitBatchSize(2)
+            .build();
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveManual(Collections.singletonList(topic))
+            .as(StepVerifier::create)
+            .consumeNextWith(KafkaReceiverRecord::acknowledge)
+            .consumeNextWith(KafkaReceiverRecord::acknowledge)
+            .thenAwait(Duration.ofSeconds(1L))
+            .then(() -> {
+                try (ReactiveAdmin admin = ReactiveAdmin.create(newKafkaProperties())) {
+                    Long maxOffset = admin.listTopicPartitionGroupOffsets(groupId)
+                        .reduce(0L, (max, next) -> Math.max(max, next.groupOffset()))
+                        .block();
+                    assertEquals(2, maxOffset);
+                }
+            })
+            .thenCancel()
+            .verify();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void receiveTxManual_givenCommitmentBatchTriggering_expectsTransactionExecution(boolean commitlessOffsets) {
+        String topic = UUID.randomUUID().toString();
+        String groupId = UUID.randomUUID().toString();
+        int partition = 0;
+
+        send(
+            KafkaSenderRecord.create(topic, partition, "key", "value1", null),
+            KafkaSenderRecord.create(topic, partition, "key", "value2", null));
+
+        KafkaReceiverOptions<String, String> receiverOptions = KafkaReceiverOptions.<String, String>newBuilder()
+            .consumerProperties(newConsumerProperties(groupId))
+            .commitBatchSize(2)
+            .commitlessOffsets(commitlessOffsets)
+            .build();
+
+        KafkaTxManager txManager = mock(KafkaTxManager.class);
+        when(txManager.begin()).thenReturn(Mono.empty());
+        when(txManager.sendOffsets(any(), any())).thenReturn(Mono.empty());
+        when(txManager.commit()).thenReturn(Mono.empty());
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveTxManual(Mono.just(txManager), Collections.singletonList(topic))
+            .as(StepVerifier::create)
+            .consumeNextWith(KafkaReceiverRecord::acknowledge)
+            .consumeNextWith(KafkaReceiverRecord::acknowledge)
+            .thenAwait(Duration.ofSeconds(1L))
+            .thenCancel()
+            .verify();
+
+        verify(txManager, times(1)).begin();
+        verify(txManager, commitlessOffsets ? never() : times(1)).sendOffsets(
+            argThat(it -> it.get(new TopicPartition(topic, partition)).offset() == 2),
+            argThat(it -> it.groupId().equals(groupId))
+        );
+        verify(txManager, times(1)).commit();
+        verify(txManager, never()).abort();
+    }
+
+    @Test
+    public void receiveTxManual_givenCommitmentPeriodTriggering_expectsTransactionExecution() {
+        String topic = UUID.randomUUID().toString();
+        String groupId = UUID.randomUUID().toString();
+        int partition = 0;
+
+        send(
+            KafkaSenderRecord.create(topic, partition, "key", "value1", null),
+            KafkaSenderRecord.create(topic, partition, "key", "value2", null));
+
+        KafkaReceiverOptions<String, String> receiverOptions = KafkaReceiverOptions.<String, String>newBuilder()
+            .consumerProperties(newConsumerProperties(groupId))
+            .commitPeriod(Duration.ofMillis(100))
+            .build();
+
+        KafkaTxManager txManager = mock(KafkaTxManager.class);
+        when(txManager.begin()).thenReturn(Mono.empty());
+        when(txManager.sendOffsets(any(), any())).thenReturn(Mono.empty());
+        when(txManager.commit()).thenReturn(Mono.empty());
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveTxManual(Mono.just(txManager), Collections.singletonList(topic))
+            .as(it -> StepVerifier.create(it, 0))
+            .thenRequest(1)
+            .consumeNextWith(KafkaReceiverRecord::acknowledge)
+            .thenAwait(receiverOptions.commitPeriod().multipliedBy(2))
+            .thenRequest(1)
+            .consumeNextWith(KafkaReceiverRecord::acknowledge)
+            .thenAwait(receiverOptions.commitPeriod().multipliedBy(5))
+            .thenCancel()
+            .verify();
+
+        verify(txManager, times(2)).begin();
+        verify(txManager, times(1)).sendOffsets(
+            argThat(it -> it.get(new TopicPartition(topic, partition)).offset() == 1),
+            argThat(it -> it.groupId().equals(groupId))
+        );
+        verify(txManager, times(1)).sendOffsets(
+            argThat(it -> it.get(new TopicPartition(topic, partition)).offset() == 2),
+            argThat(it -> it.groupId().equals(groupId))
+        );
+        verify(txManager, times(2)).commit();
+        verify(txManager, never()).abort();
+    }
+
+    @Test
+    public void receiveTxManual_givenAbortionTriggering_expectsTransactionExecution() {
+        String topic = UUID.randomUUID().toString();
+        String groupId = UUID.randomUUID().toString();
+        int partition = 0;
+
+        send(KafkaSenderRecord.create(topic, partition, "key", "value", null));
+
+        KafkaReceiverOptions<String, String> receiverOptions = KafkaReceiverOptions.<String, String>newBuilder()
+            .consumerProperties(newConsumerProperties(groupId))
+            .commitBatchSize(2)
+            .build();
+
+        KafkaTxManager txManager = mock(KafkaTxManager.class);
+        when(txManager.begin()).thenReturn(Mono.empty());
+        when(txManager.abort()).thenReturn(Mono.empty());
+
+        KafkaReceiver.create(receiverOptions)
+            .receiveTxManual(Mono.just(txManager), Collections.singletonList(topic))
+            .as(StepVerifier::create)
+            .consumeNextWith(it -> it.nacknowledge(new UnsupportedOperationException("Boom")))
+            .expectError(UnsupportedOperationException.class)
+            .verify();
+
+        verify(txManager, times(1)).begin();
+        verify(txManager, times(1)).abort();
+    }
+
+    @SafeVarargs
+    private static <T> List<KafkaSenderResult<T>> send(KafkaSenderRecord<String, String, T>... senderRecords) {
+        KafkaSenderOptions<String, String> senderOptions = KafkaSenderOptions.<String, String>newBuilder()
+            .producerProperties(newProducerProperties())
+            .build();
+
+        KafkaSender<String, String> sender = KafkaSender.create(senderOptions);
+        try {
+            return Flux.just(senderRecords).as(sender::send).collectList().block();
+        } finally {
+            sender.close();
+        }
+    }
+
+    private static KafkaReceiverOptions.Builder<String, String> newReceiverOptionsBuilder() {
+        return KafkaReceiverOptions.<String, String>newBuilder()
+            .consumerProperties(newConsumerProperties(UUID.randomUUID().toString()));
+    }
+
+    private static Map<String, Object> newProducerProperties() {
+        Map<String, Object> producerProperties = newKafkaProperties();
+        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        return producerProperties;
+    }
+
+    private static Map<String, Object> newConsumerProperties(String groupId) {
+        Map<String, Object> consumerProperties = newKafkaProperties();
+        consumerProperties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        consumerProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        return consumerProperties;
+    }
+
+    private static Map<String, Object> newKafkaProperties() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CommonClientConfigs.CLIENT_ID_CONFIG, UUID.randomUUID().toString());
+        properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_CONNECT);
+        return properties;
+    }
+}

--- a/kafka/src/test/java/io/atleon/kafka/KafkaSenderTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/KafkaSenderTest.java
@@ -1,0 +1,228 @@
+package io.atleon.kafka;
+
+import io.atleon.kafka.embedded.EmbeddedKafka;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class KafkaSenderTest {
+
+    private static final String BOOTSTRAP_CONNECT = EmbeddedKafka.startAndGetBootstrapServersConnect(10092);
+
+    @Test
+    public void send_givenSuccessfulSend_expectsProducedRecord() {
+        String topic = UUID.randomUUID().toString();
+        int partition = 0;
+
+        KafkaSenderRecord<String, String, Object> senderRecord =
+            KafkaSenderRecord.create(topic, partition, "key", "value", null);
+
+        KafkaSenderOptions<String, String> senderOptions = KafkaSenderOptions.<String, String>newBuilder()
+            .producerProperties(newProducerProperties())
+            .build();
+        KafkaSender<String, String> sender = KafkaSender.create(senderOptions);
+
+        sender.send(senderRecord).block();
+
+        assertEquals(1, countRecords(topic, partition));
+
+        sender.close();
+    }
+
+    @Test
+    public void send_givenFailedSend_expectsSubsequentRecordsToNotBeProduced() {
+        String topic = UUID.randomUUID().toString();
+        int partition = 0;
+
+        KafkaSenderRecord<String, String, Object> senderRecord1 =
+            KafkaSenderRecord.create(topic, partition, "key1", "value1", null);
+        KafkaSenderRecord<String, String, Object> senderRecord2 =
+            KafkaSenderRecord.create(topic, partition, "key2", "Boom", null);
+        KafkaSenderRecord<String, String, Object> senderRecord3 =
+            KafkaSenderRecord.create(topic, partition, "key3", "value3", null);
+
+        ProducerListener.Closure producerListener = ProducerListener.closure();
+        KafkaSenderOptions<String, String> senderOptions = KafkaSenderOptions.<String, String>newBuilder()
+            .producerListener(producerListener)
+            .producerProperties(newProducerProperties())
+            .build();
+        KafkaSender<String, String> sender = KafkaSender.create(senderOptions);
+
+        assertThrows(
+            SerializationException.class,
+            () -> Flux.just(senderRecord1, senderRecord2, senderRecord3).as(sender::send).then().block());
+
+        sender.close();
+        producerListener.closed().then(Mono.delay(Duration.ofSeconds(1))).block();
+
+        assertEquals(1, countRecords(topic, partition));
+    }
+
+    @Test
+    public void sendDelayError_givenFailedSend_expectsSubsequentRecordsToBeProduced() {
+        String topic = UUID.randomUUID().toString();
+        int partition = 0;
+
+        KafkaSenderRecord<String, String, Object> senderRecord1 =
+            KafkaSenderRecord.create(topic, partition, "key1", "value1", null);
+        KafkaSenderRecord<String, String, Object> senderRecord2 =
+            KafkaSenderRecord.create(topic, partition, "key2", "Boom", null);
+        KafkaSenderRecord<String, String, Object> senderRecord3 =
+            KafkaSenderRecord.create(topic, partition, "key3", "value3", null);
+
+        KafkaSenderOptions<String, String> senderOptions = KafkaSenderOptions.<String, String>newBuilder()
+            .producerProperties(newProducerProperties())
+            .build();
+        KafkaSender<String, String> sender = KafkaSender.create(senderOptions);
+
+        assertThrows(
+            SerializationException.class,
+            () -> Flux.just(senderRecord1, senderRecord2, senderRecord3).as(sender::sendDelayError).then().block());
+
+        assertEquals(2, countRecords(topic, partition));
+    }
+
+    @Test
+    public void sendDelegateError_givenFailedSend_expectsSendResultsToReflectErrors() {
+        String topic = UUID.randomUUID().toString();
+        int partition = 0;
+
+        KafkaSenderRecord<String, String, Boolean> senderRecord1 =
+            KafkaSenderRecord.create(topic, partition, "key1", "value1", false);
+        KafkaSenderRecord<String, String, Boolean> senderRecord2 =
+            KafkaSenderRecord.create(topic, partition, "key2", "Boom", true);
+        KafkaSenderRecord<String, String, Boolean> senderRecord3 =
+            KafkaSenderRecord.create(topic, partition, "key3", "value3", false);
+
+        KafkaSenderOptions<String, String> senderOptions = KafkaSenderOptions.<String, String>newBuilder()
+            .producerProperties(newProducerProperties())
+            .build();
+        KafkaSender<String, String> sender = KafkaSender.create(senderOptions);
+
+        Map<Boolean, List<KafkaSenderResult<Boolean>>> results = Flux.just(senderRecord1, senderRecord2, senderRecord3)
+            .as(sender::sendDelegateError)
+            .collect(Collectors.partitioningBy(KafkaSenderResult::correlationMetadata))
+            .block();
+
+        assertEquals(2, results.get(false).size());
+        assertTrue(results.get(false).stream().noneMatch(KafkaSenderResult::isFailure));
+        assertEquals(1, results.get(true).size());
+        assertTrue(results.get(true).get(0).isFailure());
+        assertInstanceOf(SerializationException.class, results.get(true).get(0).failureCause().orElse(null));
+        assertEquals(2, countRecords(topic, partition));
+    }
+
+    @Test
+    public void sendTransactional_givenSuccessfulSend_expectsProducedRecord() {
+        String topic = UUID.randomUUID().toString();
+        int partition = 0;
+
+        Flux<KafkaSenderRecord<String, String, Object>> senderRecords = Flux.just(
+            KafkaSenderRecord.create(topic, partition, "key", "value", null)
+        );
+
+        KafkaSenderOptions<String, String> senderOptions = KafkaSenderOptions.<String, String>newBuilder()
+            .producerProperties(newProducerProperties())
+            .producerProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, UUID.randomUUID().toString())
+            .build();
+        KafkaSender<String, String> sender = KafkaSender.create(senderOptions);
+
+        Flux.just(senderRecords).as(sender::sendTransactional).then(Mono.delay(Duration.ofSeconds(1))).block();
+
+        // There should be two records: One "uncommitted" record, followed by COMMIT record marker
+        assertEquals(2, countRecords(topic, partition));
+
+        sender.close();
+    }
+
+    @Test
+    public void sendTransactional_givenFailedSend_expectsAbortedProduction() {
+        String topic = UUID.randomUUID().toString();
+        int partition = 0;
+
+        Flux<KafkaSenderRecord<String, String, Object>> senderRecords = Flux.just(
+            KafkaSenderRecord.create(topic, partition, "key1", "value1", null),
+            KafkaSenderRecord.create(topic, partition, "key2", "Boom", null),
+            KafkaSenderRecord.create(topic, partition, "key3", "value3", null)
+        );
+
+        ProducerListener.Closure producerListener = ProducerListener.closure();
+        KafkaSenderOptions<String, String> senderOptions = KafkaSenderOptions.<String, String>newBuilder()
+            .producerListener(producerListener)
+            .producerProperties(newProducerProperties())
+            .producerProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, UUID.randomUUID().toString())
+            .build();
+        KafkaSender<String, String> sender = KafkaSender.create(senderOptions);
+
+        Flux.just(senderRecords)
+            .as(sender::sendTransactional)
+            .as(it -> StepVerifier.create(it, 1))
+            .expectNextCount(1)
+            .thenRequest(Long.MAX_VALUE)
+            .expectError(SerializationException.class)
+            .verify();
+
+        sender.close();
+        producerListener.closed().then(Mono.delay(Duration.ofSeconds(1))).block();
+
+        // There will be one "uncommitted" record, then an ABORT marker, because the next send
+        // fails
+        assertEquals(2, countRecords(topic, partition));
+    }
+
+    private static long countRecords(String topic, int partition) {
+        try (ReactiveAdmin admin = ReactiveAdmin.create(newKafkaProperties())) {
+            TopicPartition topicPartition = new TopicPartition(topic, partition);
+            return admin.listOffsets(Collections.singletonList(topicPartition), OffsetSpec.latest())
+                .flatMapIterable(Map::values)
+                .reduce(0L, Long::sum)
+                .blockOptional()
+                .orElse(0L);
+        }
+    }
+
+    private static Map<String, Object> newProducerProperties() {
+        Map<String, Object> producerProperties = newKafkaProperties();
+        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, BoomingStringSerializer.class.getName());
+        return producerProperties;
+    }
+
+    private static Map<String, Object> newKafkaProperties() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CommonClientConfigs.CLIENT_ID_CONFIG, UUID.randomUUID().toString());
+        properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_CONNECT);
+        return properties;
+    }
+
+    public static final class BoomingStringSerializer extends StringSerializer {
+
+        @Override
+        public byte[] serialize(String topic, String data) {
+            if ("Boom".equalsIgnoreCase(data)) {
+                throw new SerializationException("Refusing to serialize 'Boom'");
+            }
+            return super.serialize(topic, data);
+        }
+    }
+}

--- a/kafka/src/test/java/io/atleon/kafka/PollManagerTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/PollManagerTest.java
@@ -1,0 +1,209 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PollManagerTest {
+
+    @Test
+    public void activateAssigned_givenAssignedPartitions_expectsCoordinationOfInvocations() {
+        TopicPartition partition1 = new TopicPartition("topic", 0);
+        TopicPartition partition2 = new TopicPartition("topic", 1);
+
+        Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
+        pollManager.forcePause(Collections.singletonList(partition1));
+
+        pollManager.activateAssigned(consumer, Arrays.asList(partition1, partition2), Function.identity());
+
+        verify(consumer).pause(argThat(it -> it.size() == 1 && it.contains(partition1)));
+        verify(pollStrategy).onPollingPermitted(argThat(it -> it.size() == 1 && it.contains(partition2)));
+        assertEquals(partition1, pollManager.activated(partition1));
+        assertEquals(partition2, pollManager.activated(partition2));
+    }
+
+    @Test
+    public void activateAssigned_givenAlreadyAssignedPartition_expectsException() {
+        TopicPartition partition = new TopicPartition("topic", 0);
+        Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
+
+        pollManager.activateAssigned(consumer, Collections.singletonList(partition), Function.identity());
+
+        assertThrows(IllegalStateException.class, () ->
+            pollManager.activateAssigned(consumer, Collections.singletonList(partition), Function.identity())
+        );
+    }
+
+    @Test
+    public void unassigned_givenNonAssignedPartition_expectsEmptyResult() {
+        TopicPartition partition = new TopicPartition("topic", 0);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
+
+        Collection<TopicPartition> result = pollManager.unassigned(Collections.singletonList(partition));
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void unassigned_givenRevokedPartition_expectsCoordinationOfInvocations() {
+        TopicPartition partition1 = new TopicPartition("topic", 0);
+        TopicPartition partition2 = new TopicPartition("topic", 1);
+
+        Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
+        pollManager.activateAssigned(consumer, Arrays.asList(partition1, partition2), Function.identity());
+
+        Collection<TopicPartition> result = pollManager.unassigned(Collections.singletonList(partition1));
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains(partition1));
+        verify(pollStrategy).onPollingProhibited(argThat(it -> it.size() == 1 && it.contains(partition1)));
+        assertEquals(partition2, pollManager.activated(partition2));
+    }
+
+    @Test
+    public void pollWakeably_givenSufficientCapacity_expectsPreparationAndPolling() {
+        Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
+        when(consumer.poll(any())).thenReturn(ConsumerRecords.empty());
+
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+
+        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
+
+        ConsumerRecords<?, ?> records = pollManager.pollWakeably(consumer, () -> 1, () -> true);
+
+        assertEquals(ConsumerRecords.empty(), records);
+        verify(pollStrategy).prepareForPoll(any());
+        verify(consumer, never()).pause(any());
+        verify(consumer).poll(any());
+    }
+
+    @Test
+    public void pollWakeably_givenInsufficientCapacity_expectsPreparationAndPolling() {
+        Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
+        when(consumer.poll(any())).thenReturn(ConsumerRecords.empty());
+
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+
+        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
+
+        ConsumerRecords<?, ?> records = pollManager.pollWakeably(consumer, () -> 0, () -> true);
+
+        assertEquals(ConsumerRecords.empty(), records);
+        verify(pollStrategy, never()).prepareForPoll(any());
+        verify(consumer).pause(any());
+        verify(consumer).poll(any());
+    }
+
+    @Test
+    public void pollWakeably_givenWakeupException_expectsEmptyRecords() {
+        Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
+        when(consumer.poll(any())).thenThrow(new WakeupException());
+
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
+
+        ConsumerRecords<?, ?> records = pollManager.pollWakeably(consumer, () -> 1, () -> false);
+
+        assertEquals(ConsumerRecords.empty(), records);
+        verify(consumer).poll(any());
+    }
+
+    @Test
+    public void pollWakeably_givenWakeupExceptionAndCanRetry_expectsRecursiveCall() {
+        Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
+        when(consumer.poll(any()))
+            .thenThrow(new WakeupException())
+            .thenReturn(ConsumerRecords.empty());
+
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
+
+        ConsumerRecords<?, ?> records = pollManager.pollWakeably(consumer, () -> 1, () -> true);
+
+        assertEquals(ConsumerRecords.empty(), records);
+        verify(consumer, times(2)).poll(any());
+    }
+
+    @Test
+    public void pollWakeably_givenBackpressureTransition_expectsStateUpdate() {
+        TopicPartition partition = new TopicPartition("topic", 0);
+        Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
+        when(consumer.poll(any())).thenReturn(ConsumerRecords.empty());
+
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 2, Duration.ZERO);
+        pollManager.activateAssigned(consumer, Collections.singletonList(partition), Function.identity());
+
+        // First call with sufficient capacity
+        pollManager.pollWakeably(consumer, () -> 2, () -> true);
+        verify(consumer, never()).pause(any());
+
+        // Second call with insufficient capacity - should pause
+        pollManager.pollWakeably(consumer, () -> 1, () -> true);
+        verify(consumer).pause(argThat(partitions -> partitions.contains(partition)));
+    }
+
+    @Test
+    public void shouldWakeupOnSingularCapacityReclamation_givenCorrectConditions_expectsTrue() {
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 5, Duration.ZERO);
+
+        // Simulate being paused due to backpressure
+        Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
+        when(consumer.poll(any())).thenReturn(ConsumerRecords.empty());
+        pollManager.pollWakeably(consumer, () -> 1, () -> true);
+
+        assertTrue(pollManager.shouldWakeupOnSingularCapacityReclamation(5));
+        assertFalse(pollManager.shouldWakeupOnSingularCapacityReclamation(4));
+    }
+
+    @Test
+    public void forcePause_givenPartitions_expectsCoordination() {
+        TopicPartition partition = new TopicPartition("topic", 0);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
+
+        pollManager.forcePause(Collections.singletonList(partition));
+
+        verify(pollStrategy).onPollingProhibited(argThat(partitions -> partitions.contains(partition)));
+    }
+
+    @Test
+    public void allowResumption_givenPartitions_expectsCoordination() {
+        TopicPartition partition = new TopicPartition("topic", 0);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
+
+        pollManager.forcePause(Collections.singletonList(partition));
+        pollManager.allowResumption(Collections.singletonList(partition));
+
+        verify(pollStrategy).onPollingPermitted(argThat(partitions -> partitions.contains(partition)));
+    }
+}

--- a/kafka/src/test/java/io/atleon/kafka/PollStrategyTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/PollStrategyTest.java
@@ -1,0 +1,83 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PollStrategyTest {
+
+    @Test
+    public void prepareForPoll_givenConsecutiveBinaryStridesPreparation_expectsStridedPauseResume() {
+        List<TopicPartition> partitions = IntStream.range(0, 7)
+            .mapToObj(it -> new TopicPartition("topic", it))
+            .collect(Collectors.toList());
+
+        PollSelectionContext context = mock(PollSelectionContext.class);
+
+        PollStrategy pollStrategy = PollStrategy.binaryStrides();
+        pollStrategy.onPollingPermitted(partitions);
+
+        pollStrategy.prepareForPoll(context);
+        verify(context).selectExclusively(eqSelection(partitions, 0, 2, 4, 6));
+
+        pollStrategy.prepareForPoll(context);
+        verify(context).selectExclusively(eqSelection(partitions, 1, 3, 5));
+
+        pollStrategy.prepareForPoll(context);
+        verify(context).selectExclusively(eqSelection(partitions, 0, 1, 4, 5));
+
+        pollStrategy.prepareForPoll(context);
+        verify(context).selectExclusively(eqSelection(partitions, 2, 3, 6));
+
+        pollStrategy.prepareForPoll(context);
+        verify(context).selectExclusively(eqSelection(partitions, 0, 1, 2, 3));
+
+        pollStrategy.prepareForPoll(context);
+        verify(context).selectExclusively(eqSelection(partitions, 4, 5, 6));
+    }
+
+    @Test
+    public void prepareForPoll_givenPartitionsWithBatchLag_expectsSelectionOfPartitionsWithHighestBatchLag() {
+        List<TopicPartition> topicPartitions = Arrays.asList(
+            new TopicPartition("topic", 0),
+            new TopicPartition("topic", 1),
+            new TopicPartition("topic", 2),
+            new TopicPartition("topic", 3)
+        );
+
+        Map<TopicPartition, Long> batchLag = new HashMap<>();
+        batchLag.put(topicPartitions.get(0), 1L);
+        batchLag.put(topicPartitions.get(1), 5L);
+        batchLag.put(topicPartitions.get(2), 0L);
+        batchLag.put(topicPartitions.get(3), 5L);
+
+        PollSelectionContext context = mock(PollSelectionContext.class);
+        when(context.currentBatchLag(eq(batchLag.keySet()), anyLong())).thenReturn(batchLag);
+
+        PollStrategy pollStrategy = PollStrategy.greatestBatchLag();
+        pollStrategy.onPollingPermitted(topicPartitions);
+        pollStrategy.prepareForPoll(context);
+
+        verify(context).selectExclusively(eqSelection(topicPartitions, 1, 3));
+    }
+
+    private static <T> Set<T> eqSelection(List<T> list, int... indices) {
+        Collection<T> selection = IntStream.of(indices).mapToObj(list::get).collect(Collectors.toSet());
+        return argThat(it -> it.size() == selection.size() && it.containsAll(selection));
+    }
+}

--- a/kafka/src/test/java/io/atleon/kafka/PollingSubscriptionFactoryTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/PollingSubscriptionFactoryTest.java
@@ -1,0 +1,228 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.consumer.RetriableCommitFailedException;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PollingSubscriptionFactoryTest {
+
+    @Test
+    public void poll_givenInsufficientPrefetchCapacity_expectsPausing() {
+        String topic = "topic";
+        Map<TopicPartition, Long> beginningOffsets = Collections.singletonMap(new TopicPartition(topic, 0), 0L);
+        Sinks.Many<Long> polled = Sinks.many().multicast().directBestEffort();
+
+        MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        mockConsumer.updateBeginningOffsets(beginningOffsets);
+        mockConsumer.schedulePollTask(() -> mockConsumer.rebalance(beginningOffsets.keySet()));
+        schedulePollEventing(mockConsumer, polled);
+
+        KafkaReceiverOptions<String, String> options = KafkaReceiverOptions.newBuilder(__ -> mockConsumer)
+            .consumerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .consumerProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1)
+            .fullPollRecordsPrefetch(1)
+            .build();
+
+        KafkaReceiver.create(options)
+            .receiveManual(Collections.singletonList(topic))
+            .as(it -> StepVerifier.create(it, 1))
+            .then(polled.asFlux().take(5).then()::block)
+            .then(() -> mockConsumer.addRecord(new ConsumerRecord<>(topic, 0, 0L, "key", "value")))
+            .then(() -> mockConsumer.addRecord(new ConsumerRecord<>(topic, 0, 1L, "key", "value")))
+            .expectNextCount(1L)
+            .then(polled.asFlux().take(5).then()::block)
+            .then(() -> assertEquals(beginningOffsets.keySet(), mockConsumer.paused()))
+            .thenRequest(1L)
+            .expectNextCount(1)
+            .then(polled.asFlux().take(5).then()::block)
+            .then(() -> assertTrue(mockConsumer.paused().isEmpty()))
+            .thenCancel()
+            .verify();
+    }
+
+    @Test
+    public void poll_givenExternallyPausedPartitions_expectsAppropriatePausingAndResuming() {
+        String topic = "topic";
+        TopicPartition firstTopicPartition = new TopicPartition(topic, 0);
+        TopicPartition secondTopicPartition = new TopicPartition(topic, 1);
+        Map<TopicPartition, Long> beginningOffsets = new HashMap<>();
+        beginningOffsets.put(firstTopicPartition, 0L);
+        beginningOffsets.put(secondTopicPartition, 0L);
+        Sinks.Many<Long> polled = Sinks.many().multicast().directBestEffort();
+
+        MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        mockConsumer.updateBeginningOffsets(beginningOffsets);
+        mockConsumer.schedulePollTask(() -> mockConsumer.rebalance(beginningOffsets.keySet()));
+        schedulePollEventing(mockConsumer, polled);
+
+        ConsumerListener consumerListener = ConsumerListener.doOnPartitionsAssignedOnce((consumer, partitions) -> {
+            if (partitions.contains(firstTopicPartition)) {
+                consumer.pause(Collections.singletonList(firstTopicPartition));
+            }
+        });
+        KafkaReceiverOptions<String, String> options = KafkaReceiverOptions.newBuilder(__ -> mockConsumer)
+            .consumerListener(consumerListener)
+            .consumerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .consumerProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1)
+            .fullPollRecordsPrefetch(1)
+            .build();
+
+        KafkaReceiver.create(options)
+            .receiveManual(Collections.singletonList(topic))
+            .as(it -> StepVerifier.create(it, 1))
+            .then(polled.asFlux().take(5).then()::block)
+            .then(() -> mockConsumer.addRecord(new ConsumerRecord<>(topic, 0, 0L, "key", "value")))
+            .then(() -> mockConsumer.addRecord(new ConsumerRecord<>(topic, 1, 0L, "key", "value")))
+            .then(() -> mockConsumer.addRecord(new ConsumerRecord<>(topic, 0, 1L, "key", "value")))
+            .then(() -> mockConsumer.addRecord(new ConsumerRecord<>(topic, 1, 1L, "key", "value")))
+            .expectNextMatches(it -> it.topicPartition().equals(secondTopicPartition))
+            .then(polled.asFlux().take(5).then()::block)
+            .then(() -> assertEquals(beginningOffsets.keySet(), mockConsumer.paused()))
+            .thenRequest(1L)
+            .expectNextCount(1)
+            .then(polled.asFlux().take(5).then()::block)
+            .then(() -> assertEquals(Collections.singleton(firstTopicPartition), mockConsumer.paused()))
+            .thenCancel()
+            .verify();
+    }
+
+    @Test
+    public void commit_givenNonRetriableFailure_expectsError() {
+        String topic = "topic";
+        Map<TopicPartition, Long> beginningOffsets = Collections.singletonMap(new TopicPartition(topic, 0), 0L);
+        Sinks.Many<Long> polled = Sinks.many().multicast().directBestEffort();
+
+        MockConsumer<String, String> mockConsumer = new MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
+            @Override
+            public synchronized void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback) {
+                callback.onComplete(offsets, new UnsupportedOperationException("Boom"));
+            }
+        };
+        mockConsumer.updateBeginningOffsets(beginningOffsets);
+        mockConsumer.schedulePollTask(() -> mockConsumer.rebalance(beginningOffsets.keySet()));
+        schedulePollEventing(mockConsumer, polled);
+
+        KafkaReceiverOptions<String, String> options = KafkaReceiverOptions.newBuilder(__ -> mockConsumer)
+            .consumerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .commitBatchSize(1)
+            .build();
+
+        KafkaReceiver.create(options)
+            .receiveManual(Collections.singletonList(topic))
+            .as(it -> StepVerifier.create(it, 1))
+            .then(polled.asFlux().take(5).then()::block)
+            .then(() -> mockConsumer.addRecord(new ConsumerRecord<>(topic, 0, 0L, "key", "value")))
+            .consumeNextWith(KafkaReceiverRecord::acknowledge)
+            .expectError(UnsupportedOperationException.class)
+            .verify();
+    }
+
+    @Test
+    public void commit_givenRetriableFailureWithEventualSuccess_expectsRetryAndSuccess() {
+        String topic = "topic";
+        Map<TopicPartition, Long> beginningOffsets = Collections.singletonMap(new TopicPartition(topic, 0), 0L);
+        Sinks.Many<Long> polled = Sinks.many().multicast().directBestEffort();
+
+        AtomicInteger commitAttempts = new AtomicInteger(0);
+        Sinks.Empty<Void> succeeded = Sinks.empty();
+        MockConsumer<String, String> mockConsumer = new MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
+            @Override
+            public synchronized void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback) {
+                int attempt = commitAttempts.incrementAndGet();
+                if (attempt == 1) {
+                    // First attempt fails with retriable error
+                    callback.onComplete(offsets, new RetriableCommitFailedException("Persistent network error"));
+                } else {
+                    // Subsequent attempts succeed
+                    callback.onComplete(offsets, null);
+                    succeeded.tryEmitEmpty();
+                }
+            }
+        };
+        mockConsumer.updateBeginningOffsets(beginningOffsets);
+        mockConsumer.schedulePollTask(() -> mockConsumer.rebalance(beginningOffsets.keySet()));
+        schedulePollEventing(mockConsumer, polled);
+
+        KafkaReceiverOptions<String, String> options = KafkaReceiverOptions.newBuilder(__ -> mockConsumer)
+            .consumerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .commitBatchSize(1)
+            .maxCommitAttempts(3)
+            .build();
+
+        KafkaReceiver.create(options)
+            .receiveManual(Collections.singletonList(topic))
+            .as(StepVerifier::create)
+            .then(polled.asFlux().take(5).then()::block)
+            .then(() -> mockConsumer.addRecord(new ConsumerRecord<>(topic, 0, 0L, "key", "value")))
+            .consumeNextWith(KafkaReceiverRecord::acknowledge)
+            .then(polled.asFlux().take(5).then()::block)
+            .thenCancel()
+            .verify();
+
+        // Verify retry occurred and eventually succeeded
+        assertEquals(2, commitAttempts.get());
+    }
+
+    @Test
+    public void commit_givenRetriableFailureWithRetriesExhausted_expectsError() {
+        String topic = "topic";
+        Map<TopicPartition, Long> beginningOffsets = Collections.singletonMap(new TopicPartition(topic, 0), 0L);
+        Sinks.Many<Long> polled = Sinks.many().multicast().directBestEffort();
+
+        AtomicInteger commitAttempts = new AtomicInteger(0);
+        MockConsumer<String, String> mockConsumer = new MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
+            @Override
+            public synchronized void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback) {
+                commitAttempts.incrementAndGet();
+                // Always fail with retriable error
+                callback.onComplete(offsets, new RetriableCommitFailedException("Persistent network error"));
+            }
+        };
+        mockConsumer.updateBeginningOffsets(beginningOffsets);
+        mockConsumer.schedulePollTask(() -> mockConsumer.rebalance(beginningOffsets.keySet()));
+        schedulePollEventing(mockConsumer, polled);
+
+        KafkaReceiverOptions<String, String> options = KafkaReceiverOptions.newBuilder(__ -> mockConsumer)
+            .consumerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .commitBatchSize(1)
+            .maxCommitAttempts(2) // Only allow 2 attempts
+            .build();
+
+        KafkaReceiver.create(options)
+            .receiveManual(Collections.singletonList(topic))
+            .as(StepVerifier::create)
+            .then(polled.asFlux().take(5).then()::block)
+            .then(() -> mockConsumer.addRecord(new ConsumerRecord<>(topic, 0, 0L, "key", "value")))
+            .consumeNextWith(KafkaReceiverRecord::acknowledge)
+            .expectError(KafkaException.class)
+            .verify();
+
+        // Verify max attempts were made
+        assertEquals(options.maxCommitAttempts(), commitAttempts.get());
+    }
+
+    private static void schedulePollEventing(MockConsumer<String, String> mockConsumer, Sinks.Many<Long> polled) {
+        mockConsumer.schedulePollTask(() -> {
+            polled.tryEmitNext(System.currentTimeMillis());
+            schedulePollEventing(mockConsumer, polled);
+        });
+    }
+}

--- a/kafka/src/test/java/io/atleon/kafka/ReceivingConsumerTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/ReceivingConsumerTest.java
@@ -1,0 +1,236 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Sinks;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReceivingConsumerTest {
+
+    @Test
+    public void invoke_givenPermittedMethodCallsToPauseAndResume_expectsReturnedResult() {
+        TopicPartition topicPartition = new TopicPartition("topic", 0);
+        MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+
+        KafkaReceiverOptions<String, String> options = KafkaReceiverOptions.newBuilder(__ -> mockConsumer)
+            .consumerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .build();
+
+        Set<TopicPartition> paused = new HashSet<>();
+        Set<TopicPartition> resumed = new HashSet<>();
+        NoOpPartitionListener partitionListener = new NoOpPartitionListener() {
+            @Override
+            public void onExternalPartitionsPauseRequested(Collection<TopicPartition> partitions) {
+                paused.addAll(partitions);
+            }
+
+            @Override
+            public void onExternalPartitionsResumeRequested(Collection<TopicPartition> partitions) {
+                resumed.addAll(partitions);
+            }
+        };
+
+        Sinks.One<Throwable> error = Sinks.one();
+
+        ReceivingConsumer<String, String> receivingConsumer =
+            new ReceivingConsumer<>(options, partitionListener, error::tryEmitValue);
+        mockConsumer.assign(Collections.singletonList(topicPartition));
+
+        receivingConsumer.invoke(consumer -> consumer.pause(Collections.singletonList(topicPartition))).block();
+        receivingConsumer.invoke(consumer -> consumer.resume(Collections.singletonList(topicPartition))).block();
+
+        assertEquals(Collections.singleton(topicPartition), paused);
+        assertEquals(Collections.singleton(topicPartition), resumed);
+    }
+
+    @Test
+    public void invoke_givenPermittedPauseToUnassignedPartition_expectsSuccessfulPausing() {
+        TopicPartition topicPartition = new TopicPartition("topic", 0);
+        MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+
+        KafkaReceiverOptions<String, String> options = KafkaReceiverOptions.newBuilder(__ -> mockConsumer)
+            .consumerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .build();
+
+        Set<TopicPartition> paused = new HashSet<>();
+        NoOpPartitionListener partitionListener = new NoOpPartitionListener() {
+            @Override
+            public void onExternalPartitionsPauseRequested(Collection<TopicPartition> partitions) {
+                paused.addAll(partitions);
+            }
+        };
+
+        Sinks.One<Throwable> error = Sinks.one();
+
+        ReceivingConsumer<String, String> receivingConsumer =
+            new ReceivingConsumer<>(options, partitionListener, error::tryEmitValue);
+
+        receivingConsumer.invoke(it -> it.pause(Collections.singletonList(topicPartition))).block();
+
+        assertEquals(Collections.singleton(topicPartition), paused);
+    }
+
+    @Test
+    public void invoke_givenProhibitedMethodCall_expectsUnsupportedOperationException() {
+        MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+
+        KafkaReceiverOptions<String, String> options = KafkaReceiverOptions.newBuilder(__ -> mockConsumer)
+            .consumerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .build();
+        Sinks.One<Throwable> error = Sinks.one();
+
+        ReceivingConsumer<String, String> receivingConsumer =
+            new ReceivingConsumer<>(options, new NoOpPartitionListener(), error::tryEmitValue);
+
+        assertThrows(UnsupportedOperationException.class, receivingConsumer.invoke(Consumer::wakeup)::block);
+    }
+
+    @Test
+    public void invokeAndGet_givenCallFromPollingThread_expectsUnsupportedOperationException() {
+        MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+
+        KafkaReceiverOptions<String, String> options = KafkaReceiverOptions.newBuilder(__ -> mockConsumer)
+            .consumerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .build();
+        Sinks.One<Throwable> error = Sinks.one();
+
+        ReceivingConsumer<String, String> receivingConsumer =
+            new ReceivingConsumer<>(options, new NoOpPartitionListener(), error::tryEmitValue);
+
+        receivingConsumer.schedule(__ -> receivingConsumer.invokeAndGet(Consumer::paused));
+
+        assertInstanceOf(UnsupportedOperationException.class, error.asMono().block());
+    }
+
+    @Test
+    public void onPartitionsAssigned_givenCallOnProxyFromNonPollingThread_expectsUnsupportedOperationException() {
+        MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+
+        ConsumerListener consumerListener = new ConsumerListener() {
+            @Override
+            public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+                consumer.paused();
+            }
+        };
+
+        KafkaReceiverOptions<String, String> options = KafkaReceiverOptions.newBuilder(__ -> mockConsumer)
+            .consumerListener(consumerListener)
+            .consumerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .build();
+        Sinks.One<Throwable> error = Sinks.one();
+
+        ReceivingConsumer<String, String> receivingConsumer =
+            new ReceivingConsumer<>(options, new NoOpPartitionListener(), error::tryEmitValue);
+
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> receivingConsumer.onPartitionsAssigned(Collections.emptyList()));
+    }
+
+    @Test
+    public void subscribe_givenSubscriptionError_expectsContinuationOfTaskLoop() {
+        MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+
+        KafkaReceiverOptions<String, String> options = KafkaReceiverOptions.newBuilder(__ -> mockConsumer)
+            .consumerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .build();
+        Sinks.One<Throwable> error = Sinks.one();
+
+        ReceivingConsumer<String, String> receivingConsumer =
+            new ReceivingConsumer<>(options, new NoOpPartitionListener(), error::tryEmitValue);
+
+        receivingConsumer.subscribe(
+            ConsumptionSpec.subscribe(Collections.singletonList("topic")),
+            consumer -> {
+                throw new UnsupportedOperationException("Bang");
+            });
+
+        receivingConsumer.closeSafely().block();
+
+        assertInstanceOf(UnsupportedOperationException.class, error.asMono().block());
+        assertTrue(mockConsumer.closed());
+    }
+
+    @Test
+    public void wakeupSafely_givenInvocationFromTaskThread_expectsNoOp() {
+        MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+
+        KafkaReceiverOptions<String, String> options = KafkaReceiverOptions.newBuilder(__ -> mockConsumer)
+            .consumerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .build();
+        Sinks.One<Throwable> error = Sinks.one();
+
+        ReceivingConsumer<String, String> receivingConsumer =
+            new ReceivingConsumer<>(options, new NoOpPartitionListener(), error::tryEmitValue);
+
+        receivingConsumer.schedule(__ -> {
+            receivingConsumer.wakeupSafely();
+            error.tryEmitEmpty();
+        });
+
+        assertNull(error.asMono().block());
+        assertDoesNotThrow(() -> mockConsumer.poll(Duration.ZERO));
+    }
+
+    @Test
+    public void wakeupSafely_givenInvocationFromNonTaskThread_expectsNoOp() {
+        MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+
+        KafkaReceiverOptions<String, String> options = KafkaReceiverOptions.newBuilder(__ -> mockConsumer)
+            .consumerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .build();
+        Sinks.One<Throwable> error = Sinks.one();
+
+        ReceivingConsumer<String, String> receivingConsumer =
+            new ReceivingConsumer<>(options, new NoOpPartitionListener(), error::tryEmitValue);
+
+        receivingConsumer.wakeupSafely();
+
+        assertThrows(WakeupException.class, () -> mockConsumer.poll(Duration.ZERO));
+    }
+
+    public static class NoOpPartitionListener implements ReceivingConsumer.PartitionListener {
+
+        @Override
+        public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+
+        }
+
+        @Override
+        public void onPartitionsRevoked(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+
+        }
+
+        @Override
+        public void onPartitionsLost(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+
+        }
+
+        @Override
+        public void onExternalPartitionsPauseRequested(Collection<TopicPartition> partitions) {
+
+        }
+
+        @Override
+        public void onExternalPartitionsResumeRequested(Collection<TopicPartition> partitions) {
+
+        }
+    }
+}

--- a/kafka/src/test/java/io/atleon/kafka/SendingProducerTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/SendingProducerTest.java
@@ -1,0 +1,113 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SendingProducerTest {
+
+    @Test
+    public void invokeAndGet_givenPermittedMethodCalls_expectsReturnedResult() {
+        MockProducer<String, String> mockProducer = new MockProducer<>();
+
+        KafkaSenderOptions<String, String> options = KafkaSenderOptions.newBuilder(__ -> mockProducer)
+            .producerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .build();
+
+        SendingProducer<String, String> producer = new SendingProducer<>(options);
+
+        assertNotNull(producer.invokeAndGet(Producer::metrics).block());
+    }
+
+    @Test
+    public void invoke_givenProhibitedMethodCall_expectsUnsupportedOperationException() {
+        MockProducer<String, String> mockProducer = new MockProducer<>();
+
+        KafkaSenderOptions<String, String> options = KafkaSenderOptions.newBuilder(__ -> mockProducer)
+            .producerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .build();
+
+        SendingProducer<String, String> producer = new SendingProducer<>(options);
+
+        assertThrows(UnsupportedOperationException.class, () -> producer.invoke(Producer::close).block());
+    }
+
+    @Test
+    public void invoke_givenRecursiveInvocation_expectsUnsupportedOperationException() {
+        MockProducer<String, String> mockProducer = new MockProducer<>();
+
+        KafkaSenderOptions<String, String> options = KafkaSenderOptions.newBuilder(__ -> mockProducer)
+            .producerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .build();
+
+        SendingProducer<String, String> producer = new SendingProducer<>(options);
+
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> producer.invoke(__ -> producer.invoke(Producer::metrics)).block());
+    }
+
+    @Test
+    public void initTransactions_givenMultipleExecutions_expectsProducerInitializationOnce() {
+        MockProducer<String, String> mockProducer = new MockProducer<>();
+
+        KafkaSenderOptions<String, String> options = KafkaSenderOptions.newBuilder(__ -> mockProducer)
+            .producerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .build();
+
+        SendingProducer<String, String> producer = new SendingProducer<>(options);
+
+        producer.initTransactions().block();
+        producer.initTransactions().block();
+
+        assertTrue(mockProducer.transactionInitialized());
+        assertFalse(mockProducer.closed());
+    }
+
+    @Test
+    public void initTransactions_givenInitialFailureFollowedBySuccess_expectsProducerInitializationOnce() {
+        MockProducer<String, String> mockProducer = new MockProducer<>();
+
+        KafkaSenderOptions<String, String> options = KafkaSenderOptions.newBuilder(__ -> mockProducer)
+            .producerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .build();
+
+        SendingProducer<String, String> producer = new SendingProducer<>(options);
+
+        mockProducer.initTransactionException = new KafkaException("test");
+        assertThrows(KafkaException.class, () -> producer.initTransactions().block());
+
+        mockProducer.initTransactionException = null;
+        producer.initTransactions().block();
+        producer.initTransactions().block();
+
+        assertTrue(mockProducer.transactionInitialized());
+        assertFalse(mockProducer.closed());
+    }
+
+    @Test
+    public void initTransactions_givenProducerFencedException_expectsProducerToBeClosed() {
+        MockProducer<String, String> mockProducer = new MockProducer<>();
+
+        mockProducer.initTransactionException = new ProducerFencedException("test");
+
+        KafkaSenderOptions<String, String> options = KafkaSenderOptions.newBuilder(__ -> mockProducer)
+            .producerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+            .build();
+
+        SendingProducer<String, String> producer = new SendingProducer<>(options);
+
+        assertThrows(ProducerFencedException.class, () -> producer.initTransactions().block());
+        assertNull(producer.closed().block());
+        assertTrue(mockProducer.closed());
+    }
+}

--- a/kafka/src/test/java/io/atleon/kafka/TransactionalProcessingTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/TransactionalProcessingTest.java
@@ -1,0 +1,196 @@
+package io.atleon.kafka;
+
+import io.atleon.kafka.embedded.EmbeddedKafka;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class TransactionalProcessingTest {
+
+    private static final String BOOTSTRAP_CONNECT = EmbeddedKafka.startAndGetBootstrapServersConnect(10092);
+
+    @Test
+    public void process_givenSuccessfulProcessing_expectsSubsequentContinuation() {
+        // Create topics and test data
+        String inputTopic = UUID.randomUUID().toString();
+        String outputTopic = UUID.randomUUID().toString();
+
+        KafkaSenderRecord<String, String, Object> senderRecord1 =
+            KafkaSenderRecord.create(inputTopic, "key", "value1", null);
+        KafkaSenderRecord<String, String, Object> senderRecord2 =
+            KafkaSenderRecord.create(inputTopic, "key", "value2", null);
+
+        // Create transactional sender and produce test data
+        KafkaSenderOptions<String, String> senderOptions = KafkaSenderOptions.<String, String>newBuilder()
+            .producerProperties(newProducerProperties(UUID.randomUUID().toString()))
+            .build();
+        KafkaSender<String, String> sender = KafkaSender.create(senderOptions);
+
+        Flux.just(senderRecord1, senderRecord2).as(it -> sender.sendTransactional(Flux.just(it))).then().block();
+
+        // Create reception options
+        String groupId = UUID.randomUUID().toString();
+        ConsumerListener.Closure closureListener = ConsumerListener.closure();
+        KafkaReceiverOptions<String, String> receiverOptions = KafkaReceiverOptions.<String, String>newBuilder()
+            .consumerProperties(newConsumerProperties(groupId))
+            .consumerListener(closureListener)
+            .commitBatchSize(1)
+            .build();
+
+        // Successfully process data to output topic
+        KafkaReceiver.create(receiverOptions)
+            .receiveTxManual(sender.txManager(), Collections.singletonList(inputTopic))
+            .map(it -> KafkaSenderRecord.create(outputTopic, it.key(), it.value(), it))
+            .transform(sender::send)
+            .as(StepVerifier::create)
+            .consumeNextWith(it -> it.correlationMetadata().acknowledge())
+            .thenAwait(Duration.ofSeconds(1))
+            .thenCancel()
+            .verify();
+
+        assertNull(closureListener.closed().block());
+
+        // Verify committed offset
+        try (ReactiveAdmin admin = ReactiveAdmin.create(newKafkaProperties())) {
+            Long maxOffset = admin.listTopicPartitionGroupOffsets(groupId)
+                .reduce(0L, (max, next) -> Math.max(max, next.groupOffset()))
+                .block();
+            assertEquals(1, maxOffset);
+        }
+
+        // Verify processing continuation
+        KafkaReceiver.create(receiverOptions)
+            .receiveManual(Collections.singletonList(outputTopic))
+            .as(StepVerifier::create)
+            .expectNextMatches(it -> it.consumerRecord().key().equals(senderRecord1.key()))
+            .thenCancel()
+            .verify();
+
+        sender.close();
+    }
+
+    @Test
+    public void process_givenFailedProcessing_expectsReprocessing() {
+        // Create topics and test data
+        String inputTopic = UUID.randomUUID().toString();
+        String outputTopic = UUID.randomUUID().toString();
+
+        KafkaSenderRecord<String, String, Object> senderRecord1 =
+            KafkaSenderRecord.create(inputTopic, "key", "value1", null);
+        KafkaSenderRecord<String, String, Object> senderRecord2 =
+            KafkaSenderRecord.create(inputTopic, "key", "value2", null);
+
+        // Create transactional sender and produce test data
+        KafkaSenderOptions<String, String> senderOptions = KafkaSenderOptions.<String, String>newBuilder()
+            .producerProperties(newProducerProperties(UUID.randomUUID().toString()))
+            .build();
+        KafkaSender<String, String> sender = KafkaSender.create(senderOptions);
+
+        Flux.just(senderRecord1, senderRecord2).as(it -> sender.sendTransactional(Flux.just(it))).then().block();
+
+        // Create reception options
+        String groupId = UUID.randomUUID().toString();
+        ConsumerListener.Closure closureListener = ConsumerListener.closure();
+        KafkaReceiverOptions<String, String> receiverOptions = KafkaReceiverOptions.<String, String>newBuilder()
+            .consumerProperties(newConsumerProperties(groupId))
+            .consumerListener(closureListener)
+            .commitBatchSize(2)
+            .build();
+
+        // Fail transactional processing of data
+        KafkaReceiver.create(receiverOptions)
+            .receiveTxManual(sender.txManager(), Collections.singletonList(inputTopic))
+            .map(it -> KafkaSenderRecord.create(outputTopic, it.key(), it.value(), it))
+            .transform(sender::send)
+            .as(it -> StepVerifier.create(it, 1))
+            .consumeNextWith(it -> it.correlationMetadata().nacknowledge(new UnsupportedOperationException("Boom")))
+            .expectError(UnsupportedOperationException.class)
+            .verify();
+
+        assertNull(closureListener.closed().block());
+
+        // Verify expected input offsets and output records
+        try (ReactiveAdmin admin = ReactiveAdmin.create(newKafkaProperties())) {
+            Long maxOffset = admin.listTopicPartitionGroupOffsets(groupId)
+                .reduce(0L, (max, next) -> Math.max(max, next.groupOffset()))
+                .block();
+            assertEquals(0, maxOffset);
+
+            Map<TopicPartition, Long> outputOffsets = admin.listTopicPartitions(outputTopic)
+                .collectList()
+                .flatMap(it -> admin.listOffsets(it, OffsetSpec.latest()))
+                .block();
+            // Uncommitted record written, plus ABORT marker
+            assertEquals(2, outputOffsets.values().stream().reduce(0L, Math::max));
+        }
+
+        // Verify reprocessing of previously failed record(s)
+        KafkaReceiver.create(receiverOptions)
+            .receiveTxManual(sender.txManager(), Collections.singletonList(inputTopic))
+            .map(it -> KafkaSenderRecord.create(outputTopic, it.key(), it.value(), it))
+            .transform(sender::send)
+            .as(StepVerifier::create)
+            .consumeNextWith(it -> it.correlationMetadata().acknowledge())
+            .consumeNextWith(it -> it.correlationMetadata().acknowledge())
+            .thenAwait(Duration.ofSeconds(1))
+            .thenCancel()
+            .verify();
+
+        // Verify expected input offsets and output records
+        try (ReactiveAdmin admin = ReactiveAdmin.create(newKafkaProperties())) {
+            Long maxGroupOffset = admin.listTopicPartitionGroupOffsets(groupId)
+                .reduce(0L, (max, next) -> Math.max(max, next.groupOffset()))
+                .block();
+            assertEquals(2, maxGroupOffset);
+
+            Map<TopicPartition, Long> outputOffsets = admin.listTopicPartitions(outputTopic)
+                .collectList()
+                .flatMap(it -> admin.listOffsets(it, OffsetSpec.latest()))
+                .block();
+            assertEquals(5, outputOffsets.values().stream().reduce(0L, Math::max));
+        }
+
+        sender.close();
+    }
+
+    private static Map<String, Object> newProducerProperties(String transactionalId) {
+        Map<String, Object> producerProperties = newKafkaProperties();
+        producerProperties.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
+        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        return producerProperties;
+    }
+
+    private static Map<String, Object> newConsumerProperties(String groupId) {
+        Map<String, Object> consumerProperties = newKafkaProperties();
+        consumerProperties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        consumerProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        consumerProperties.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        return consumerProperties;
+    }
+
+    private static Map<String, Object> newKafkaProperties() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CommonClientConfigs.CLIENT_ID_CONFIG, UUID.randomUUID().toString());
+        properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_CONNECT);
+        return properties;
+    }
+}


### PR DESCRIPTION
### :pencil: Description
- Implementing replaceable alternative for Reactor Kafka (due to [support discontinuation](https://spring.io/blog/2025/05/20/reactor-kafka-discontinued))
- Receiver improvements:
  - Fully async and lockless (vs. [usage of `synchronized`](https://github.com/reactor/reactor-kafka/blob/f7ba7db945f682db0351fbb70dfff406432158a9/src/main/java/reactor/kafka/receiver/internals/CommittableBatch.java#L48-L182))
  - Supports fair and/or dynamic polling
  - No longer dependent on [busy waiting](https://github.com/reactor/reactor-kafka/blob/1.3.x/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java#L176)
  - Listener hooks now available for consumer and reception lifecycle
  - Support for both positive and negative acknowledgement
  - Simplified deterministic prefetch control
  - Active in-flight limiting enabled by default
  - Guaranteed in-order offset commitment independent of processing order with constant time complexity (vs. [logarithmic](https://github.com/reactor/reactor-kafka/blob/f7ba7db945f682db0351fbb70dfff406432158a9/src/main/java/reactor/kafka/receiver/internals/CommittableBatch.java#L53))
  - Simplified transactional API
  - Exactly once semantics now automatically/transparently handled
  - Fixed [Consumer instance leak bug](https://github.com/atleon/atleon/issues/334)
- Sender improvements:
  - Simplified threading model
  - Producer sends can now be scheduled immediately (on publishing thread)
  - Simplified transactional API
- Omitted/Deferred features:
  - At-most-once reception
  - Kafka-native batch reception (replaceable with Reactor-native buffer operators)
  - Kafka sending/outbound gateway building (replaceable with Reactor-native `Flux` chaining)
  - Micrometer Observation decoration (replaceable with `Alo`-specific reception)

### :link: Related Issues
#396 