### PR TITLE
[#398] Enable migration to optimized Kafka Receiver+Sender

### DIFF
--- a/kafka-embedded/pom.xml
+++ b/kafka-embedded/pom.xml
@@ -27,6 +27,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/kafka/src/main/java/io/atleon/kafka/ConsumerMutexEnforcer.java
+++ b/kafka/src/main/java/io/atleon/kafka/ConsumerMutexEnforcer.java
@@ -16,7 +16,6 @@ import org.apache.kafka.common.Uuid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.kafka.receiver.ReceiverOptions;
-import reactor.kafka.receiver.internals.ConsumerFactory;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -36,7 +35,7 @@ import java.util.regex.Pattern;
  * possible for a Consumer and its event loop to become orphaned, yet continue to poll with paused
  * partitions, and therefore silently occupy assigned partitions without doing any processing.
  */
-class ConsumerMutexEnforcer extends ConsumerFactory {
+class ConsumerMutexEnforcer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerMutexEnforcer.class);
 
@@ -50,7 +49,7 @@ class ConsumerMutexEnforcer extends ConsumerFactory {
         return new KafkaConsumer<>(options.consumerProperties(), options.keyDeserializer(), options.valueDeserializer());
     }
 
-    final class ProhibitableConsumerFactory extends ConsumerFactory {
+    final class ProhibitableConsumerFactory extends reactor.kafka.receiver.internals.ConsumerFactory {
 
         private final int ticket;
 

--- a/kafka/src/main/java/io/atleon/kafka/ContextualProducer.java
+++ b/kafka/src/main/java/io/atleon/kafka/ContextualProducer.java
@@ -74,7 +74,9 @@ final class ContextualProducer<K, V> implements Producer<K, V> {
 
     @Override
     public Future<RecordMetadata> send(ProducerRecord<K, V> record) {
-        Object correlationMetadata = SenderRecord.class.cast(record).correlationMetadata();
+        Object correlationMetadata = record instanceof SenderRecord
+            ? SenderRecord.class.cast(record).correlationMetadata()
+            : KafkaSenderRecord.class.cast(record).correlationMetadata();
         return correlationMetadata instanceof Contextual
             ? Contextual.class.cast(correlationMetadata).supplyInContext(() -> delegate.send(record))
             : delegate.send(record);
@@ -82,7 +84,9 @@ final class ContextualProducer<K, V> implements Producer<K, V> {
 
     @Override
     public Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback) {
-        Object correlationMetadata = SenderRecord.class.cast(record).correlationMetadata();
+        Object correlationMetadata = record instanceof SenderRecord
+            ? SenderRecord.class.cast(record).correlationMetadata()
+            : KafkaSenderRecord.class.cast(record).correlationMetadata();
         return correlationMetadata instanceof Contextual
             ? Contextual.class.cast(correlationMetadata).supplyInContext(() -> delegate.send(record, callback))
             : delegate.send(record, callback);

--- a/kafka/src/main/java/io/atleon/kafka/KafkaConfig.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaConfig.java
@@ -39,6 +39,14 @@ public class KafkaConfig {
         return modifiedProperties;
     }
 
+    public <T> Optional<T> loadInstanceWithPredefinedTypes(
+        String key,
+        Class<? extends T> type,
+        Function<String, Optional<T>> predefinedTypeInstantiator
+    ) {
+        return ConfigLoading.loadInstanceWithPredefinedTypes(properties, key, type, predefinedTypeInstantiator);
+    }
+
     public <T extends Configurable> Optional<T> loadConfiguredWithPredefinedTypes(
         String key,
         Class<? extends T> type,

--- a/kafka/src/main/java/io/atleon/kafka/KafkaSenderResult.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaSenderResult.java
@@ -28,6 +28,11 @@ public final class KafkaSenderResult<T> implements SenderResult {
         return new KafkaSenderResult<>(null, exception, correlationMetadata);
     }
 
+    static <T> Alo<KafkaSenderResult<T>> invertAlo(KafkaSenderResult<Alo<T>> senderResult) {
+        return senderResult.correlationMetadata().map(correlationMetadata ->
+            new KafkaSenderResult<>(senderResult.recordMetadata, senderResult.exception, correlationMetadata));
+    }
+
     static <T> KafkaSenderResult<T> fromSenderResult(reactor.kafka.sender.SenderResult<T> senderResult) {
         return new KafkaSenderResult<>(senderResult.recordMetadata(), senderResult.exception(), senderResult.correlationMetadata());
     }

--- a/kafka/src/main/java/io/atleon/kafka/LegacyReceiveResources.java
+++ b/kafka/src/main/java/io/atleon/kafka/LegacyReceiveResources.java
@@ -1,0 +1,173 @@
+package io.atleon.kafka;
+
+import io.atleon.core.AcknowledgementQueueMode;
+import io.atleon.core.Alo;
+import io.atleon.core.AloComponentExtractor;
+import io.atleon.core.AloFactory;
+import io.atleon.core.AloFactoryConfig;
+import io.atleon.core.AloQueueListener;
+import io.atleon.core.AloQueueListenerConfig;
+import io.atleon.core.AloQueueingTransformer;
+import io.atleon.core.AloSignalListenerFactory;
+import io.atleon.core.AloSignalListenerFactoryConfig;
+import io.atleon.core.ErrorEmitter;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import reactor.core.publisher.Flux;
+import reactor.kafka.receiver.KafkaReceiver;
+import reactor.kafka.receiver.ReceiverOptions;
+import reactor.kafka.receiver.ReceiverRecord;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+final class LegacyReceiveResources<K, V> {
+
+    private static final Map<String, AtomicLong> COUNTS_BY_ID = new ConcurrentHashMap<>();
+
+    private final KafkaConfig config;
+
+    private final NacknowledgerFactory<K, V> nacknowledgerFactory;
+
+    private final AcknowledgementQueueMode acknowledgementQueueMode;
+
+    public LegacyReceiveResources(KafkaConfig config) {
+        this.config = config;
+        this.nacknowledgerFactory = createNacknowledgerFactory(config);
+        this.acknowledgementQueueMode = loadAcknowledgementQueueMode(config);
+    }
+
+    public Flux<Alo<ConsumerRecord<K, V>>>
+    receive(OptionsInitializer<K, V> optionsInitializer, ConsumerMutexEnforcer consumerMutexEnforcer) {
+        ErrorEmitter<Alo<ConsumerRecord<K, V>>> errorEmitter = newErrorEmitter();
+        ReceiverOptions<K, V> options = newReceiverOptions(optionsInitializer);
+        ConsumerMutexEnforcer.ProhibitableConsumerFactory consumerFactory = consumerMutexEnforcer.newConsumerFactory();
+        return KafkaReceiver.create(consumerFactory, options).receive()
+            .transform(newAloQueueingTransformer(errorEmitter::safelyEmit))
+            .transform(errorEmitter::applyTo)
+            .transform(this::applySignalListenerFactories)
+            .doFinally(__ -> consumerFactory.prohibitFurtherConsumption(options.closeTimeout().multipliedBy(2)));
+    }
+
+    private ErrorEmitter<Alo<ConsumerRecord<K, V>>> newErrorEmitter() {
+        Duration timeout = config.loadDuration(AloKafkaReceiver.ERROR_EMISSION_TIMEOUT_CONFIG)
+            .orElse(ErrorEmitter.DEFAULT_TIMEOUT);
+        return ErrorEmitter.create(timeout);
+    }
+
+    private ReceiverOptions<K, V> newReceiverOptions(OptionsInitializer<K, V> optionsInitializer) {
+        ReceiverOptions<K, V> defaultOptions = optionsInitializer.initialize(newConsumerConfig());
+        return defaultOptions
+            .pollTimeout(config.loadDuration(AloKafkaReceiver.POLL_TIMEOUT_CONFIG)
+                .orElse(defaultOptions.pollTimeout()))
+            .commitInterval(config.loadDuration(AloKafkaReceiver.COMMIT_INTERVAL_CONFIG)
+                .orElse(defaultOptions.commitInterval()))
+            .maxCommitAttempts(config.loadInt(AloKafkaReceiver.MAX_COMMIT_ATTEMPTS_CONFIG)
+                .orElse(defaultOptions.maxCommitAttempts()))
+            .closeTimeout(config.loadDuration(AloKafkaReceiver.CLOSE_TIMEOUT_CONFIG)
+                .orElse(Duration.ofSeconds(30)))
+            .maxDelayRebalance(loadMaxDelayRebalance().orElse(defaultOptions.maxDelayRebalance()));
+    }
+
+    private Map<String, Object> newConsumerConfig() {
+        return config.modifyAndGetProperties(properties -> {
+            // Remove any Atleon-specific config (helps avoid warning logs about unused config)
+            properties.keySet().removeIf(key -> key.startsWith(AloKafkaReceiver.CONFIG_PREFIX));
+
+            // If enabled, increment Client ID
+            if (config.loadBoolean(AloKafkaReceiver.AUTO_INCREMENT_CLIENT_ID_CONFIG).orElse(false)) {
+                properties.computeIfPresent(CommonClientConfigs.CLIENT_ID_CONFIG, (__, id) -> incrementId(id.toString()));
+            }
+        });
+    }
+
+    private Optional<Duration> loadMaxDelayRebalance() {
+        Optional<Duration> maxDelayRebalance = config.loadDuration(AloKafkaReceiver.MAX_DELAY_REBALANCE_CONFIG);
+        return maxDelayRebalance.isPresent() || acknowledgementQueueMode == AcknowledgementQueueMode.STRICT
+            ? maxDelayRebalance
+            : Optional.of(Duration.ZERO); // By default, disable delay if acknowledgements may be skipped
+    }
+
+    private AloQueueingTransformer<ReceiverRecord<K, V>, ConsumerRecord<K, V>>
+    newAloQueueingTransformer(Consumer<Throwable> errorEmitter) {
+        return AloQueueingTransformer.create(newComponentExtractor(errorEmitter))
+            .withGroupExtractor(record -> record.receiverOffset().topicPartition())
+            .withQueueMode(acknowledgementQueueMode)
+            .withListener(loadQueueListener())
+            .withFactory(loadAloFactory())
+            .withMaxInFlight(loadMaxInFlightPerSubscription());
+    }
+
+    private AloComponentExtractor<ReceiverRecord<K, V>, ConsumerRecord<K, V>>
+    newComponentExtractor(Consumer<Throwable> errorEmitter) {
+        return AloComponentExtractor.composed(
+            record -> record.receiverOffset()::acknowledge,
+            record -> nacknowledgerFactory.create(record, errorEmitter),
+            Function.identity()
+        );
+    }
+
+    private AloQueueListener loadQueueListener() {
+        Map<String, Object> listenerConfig = config.modifyAndGetProperties(properties -> {});
+        return AloQueueListenerConfig.load(listenerConfig, AloKafkaQueueListener.class)
+            .orElseGet(AloQueueListener::noOp);
+    }
+
+    private AloFactory<ConsumerRecord<K, V>> loadAloFactory() {
+        Map<String, Object> factoryConfig = config.modifyAndGetProperties(properties -> {});
+        return AloFactoryConfig.loadDecorated(factoryConfig, AloKafkaConsumerRecordDecorator.class);
+    }
+
+    private long loadMaxInFlightPerSubscription() {
+        return config.loadLong(AloKafkaReceiver.MAX_IN_FLIGHT_PER_SUBSCRIPTION_CONFIG).orElse(4096L);
+    }
+
+    private Flux<Alo<ConsumerRecord<K, V>>> applySignalListenerFactories(Flux<Alo<ConsumerRecord<K, V>>> aloRecords) {
+        Map<String, Object> factoryConfig = config.modifyAndGetProperties(properties -> {});
+        List<AloSignalListenerFactory<ConsumerRecord<K, V>, ?>> factories =
+            AloSignalListenerFactoryConfig.loadList(factoryConfig, AloKafkaConsumerRecordSignalListenerFactory.class);
+        for (AloSignalListenerFactory<ConsumerRecord<K, V>, ?> factory : factories) {
+            aloRecords = aloRecords.tap(factory);
+        }
+        return aloRecords;
+    }
+
+    private static <K, V> NacknowledgerFactory<K, V> createNacknowledgerFactory(KafkaConfig config) {
+        Optional<NacknowledgerFactory<K, V>> nacknowledgerFactory =
+            loadNacknowledgerFactory(config, AloKafkaReceiver.NACKNOWLEDGER_TYPE_CONFIG, NacknowledgerFactory.class);
+        return nacknowledgerFactory.orElseGet(NacknowledgerFactory.Emit::new);
+    }
+
+    private static <K, V, N extends NacknowledgerFactory<K, V>> Optional<NacknowledgerFactory<K, V>>
+    loadNacknowledgerFactory(KafkaConfig config, String key, Class<N> type) {
+        return config.loadConfiguredWithPredefinedTypes(key, type, LegacyReceiveResources::newPredefinedNacknowledgerFactory);
+    }
+
+    private static <K, V> Optional<NacknowledgerFactory<K, V>> newPredefinedNacknowledgerFactory(String typeName) {
+        if (typeName.equalsIgnoreCase(AloKafkaReceiver.NACKNOWLEDGER_TYPE_EMIT)) {
+            return Optional.of(new NacknowledgerFactory.Emit<>());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private static AcknowledgementQueueMode loadAcknowledgementQueueMode(KafkaConfig config) {
+        return config.loadEnum(AloKafkaReceiver.ACKNOWLEDGEMENT_QUEUE_MODE_CONFIG, AcknowledgementQueueMode.class)
+            .orElse(AcknowledgementQueueMode.STRICT);
+    }
+
+    private static String incrementId(String id) {
+        return id + "-" + COUNTS_BY_ID.computeIfAbsent(id, __ -> new AtomicLong()).incrementAndGet();
+    }
+
+    public interface OptionsInitializer<K, V> {
+
+        ReceiverOptions<K, V> initialize(Map<String, Object> consumerConfig);
+    }
+}

--- a/kafka/src/test/java/io/atleon/kafka/AloKafkaReceiverTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/AloKafkaReceiverTest.java
@@ -25,7 +25,8 @@ class AloKafkaReceiverTest {
 
     @Test
     public void receiveAloRecords_givenMultipleSubscriptionAttempts_expectsEnforcementOfMutualExclusion() {
-        KafkaConfigSource configSource = TestKafkaConfigSourceFactory.createSource(BOOTSTRAP_CONNECT);
+        KafkaConfigSource configSource = TestKafkaConfigSourceFactory.createSource(BOOTSTRAP_CONNECT)
+            .with(AloKafkaReceiver.RECEPTION_TYPE_CONFIG, "LEGACY");
 
         AloKafkaSender.create(configSource)
             .sendValues(Mono.just("DATA"), topic, Function.identity())

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -24,7 +24,7 @@
         <junit-jupiter.version>5.10.1</junit-jupiter.version>
         <kotlin.version>1.9.21</kotlin.version> <!-- Dictated by kotlinx-coroutines version -->
         <kotlinx-coroutines.version>1.8.0</kotlinx-coroutines.version>
-        <micrometer.version>1.0.7</micrometer.version>
+        <micrometer.version>1.13.1</micrometer.version>
         <mockito.version>4.11.0</mockito.version>
         <netty.version>4.1.113.Final</netty.version>
         <opentracing.verion>0.32.0</opentracing.verion>


### PR DESCRIPTION
### :pencil: Description
Enable using new/optimized Kafka Receiver+Sender implementations by setting `kafka.receiver.reception.type`+`kafka.sender.sending.type` to `"OPTIMIZED"`

### :link: Related Issues
#396 