### PR TITLE
[#466] Add innerAddErrorOnDelegate to GroupFlux.java

### DIFF
--- a/core/src/main/java/io/atleon/core/GroupFlux.java
+++ b/core/src/main/java/io/atleon/core/GroupFlux.java
@@ -9,6 +9,7 @@ import reactor.core.scheduler.Schedulers;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -216,6 +217,16 @@ public class GroupFlux<K, T> {
      */
     public GroupFlux<K, T> innerTap(SignalListenerFactory<Alo<T>, ?> signalListenerFactory) {
         return map(group -> group.tap(signalListenerFactory));
+    }
+
+    /**
+     * Convenience method for applying {@link AloFlux#addAloErrorDelegation(BiFunction)} to each inner
+     * grouped sequence.
+     *
+     * @return a transformed {@link GroupFlux}
+     */
+    public GroupFlux<K, T> innerAddAloErrorDelegation(ErrorDelegator<T> errorDelegator) {
+        return map(group -> group.addAloErrorDelegation(errorDelegator));
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built the project locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
Adding `innerAddErrorOnDelegate` to make it more convenient to add `ErrorDelegator` for `GroupBy`. Also it follows the `inner` prefix pattern with the other supporting `inner` methods.

### :link: Related Issues
#466 
