### PR TITLE
[#427] Enable+implement strategic prioritized polling

### DIFF
--- a/kafka/src/main/java/io/atleon/kafka/AloKafkaBoundedReceiver.java
+++ b/kafka/src/main/java/io/atleon/kafka/AloKafkaBoundedReceiver.java
@@ -100,7 +100,7 @@ public class AloKafkaBoundedReceiver<K, V> {
             .collectMap(TopicPartitionGroupOffsets::topicPartition, it -> toOffsetRange(it.groupOffset(), maxInclusive))
             .flatMapMany(it -> RecordRange.list(admin, it))
             .filter(RecordRange::hasNonNegativeLength)
-            .sort(Comparator.comparing(RecordRange::topicPartition, topicPartitionComparator()))
+            .sort(Comparator.comparing(RecordRange::topicPartition, KafkaComparators.topicThenPartition()))
             .concatMap(it -> receiveAndCommitRecordsInRange(admin, groupId, it));
     }
 
@@ -121,9 +121,5 @@ public class AloKafkaBoundedReceiver<K, V> {
 
     private static OffsetRange toOffsetRange(long rawMinInclusive, OffsetCriteria maxInclusive) {
         return OffsetCriteria.raw(rawMinInclusive).to(maxInclusive);
-    }
-
-    private static Comparator<TopicPartition> topicPartitionComparator() {
-        return Comparator.comparing(TopicPartition::topic).thenComparing(TopicPartition::partition);
     }
 }

--- a/kafka/src/main/java/io/atleon/kafka/KafkaComparators.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaComparators.java
@@ -1,0 +1,16 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Comparator;
+
+final class KafkaComparators {
+
+    private KafkaComparators() {
+
+    }
+
+    public static Comparator<TopicPartition> topicThenPartition() {
+        return Comparator.comparing(TopicPartition::topic).thenComparing(TopicPartition::partition);
+    }
+}

--- a/kafka/src/main/java/io/atleon/kafka/KafkaReceiver.java
+++ b/kafka/src/main/java/io/atleon/kafka/KafkaReceiver.java
@@ -77,8 +77,8 @@ import java.util.regex.Pattern;
  * delivery semantics and ensure that no offset is made eligible for commitment until all preceding
  * records in the actively assigned partition have been acknowledged):
  * <ul>
- * <li><b>STRICT Mode:</b> The default mode where each acknowledged record's offset becomes
- * eligible for commitment individually.</li>
+ * <li><b>STRICT Mode (Default):</b> The default mode where each acknowledged record's offset
+ * becomes eligible for commitment individually.</li>
  * <li><b>COMPACT Mode:</b> An optimization where acknowledgement tracking may be consolidated when
  * multiple sequential records are acknowledged but not yet eligible for commitment, reducing the
  * granularity of offset eligibility tracking. This mode is particularly beneficial for
@@ -104,6 +104,10 @@ import java.util.regex.Pattern;
  * <li><b>Greatest Batch Lag:</b> Prioritizes partitions with the highest lag in units of the
  * polling batch size. This strategy is useful when prioritizing uniform lag across all assigned
  * partitions</li>
+ * <li><b>PriorityLagCutoff:</b> Prioritizes polling from partitions as indicated by a provided
+ * {@link java.util.Comparator}, cutting off the selection of lower-priority partitions if/when
+ * the lag for a higher-priority partition meets-or-exceeds a specified threshold. This is useful
+ * for priority based messaging where partition numbers represent "priority".</li>
  * </ul>
  * <p>
  * Polling strategies can be configured via 

--- a/kafka/src/main/java/io/atleon/kafka/OffsetRangeProvider.java
+++ b/kafka/src/main/java/io/atleon/kafka/OffsetRangeProvider.java
@@ -92,7 +92,7 @@ public interface OffsetRangeProvider {
      * deterministic order
      */
     default Comparator<? super TopicPartition> topicPartitionComparator() {
-        return Comparator.comparing(TopicPartition::topic).thenComparing(TopicPartition::partition);
+        return KafkaComparators.topicThenPartition();
     }
 
     final class StartingFromRawOffsetInTopicPartition implements OffsetRangeProvider {

--- a/kafka/src/main/java/io/atleon/kafka/PollSelectionContext.java
+++ b/kafka/src/main/java/io/atleon/kafka/PollSelectionContext.java
@@ -27,6 +27,24 @@ public interface PollSelectionContext {
     void selectNaturally();
 
     /**
+     * Retrieves current lag for the provided partitions. This method will return immediately, and
+     * is backed by cached metadata in the underlying consumer. It is therefore possible that not
+     * every provided partition will have lag metadata immediately available. In this case, the
+     * provided default value will be returned for each partition that does not (yet) have
+     * metadata. Note that the freshness of the underlying metadata is controlled by the consumer,
+     * and may become relatively stale for any partition that has not been actively polled for a
+     * significant period of time. It is therefore recommended that attention is given to the
+     * configuration {@link org.apache.kafka.clients.CommonClientConfigs#METADATA_MAX_AGE_CONFIG}
+     * such as to potentially limit the max staleness of lag metadata.
+     *
+     * @param partitions   the set of partitions for which to get lag measurements
+     * @param defaultValue the default value to use when lag metadata is not immediately available
+     * @return a map of partitions to their current lag values
+     * @see org.apache.kafka.clients.consumer.Consumer#currentLag(TopicPartition)
+     */
+    Map<TopicPartition, Long> currentLag(Set<TopicPartition> partitions, long defaultValue);
+
+    /**
      * Retrieves current lag in terms of the number of logical batches (as configured by
      * {@link org.apache.kafka.clients.consumer.ConsumerConfig#MAX_POLL_RECORDS_CONFIG}) for the
      * provided partitions. This method will return immediately, and is backed by cached metadata

--- a/kafka/src/test/java/io/atleon/kafka/PollManagerTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/PollManagerTest.java
@@ -32,7 +32,7 @@ class PollManagerTest {
         TopicPartition partition2 = new TopicPartition("topic", 1);
 
         Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
-        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class, Mockito.CALLS_REAL_METHODS);
         PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
         pollManager.forcePause(Collections.singletonList(partition1));
 
@@ -49,7 +49,7 @@ class PollManagerTest {
         TopicPartition original = new TopicPartition("topic", 0);
         TopicPartition duplicate = new TopicPartition("topic", 0);
         Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
-        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class, Mockito.CALLS_REAL_METHODS);
         PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
 
         pollManager.activateAssigned(consumer, Collections.singletonList(original), Function.identity());
@@ -63,7 +63,7 @@ class PollManagerTest {
     @Test
     public void unassigned_givenNonAssignedPartition_expectsEmptyResult() {
         TopicPartition partition = new TopicPartition("topic", 0);
-        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class, Mockito.CALLS_REAL_METHODS);
         PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
 
         Collection<TopicPartition> result = pollManager.unassigned(Collections.singletonList(partition));
@@ -77,7 +77,7 @@ class PollManagerTest {
         TopicPartition partition2 = new TopicPartition("topic", 1);
 
         Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
-        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class, Mockito.CALLS_REAL_METHODS);
         PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
         pollManager.activateAssigned(consumer, Arrays.asList(partition1, partition2), Function.identity());
 
@@ -94,7 +94,7 @@ class PollManagerTest {
         Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
         when(consumer.poll(any())).thenReturn(ConsumerRecords.empty());
 
-        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class, Mockito.CALLS_REAL_METHODS);
 
         PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
 
@@ -111,7 +111,7 @@ class PollManagerTest {
         Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
         when(consumer.poll(any())).thenReturn(ConsumerRecords.empty());
 
-        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class, Mockito.CALLS_REAL_METHODS);
 
         PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
 
@@ -128,7 +128,7 @@ class PollManagerTest {
         Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
         when(consumer.poll(any())).thenThrow(new WakeupException());
 
-        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class, Mockito.CALLS_REAL_METHODS);
         PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
 
         ConsumerRecords<?, ?> records = pollManager.pollWakeably(consumer, () -> 1, () -> false);
@@ -144,7 +144,7 @@ class PollManagerTest {
             .thenThrow(new WakeupException())
             .thenReturn(ConsumerRecords.empty());
 
-        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class, Mockito.CALLS_REAL_METHODS);
         PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
 
         ConsumerRecords<?, ?> records = pollManager.pollWakeably(consumer, () -> 1, () -> true);
@@ -159,7 +159,7 @@ class PollManagerTest {
         Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
         when(consumer.poll(any())).thenReturn(ConsumerRecords.empty());
 
-        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class, Mockito.CALLS_REAL_METHODS);
         PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 2, Duration.ZERO);
         pollManager.activateAssigned(consumer, Collections.singletonList(partition), Function.identity());
 
@@ -174,7 +174,7 @@ class PollManagerTest {
 
     @Test
     public void shouldWakeupOnSingularCapacityReclamation_givenCorrectConditions_expectsTrue() {
-        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class, Mockito.CALLS_REAL_METHODS);
         PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 5, Duration.ZERO);
 
         // Simulate being paused due to backpressure
@@ -189,7 +189,7 @@ class PollManagerTest {
     @Test
     public void forcePause_givenPartitions_expectsCoordination() {
         TopicPartition partition = new TopicPartition("topic", 0);
-        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class, Mockito.CALLS_REAL_METHODS);
         PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
 
         pollManager.forcePause(Collections.singletonList(partition));
@@ -200,7 +200,7 @@ class PollManagerTest {
     @Test
     public void allowResumption_givenPartitions_expectsCoordination() {
         TopicPartition partition = new TopicPartition("topic", 0);
-        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
+        PollStrategy pollStrategy = Mockito.mock(PollStrategy.class, Mockito.CALLS_REAL_METHODS);
         PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
 
         pollManager.forcePause(Collections.singletonList(partition));

--- a/kafka/src/test/java/io/atleon/kafka/PollStrategyTest.java
+++ b/kafka/src/test/java/io/atleon/kafka/PollStrategyTest.java
@@ -1,17 +1,24 @@
 package io.atleon.kafka;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -74,6 +81,69 @@ class PollStrategyTest {
         pollStrategy.prepareForPoll(context);
 
         verify(context).selectExclusively(eqSelection(topicPartitions, 1, 3));
+    }
+
+    @Test
+    public void prepareForPoll_givenPriorityCutoffOnLag_expectsPrioritizedSelectionWithLagCutoff() {
+        List<TopicPartition> topicPartitions = Arrays.asList(
+            new TopicPartition("topic", 0),
+            new TopicPartition("topic", 1),
+            new TopicPartition("topic", 2),
+            new TopicPartition("topic", 3)
+        );
+
+        Map<TopicPartition, Long> lag = new HashMap<>();
+        lag.put(topicPartitions.get(0), 0L);
+        lag.put(topicPartitions.get(1), 1L);
+        lag.put(topicPartitions.get(2), 2L);
+        lag.put(topicPartitions.get(3), 3L);
+
+        PollSelectionContext context = mock(PollSelectionContext.class);
+        when(context.currentLag(eq(lag.keySet()), anyLong())).thenReturn(lag);
+
+        Comparator<TopicPartition> priorityComparator = Comparator.comparing(TopicPartition::partition);
+        PollStrategy pollStrategy = PollStrategy.priorityCutoffOnLag(priorityComparator, 2);
+        pollStrategy.onPollingPermitted(topicPartitions);
+        pollStrategy.prepareForPoll(context);
+
+        verify(context).selectExclusively(eqSelection(topicPartitions, 0, 1, 2));
+    }
+
+    @Test
+    public void onPoll_givenPriorityCutoffOnLag_expectsConsumerRecordsOrderedByPriority() {
+        List<TopicPartition> orderedPartitions = Arrays.asList(
+            new TopicPartition("topic", 0),
+            new TopicPartition("topic", 1),
+            new TopicPartition("topic", 2),
+            new TopicPartition("topic", 3)
+        );
+
+        Map<TopicPartition, List<ConsumerRecord<String, String>>> consumerRecords = new LinkedHashMap<>();
+        consumerRecords.put(
+            orderedPartitions.get(0),
+            Collections.singletonList(createConsumerRecord(orderedPartitions.get(0), 0L, "key", "value")));
+        consumerRecords.put(
+            orderedPartitions.get(2),
+            Collections.singletonList(createConsumerRecord(orderedPartitions.get(2), 0L, "key", "value")));
+        consumerRecords.put(
+            orderedPartitions.get(3),
+            Collections.singletonList(createConsumerRecord(orderedPartitions.get(3), 0L, "key", "value")));
+        consumerRecords.put(
+            orderedPartitions.get(1),
+            Collections.singletonList(createConsumerRecord(orderedPartitions.get(1), 0L, "key", "value")));
+
+        Comparator<TopicPartition> priorityComparator = Comparator.comparing(TopicPartition::partition);
+        PollStrategy pollStrategy = PollStrategy.priorityCutoffOnLag(priorityComparator, 2);
+        pollStrategy.onPollingPermitted(orderedPartitions);
+
+        ConsumerRecords<String, String> result = pollStrategy.onPoll(new ConsumerRecords<>(consumerRecords));
+
+        // Verify count and order with a single assertion
+        assertEquals(orderedPartitions, new ArrayList<>(result.partitions()));
+    }
+
+    private <K, V> ConsumerRecord<K, V> createConsumerRecord(TopicPartition partition, long offset, K key, V value) {
+        return new ConsumerRecord<>(partition.topic(), partition.partition(), offset, key, value);
     }
 
     private static <T> Set<T> eqSelection(List<T> list, int... indices) {

--- a/util/src/main/java/io/atleon/util/Collecting.java
+++ b/util/src/main/java/io/atleon/util/Collecting.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -87,6 +88,34 @@ public final class Collecting {
                 result.add(element);
             } else if (comparison == 0) {
                 result.add(element);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Collects the elements from a provided collection, up-to-and-including the first element that
+     * matches the provided predicate, into a new collection as initialized by the provided
+     * {@link Supplier}. The "first" element is determined by the encounter order of the source
+     * collection.
+     *
+     * @param <T>                the type of elements in the input collection
+     * @param <C>                the type of collection to return
+     * @param collection         the source collection to evaluate
+     * @param predicate          the predicate on which detect terminating element
+     * @param collectionSupplier supplier that creates the result collection instance
+     * @return A <i>new</i> collection containing elements up-to-and-including matching element
+     */
+    public static <T, C extends Collection<T>> C takeUntil(
+        Collection<T> collection,
+        Predicate<? super T> predicate,
+        Supplier<C> collectionSupplier
+    ) {
+        C result = collectionSupplier.get();
+        for (T element : collection) {
+            result.add(element);
+            if (predicate.test(element)) {
+                return result;
             }
         }
         return result;

--- a/util/src/test/java/io/atleon/util/CollectingTest.java
+++ b/util/src/test/java/io/atleon/util/CollectingTest.java
@@ -127,6 +127,19 @@ class CollectingTest {
     }
 
     @Test
+    public void takeUntil_givenCollectionAndPredicate_expectsResultContainingUpToAndIncludingMatchingElement() {
+        List<String> strings = Arrays.asList("one", "two", "three", "three", "four", "one");
+
+        assertEquals(
+            Arrays.asList("one"),
+            Collecting.takeUntil(strings, it -> it.equals("one"), ArrayList::new));
+        assertEquals(
+            Arrays.asList("one", "two", "three"),
+            Collecting.takeUntil(strings, it -> it.equals("three"), ArrayList::new));
+        assertEquals(strings, Collecting.takeUntil(strings, __ -> false, ArrayList::new));
+    }
+
+    @Test
     public void difference_givenCollections_expectsSubtractedResult() {
         assertEquals(Collections.emptyList(), Collecting.difference(Collections.emptyList(), Collections.emptyList()));
         assertEquals(Arrays.asList(1, 2, 3), Collecting.difference(Arrays.asList(1, 2, 3), Collections.emptyList()));


### PR DESCRIPTION
### :pencil: Description
- Provide for ability to post-process polled records in poll strategies
- Extract a few reusable methods, including default topic-partition ordering and `takeUntil` on collections

### :link: Related Issues
#427 