### PR TITLE
[#452] kafka: Ensure idempotence is explicilty set by default

### DIFF
--- a/examples/core/src/main/java/io/atleon/examples/deadlettering/KafkaDeadlettering.java
+++ b/examples/core/src/main/java/io/atleon/examples/deadlettering/KafkaDeadlettering.java
@@ -28,8 +28,7 @@ public class KafkaDeadlettering {
             .with(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
             .with(CommonClientConfigs.CLIENT_ID_CONFIG, KafkaDeadlettering.class.getSimpleName())
             .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
         //Step 2) Create Kafka Config for Consumer that backs Receiver. Note that we use an Auto
         // Offset Reset of 'earliest' to ensure we receive Records produced before subscribing with

--- a/examples/core/src/main/java/io/atleon/examples/deduplication/KafkaDeduplication.java
+++ b/examples/core/src/main/java/io/atleon/examples/deduplication/KafkaDeduplication.java
@@ -42,8 +42,7 @@ public class KafkaDeduplication {
             .with(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
             .with(CommonClientConfigs.CLIENT_ID_CONFIG, KafkaDeduplication.class.getSimpleName())
             .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
         //Step 2) Create Kafka Config for Consumer that backs Receiver. Note that set the auto
         // offset reset to earliest such that subsequently produced Records are processed

--- a/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart1.java
+++ b/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart1.java
@@ -25,8 +25,7 @@ public class KafkaPart1 {
             .with(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
             .with(ProducerConfig.CLIENT_ID_CONFIG, KafkaPart1.class.getSimpleName())
             .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
         //Step 2) Send some Record values to a hardcoded topic, using values as Record keys
         AloKafkaSender<String, String> sender = AloKafkaSender.create(kafkaSenderConfig);

--- a/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart2.java
+++ b/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart2.java
@@ -30,8 +30,7 @@ public class KafkaPart2 {
             .with(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
             .with(CommonClientConfigs.CLIENT_ID_CONFIG, KafkaPart2.class.getSimpleName())
             .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
         //Step 2) Create Kafka Config for Consumer that backs Receiver. Note that we use an Auto
         // Offset Reset of 'earliest' to ensure we receive Records produced before subscribing with

--- a/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart3.java
+++ b/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart3.java
@@ -34,8 +34,7 @@ public class KafkaPart3 {
             .with(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
             .with(CommonClientConfigs.CLIENT_ID_CONFIG, KafkaPart3.class.getSimpleName())
             .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
         //Step 2) Create Kafka Config for Consumer that backs Receiver. Note that we use an Auto
         // Offset Reset of 'earliest' to ensure we receive Records produced before subscribing with

--- a/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart4.java
+++ b/examples/core/src/main/java/io/atleon/examples/endtoendtoend/KafkaPart4.java
@@ -32,8 +32,7 @@ public class KafkaPart4 {
             .with(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
             .with(CommonClientConfigs.CLIENT_ID_CONFIG, KafkaPart4.class.getSimpleName())
             .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
         //Step 2) Create Kafka Config for Consumer that backs Receiver. Note that we use an Auto
         // Offset Reset of 'earliest' to ensure we receive Records produced before subscribing with

--- a/examples/core/src/main/java/io/atleon/examples/errorhandling/KafkaErrorHandling.java
+++ b/examples/core/src/main/java/io/atleon/examples/errorhandling/KafkaErrorHandling.java
@@ -48,8 +48,7 @@ public class KafkaErrorHandling {
             .with(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
             .with(CommonClientConfigs.CLIENT_ID_CONFIG, KafkaErrorHandling.class.getSimpleName())
             .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
         //Step 2) Create "faulty" Kafka Config where the second value we try to process will throw
         // an Exception at serialization time
@@ -57,8 +56,7 @@ public class KafkaErrorHandling {
             .with(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
             .with(CommonClientConfigs.CLIENT_ID_CONFIG, KafkaErrorHandling.class.getSimpleName())
             .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, SecondTimeFailingSerializer.class.getName())
-            .with(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, SecondTimeFailingSerializer.class.getName());
 
         //Step 3) Create Kafka Config for Consumer that backs Receiver
         KafkaConfigSource kafkaReceiverConfig = KafkaConfigSource.useClientIdAsName()

--- a/examples/core/src/main/java/io/atleon/examples/metrics/KafkaMicrometer.java
+++ b/examples/core/src/main/java/io/atleon/examples/metrics/KafkaMicrometer.java
@@ -46,7 +46,6 @@ public class KafkaMicrometer {
             .with(CommonClientConfigs.CLIENT_ID_CONFIG, KafkaMicrometer.class.getSimpleName())
             .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
             .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1)
             .with(ProducerConfig.METRIC_REPORTER_CLASSES_CONFIG, AloKafkaMetricsReporter.class.getName());
 
         //Step 2) Create Kafka Config for Consumer that backs Receiver. Note we are adding a

--- a/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaArbitraryParallelism.java
+++ b/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaArbitraryParallelism.java
@@ -45,8 +45,7 @@ public class KafkaArbitraryParallelism {
             .with(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
             .with(CommonClientConfigs.CLIENT_ID_CONFIG, KafkaArbitraryParallelism.class.getSimpleName())
             .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
         //Step 2) Create Kafka Config for Consumer that backs Receiver. Note that set the auto
         // offset reset to earliest such that subsequently produced Records are processed

--- a/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaTopicPartitionParallelism.java
+++ b/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaTopicPartitionParallelism.java
@@ -40,8 +40,7 @@ public class KafkaTopicPartitionParallelism {
             .with(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
             .with(CommonClientConfigs.CLIENT_ID_CONFIG, KafkaArbitraryParallelism.class.getSimpleName())
             .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-            .with(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+            .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
         //Step 2) Create Kafka Config for Consumer that backs Receiver. Note that set the auto
         // offset reset to earliest such that subsequently produced Records are processed

--- a/examples/spring/src/main/java/io/atleon/examples/spring/kafka/stream/KafkaGenerationStream.java
+++ b/examples/spring/src/main/java/io/atleon/examples/spring/kafka/stream/KafkaGenerationStream.java
@@ -37,7 +37,6 @@ public class KafkaGenerationStream extends SpringAloStream {
 
     private AloKafkaSender<Long, Long> buildKafkaLongSender() {
         return configSource.withClientId(name())
-            .withProducerOrderingAndResiliencyConfigs()
             .withKeySerializer(LongSerializer.class)
             .withValueSerializer(LongSerializer.class)
             .as(AloKafkaSender::create);

--- a/examples/spring/src/main/java/io/atleon/examples/spring/kafka/stream/KafkaProcessingStream.java
+++ b/examples/spring/src/main/java/io/atleon/examples/spring/kafka/stream/KafkaProcessingStream.java
@@ -56,7 +56,6 @@ public class KafkaProcessingStream extends SpringAloStream {
     private AloKafkaSender<Long, Long> buildKafkaLongSender() {
         return configSource.withClientId(name())
             .withClientId(name())
-            .withProducerOrderingAndResiliencyConfigs()
             .withKeySerializer(LongSerializer.class)
             .withValueSerializer(LongSerializer.class)
             .as(AloKafkaSender::create);

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/KafkaConfigSource.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/KafkaConfigSource.java
@@ -48,6 +48,12 @@ public class KafkaConfigSource extends ConfigSource<KafkaConfig, KafkaConfigSour
         return with(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     }
 
+    /**
+     * @deprecated The properties set by this method are no longer necessary to guarantee ordering
+     * and resiliency. Idempotency is now (explicitly via sender) enabled by default, the default
+     * max in flight requests supports idempotency, and the default acks is set to "all".
+     */
+    @Deprecated
     public KafkaConfigSource withProducerOrderingAndResiliencyConfigs() {
         Map<String, Object> configs = new HashMap<>();
         configs.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);


### PR DESCRIPTION
### :pencil: Description
- Make message production ordering guarantee the default beahvior

### :link: Related Issues
#452