### PR TITLE
[#463] RabbitMQ: Reimplement low-level sender and receiver

### DIFF
--- a/infrastructures/rabbitmq/pom.xml
+++ b/infrastructures/rabbitmq/pom.xml
@@ -32,8 +32,16 @@
             <artifactId>reactor-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.projectreactor.addons</groupId>
+            <artifactId>reactor-pool</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.projectreactor.rabbitmq</groupId>
             <artifactId>reactor-rabbitmq</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
         </dependency>
         <dependency>
             <groupId>org.reactivestreams</groupId>
@@ -65,6 +73,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/AloConfiguratorConnectionSupplier.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/AloConfiguratorConnectionSupplier.java
@@ -1,0 +1,20 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.ConnectionFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Special extension of {@link ConfiguratorConnectionSupplier} that uses
+ * {@link AloConnectionFactory} to create {@link ConnectionFactory} instances.
+ */
+public final class AloConfiguratorConnectionSupplier extends ConfiguratorConnectionSupplier {
+
+    @Override
+    protected ConnectionFactory createConnectionFactory(Map<String, ?> properties) {
+        Map<String, Object> sanitizedProperties = new HashMap<>(properties);
+        consumeDefaultProperties(sanitizedProperties::putIfAbsent);
+        return AloConnectionFactory.create(sanitizedProperties);
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/BasicConsumeArguments.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/BasicConsumeArguments.java
@@ -1,0 +1,35 @@
+package io.atleon.rabbitmq;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
+
+/**
+ * Encapsulates arguments for <code>basicConsume</code> on {@link com.rabbitmq.client.Channel}.
+ */
+final class BasicConsumeArguments {
+
+    private final String queue;
+
+    private final String consumerTag;
+
+    private final @Nullable Integer priority;
+
+    public BasicConsumeArguments(String queue, String consumerTag, @Nullable Integer priority) {
+        this.queue = queue;
+        this.consumerTag = consumerTag;
+        this.priority = priority;
+    }
+
+    public String queue() {
+        return queue;
+    }
+
+    public String consumerTag() {
+        return consumerTag;
+    }
+
+    public Optional<Integer> priority() {
+        return Optional.ofNullable(priority);
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/BasicPublishArguments.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/BasicPublishArguments.java
@@ -1,0 +1,44 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.AMQP;
+
+/**
+ * Encapsulates arguments for <code>basicPublish</code> on {@link com.rabbitmq.client.Channel}.
+ */
+final class BasicPublishArguments {
+
+    private final String exchange;
+
+    private final String routingKey;
+
+    private final AMQP.BasicProperties properties;
+
+    private final byte[] body;
+
+    public BasicPublishArguments(String exchange, String routingKey, AMQP.BasicProperties properties, byte[] body) {
+        this.exchange = exchange;
+        this.routingKey = routingKey;
+        this.properties = properties;
+        this.body = body;
+    }
+
+    public <T> OutboundDelivery<T> toOutboundDelivery(T correlationMetadata) {
+        return new OutboundDelivery<>(exchange, routingKey, properties, correlationMetadata);
+    }
+
+    public String exchange() {
+        return exchange;
+    }
+
+    public String routingKey() {
+        return routingKey;
+    }
+
+    public AMQP.BasicProperties properties() {
+        return properties;
+    }
+
+    public byte[] body() {
+        return body;
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/CanceledConsumeException.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/CanceledConsumeException.java
@@ -1,0 +1,11 @@
+package io.atleon.rabbitmq;
+
+/**
+ * Represents cancellation of consume operation initiated by broker.
+ */
+public class CanceledConsumeException extends RuntimeException {
+
+    CanceledConsumeException(String consumerTag) {
+        super("Consume canceled with consumerTag=" + consumerTag);
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/ConfigurableConnectionSupplier.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/ConfigurableConnectionSupplier.java
@@ -1,0 +1,33 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.Connection;
+import io.atleon.util.ConfigLoading;
+import io.atleon.util.Configurable;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * API through which a provider of {@link Connection} instances can be configured and invoked.
+ */
+@FunctionalInterface
+public interface ConfigurableConnectionSupplier extends Configurable {
+
+    /**
+     * When configuring a connection supplier in properties, the value for this key can be either
+     * the qualified name of a {@link ConfigurableConnectionSupplier} implementation or an instance
+     * of one.
+     */
+    String CONFIG = "configurable.connection.supplier";
+
+    static ConfigurableConnectionSupplier load(
+            Map<String, ?> properties, Supplier<? extends ConfigurableConnectionSupplier> defaultSupplier) {
+        return ConfigLoading.loadConfigured(properties, CONFIG, ConfigurableConnectionSupplier.class, defaultSupplier);
+    }
+
+    @Override
+    default void configure(Map<String, ?> properties) {}
+
+    Connection getConnection() throws IOException;
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/ConfiguratorConnectionSupplier.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/ConfiguratorConnectionSupplier.java
@@ -1,0 +1,49 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.ConnectionFactoryConfigurator;
+import io.atleon.util.Calling;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+/**
+ * Default implementation of {@link ConfigurableConnectionSupplier} that creates {@link Connection}s
+ * through {@link ConnectionFactory} instances, which are configured through the
+ * {@link ConnectionFactoryConfigurator} API.
+ */
+public class ConfiguratorConnectionSupplier implements ConfigurableConnectionSupplier {
+
+    private ConnectionFactory connectionFactory;
+
+    @Override
+    public void configure(Map<String, ?> properties) {
+        this.connectionFactory = createConnectionFactory(properties);
+    }
+
+    @Override
+    public final Connection getConnection() throws IOException {
+        return Calling.callAsIO(connectionFactory::newConnection);
+    }
+
+    protected ConnectionFactory createConnectionFactory(Map<String, ?> properties) {
+        ConnectionFactory connectionFactory = new ConnectionFactory();
+        ConnectionFactoryConfigurator.load(connectionFactory, sanitizeProperties(properties), "");
+        return connectionFactory;
+    }
+
+    protected static Map<String, String> sanitizeProperties(Map<String, ?> properties) {
+        Map<String, String> sanitizedProperties = properties.entrySet().stream()
+                .filter(it -> !it.getKey().equals(ConfigurableConnectionSupplier.CONFIG))
+                .collect(Collectors.toMap(Map.Entry::getKey, it -> it.getValue().toString()));
+        consumeDefaultProperties(sanitizedProperties::putIfAbsent);
+        return sanitizedProperties;
+    }
+
+    protected static void consumeDefaultProperties(BiConsumer<String, ? super String> consumer) {
+        consumer.accept(ConnectionFactoryConfigurator.USE_NIO, "true");
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/ConsumingSubscriptionFactory.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/ConsumingSubscriptionFactory.java
@@ -1,0 +1,270 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.ShutdownSignalException;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Operators;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+final class ConsumingSubscriptionFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConsumingSubscriptionFactory.class);
+
+    private final RabbitMQReceiverOptions options;
+
+    public ConsumingSubscriptionFactory(RabbitMQReceiverOptions options) {
+        this.options = options;
+    }
+
+    public Subscription create(String queue, Subscriber<? super RabbitMQReceiverMessage> subscriber) {
+        return new SubscriptionConsumer(queue, subscriber);
+    }
+
+    private static void runSafely(Runnable task, String name) {
+        try {
+            task.run();
+        } catch (Exception e) {
+            LOGGER.error("Unexpected failure: name={}", name, e);
+        }
+    }
+
+    private final class SubscriptionConsumer implements Subscription, Consumer {
+
+        private final Mono<ReceivingConnection> connection;
+
+        private final String queue;
+
+        private final Subscriber<? super RabbitMQReceiverMessage> subscriber;
+
+        private final AtomicReference<State> publishingState = new AtomicReference<>(State.ACTIVE);
+
+        // This counter doubles as both our connection state (via polarity: negative == CLOSED,
+        // non-negative == OPEN) and (when non-negative) our outstanding request count. As such,
+        // it is initialized as (barely) negative to indicate "not yet opened". When this first
+        // becomes non-negative, it means connection initialization and consumption initialization
+        // have (at least) been scheduled (or about to be). When it becomes negative again, it
+        // means the connection has been (at least) scheduled to be closed.
+        private final AtomicLong requested = new AtomicLong(-1L);
+
+        private final Queue<RabbitMQReceiverMessage> emittableMessages = new ConcurrentLinkedQueue<>();
+
+        private final AtomicReference<Throwable> error = new AtomicReference<>();
+
+        private final AtomicInteger drainsInProgress = new AtomicInteger(0);
+
+        public SubscriptionConsumer(String queue, Subscriber<? super RabbitMQReceiverMessage> subscriber) {
+            this.connection = ReceivingConnection.create(options).cache();
+            this.queue = queue;
+            this.subscriber = subscriber;
+        }
+
+        @Override
+        public void request(long n) {
+            if (!Operators.validate(n)) {
+                return;
+            }
+
+            long previousRequested = requested.getAndUpdate(it -> {
+                if (it < 0) {
+                    // Either initial request, or request after cancellation.
+                    return it == -1 ? n : it;
+                } else {
+                    return Operators.addCap(it, n);
+                }
+            });
+
+            if (previousRequested == -1L && publishingState.get() == State.ACTIVE) {
+                // Initial request, so initialize consumption. Note that we do not need to also
+                // subscribe to connection closure, as the following invocation will notify us of
+                // such an error, or will upon/after invoking "consume" via Consumer callback(s).
+                scheduleOnConnection(it -> it.consume(queue, this));
+            } else if (previousRequested == 0) {
+                // Request had been exhausted and could have been limiting emission, so must drain.
+                drain();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            if (enterTerminableState()) {
+                drain();
+            }
+        }
+
+        @Override
+        public void handleConsumeOk(String consumerTag) {
+            LOGGER.info("Consume OK with consumerTag={}", consumerTag);
+        }
+
+        @Override
+        public void handleCancelOk(String consumerTag) {
+            LOGGER.info("Cancel OK with consumerTag={}", consumerTag);
+        }
+
+        @Override
+        public void handleCancel(String consumerTag) {
+            failSafely(new CanceledConsumeException(consumerTag));
+        }
+
+        @Override
+        public void handleShutdownSignal(String consumerTag, ShutdownSignalException sig) {
+            failSafely(sig);
+        }
+
+        @Override
+        public void handleRecoverOk(String consumerTag) {
+            LOGGER.info("Recover OK with consumerTag={}", consumerTag);
+        }
+
+        @Override
+        public void handleDelivery(
+                String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) {
+            if (publishingState.get() == State.TERMINATED) {
+                return;
+            }
+
+            RabbitMQDeliverySettler deliverySettler = new RabbitMQDeliverySettlerImpl(envelope.getDeliveryTag());
+            emittableMessages.add(RabbitMQReceiverMessage.create(envelope, properties, body, deliverySettler));
+            drain();
+        }
+
+        private void failSafely(Throwable failure) {
+            if (!active() || !error.compareAndSet(null, failure)) {
+                // Failures during termination and failures that don't initiate termination can be
+                // safely dropped.
+                LOGGER.debug("Ignoring failure during termination", failure);
+            } else if (enterTerminableState()) {
+                // Could be racing with cancellation, but it's not a spec violation if onError
+                // emission is concurrent with downstream cancellation.
+                drain();
+            }
+        }
+
+        private void drain() {
+            if (drainsInProgress.getAndIncrement() != 0) {
+                return;
+            }
+
+            int missed = 1;
+            do {
+                // Handle onNext emission, update outstanding capacities, and re-trigger drain loop
+                // if we exhaust whatever resource first limits emission. This makes it such that
+                // we don't need to invoke drain every time a possibly-limiting resource is updated
+                // (request, active cap, etc.), unless/until it is updated from (or to) zero.
+                long maxToEmit = emittableMessages.isEmpty() ? 0L : requested.get();
+
+                if (maxToEmit > 0) {
+                    long emitted = 0;
+                    RabbitMQReceiverMessage emittable;
+                    while (emitted < maxToEmit && active() && (emittable = emittableMessages.poll()) != null) {
+                        try {
+                            subscriber.onNext(emittable);
+                            emitted++;
+                        } catch (Throwable error) {
+                            LOGGER.error("Emission failure (violates Reactive Streams §2.13)", error);
+                            failSafely(error);
+                        }
+                    }
+
+                    if (requested.get() != Long.MAX_VALUE) {
+                        requested.addAndGet(-emitted);
+                    }
+                    if (maxToEmit == emitted) {
+                        drainsInProgress.incrementAndGet();
+                    }
+                }
+
+                // Handle termination if now is the time to do so. Don't need CAS here since this
+                // is the only place to transition to TERMINATED.
+                if (publishingState.get() == State.TERMINABLE) {
+                    terminateSafely();
+                    publishingState.set(State.TERMINATED);
+                }
+
+                missed = drainsInProgress.addAndGet(-missed);
+            } while (missed != 0);
+        }
+
+        private boolean enterTerminableState() {
+            return publishingState.compareAndSet(State.ACTIVE, State.TERMINABLE);
+        }
+
+        private void terminateSafely() {
+            // Check if connection needs to be closed while setting outstanding request to a value
+            // that will make subsequent requests no-ops.
+            if (requested.getAndSet(Long.MIN_VALUE) >= 0) {
+                scheduleOnConnection(ReceivingConnection::closeSafely);
+            }
+
+            Throwable errorToEmit = error.get();
+            if (errorToEmit != null) {
+                runSafely(() -> subscriber.onError(errorToEmit), "subscriber::onError §2.13");
+                LOGGER.debug("Terminated due to error");
+            } else {
+                LOGGER.debug("Terminated due to cancel");
+            }
+        }
+
+        private void scheduleOnConnection(Function<ReceivingConnection, Mono<?>> function) {
+            connection.flatMap(function).subscribe(__ -> {}, this::failSafely);
+        }
+
+        private boolean active() {
+            return publishingState.get() == State.ACTIVE;
+        }
+
+        private final class RabbitMQDeliverySettlerImpl implements RabbitMQDeliverySettler {
+
+            private final long tag;
+
+            private final AtomicBoolean settled = new AtomicBoolean(false);
+
+            public RabbitMQDeliverySettlerImpl(long tag) {
+                this.tag = tag;
+            }
+
+            @Override
+            public void ack() {
+                settle(ReceivingConnection::ack);
+            }
+
+            @Override
+            public void reject() {
+                settle(ReceivingConnection::reject);
+            }
+
+            @Override
+            public void requeue() {
+                settle(ReceivingConnection::requeue);
+            }
+
+            private void settle(BiFunction<ReceivingConnection, Long, Mono<Void>> settler) {
+                if (settled.compareAndSet(false, true)) {
+                    scheduleOnConnection(it -> settler.apply(it, tag));
+                } else {
+                    LOGGER.debug("Delivery already settled where tag={}", tag);
+                }
+            }
+        }
+    }
+
+    private enum State {
+        ACTIVE,
+        TERMINABLE,
+        TERMINATED
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/NackedOutboundDeliveryException.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/NackedOutboundDeliveryException.java
@@ -1,0 +1,11 @@
+package io.atleon.rabbitmq;
+
+/**
+ * Represents publishing failure due to delivery being negatively acknowledged by broker.
+ */
+public class NackedOutboundDeliveryException extends OutboundDeliveryException {
+
+    NackedOutboundDeliveryException(long deliveryTag, boolean multiple) {
+        super(String.format("Delivery with tag=%d was nacked with multiple=%b", deliveryTag, multiple));
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/OutboundDelivery.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/OutboundDelivery.java
@@ -1,0 +1,41 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.AMQP;
+
+/**
+ * A delivery for which publishing has been (or is about to be) attempted.
+ */
+final class OutboundDelivery<T> {
+
+    private final String exchange;
+
+    private final String routingKey;
+
+    private final AMQP.BasicProperties properties;
+
+    private final T correlationMetadata;
+
+    public OutboundDelivery(
+            String exchange, String routingKey, AMQP.BasicProperties properties, T correlationMetadata) {
+        this.exchange = exchange;
+        this.routingKey = routingKey;
+        this.properties = properties;
+        this.correlationMetadata = correlationMetadata;
+    }
+
+    public String exchange() {
+        return exchange;
+    }
+
+    public String routingKey() {
+        return routingKey;
+    }
+
+    public AMQP.BasicProperties properties() {
+        return properties;
+    }
+
+    public T correlationMetadata() {
+        return correlationMetadata;
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/OutboundDeliveryException.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/OutboundDeliveryException.java
@@ -1,0 +1,11 @@
+package io.atleon.rabbitmq;
+
+/**
+ * Base class for exceptions representing outbound delivery failures.
+ */
+public class OutboundDeliveryException extends RuntimeException {
+
+    OutboundDeliveryException(String message) {
+        super(message);
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/PublishException.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/PublishException.java
@@ -1,0 +1,21 @@
+package io.atleon.rabbitmq;
+
+import java.io.IOException;
+
+/**
+ * Wraps error (as cause) from <code>basicPublish</code> on {@link com.rabbitmq.client.Channel}
+ * with corresponding delivery tag.
+ */
+final class PublishException extends RuntimeException {
+
+    private final long deliveryTag;
+
+    public PublishException(long deliveryTag, IOException cause) {
+        super(cause);
+        this.deliveryTag = deliveryTag;
+    }
+
+    public long deliveryTag() {
+        return deliveryTag;
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQConfig.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQConfig.java
@@ -1,9 +1,11 @@
 package io.atleon.rabbitmq;
 
+import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import io.atleon.util.ConfigLoading;
 import io.atleon.util.Configurable;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -21,6 +23,11 @@ public class RabbitMQConfig {
 
     public static RabbitMQConfig create(Map<String, ?> properties) {
         return new RabbitMQConfig(properties);
+    }
+
+    public Connection buildConnection() throws IOException {
+        return ConfigurableConnectionSupplier.load(properties, AloConfiguratorConnectionSupplier::new)
+                .getConnection();
     }
 
     public ConnectionFactory buildConnectionFactory() {

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQDeliverySettler.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQDeliverySettler.java
@@ -1,0 +1,24 @@
+package io.atleon.rabbitmq;
+
+/**
+ * Interface through which settlement of RabbitMQ message delivery is (scheduled to be) performed.
+ */
+public interface RabbitMQDeliverySettler {
+
+    /**
+     * Settle with status used to indicate "successful processing".
+     */
+    void ack();
+
+    /**
+     * Settle with status used to indicate "permanent/fatally failed processing". May trigger
+     * dead-lettering if queue is configured as such.
+     */
+    void reject();
+
+    /**
+     * Settle with status used to indicate "temporary/retriable processing failure". Message should
+     * be re-queued on the originating queue.
+     */
+    void requeue();
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQReceiver.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQReceiver.java
@@ -1,0 +1,60 @@
+package io.atleon.rabbitmq;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * A reactive receiver of messages from RabbitMQ, wrapped as {@link RabbitMQReceiverMessage}. An
+ * independent {@link com.rabbitmq.client.Connection} and {@link com.rabbitmq.client.Channel} are
+ * associated with each receiver subscription, and closed if/when that subscription is canceled or
+ * errored out. Each emitted message is associated with a {@link RabbitMQDeliverySettler} which
+ * <i>must</i> be invoked to signal the final settlement state of a message. This can be either
+ * "ack" (message was successfully fully processed), "reject" (message processing failed fatally,
+ * and may be dead-lettered if queue is configured as such), or "requeue" (message processing can
+ * or should be retried again in the future).
+ * <p>
+ * <b>Unsupported Consumption Features:</b> The following are noteworthy unsupported consumption
+ * features:
+ * <ul>
+ * <li><b>Native auto-ack / no-ack:</b> With the underlying reception backed by consumption on a
+ * normal RabbitMQ channel, the only mechanism available for controlling back-pressure between a
+ * given queue and downstream emission of messages is the native {@code qos} channel setting. This
+ * means we are all but forced to use manual acknowledgement in a reactive context.</li>
+ * <li><b>No-local:</b> RabbitMQ does not support the {@code noLocal} flag on consumption.</li>
+ * <li><b>Exclusive:</b> The {@code exclusive} flag is not supported due to having at least one
+ * recommended queue-level alterative ("single active consumer") and not being supported in later
+ * versions (i.e. 1.0+) of the AMQP spec.</li>
+ * <li><b>Multi-message settlement:</b> Settling more than one message at a time (by setting the
+ * "multiple" flag on ack/nack) is dubious to support in a reactive context. In such a context, it
+ * is likely (if not assumed) that there is some amount of asynchronous processing occurring, which
+ * makes out-of-order completion of messages possible. As such, in order to avoid accidental
+ * violation of at-least-once processing semantics, we avoid exposing the "multiple" flag. Note
+ * this is commensurate with newer versions (i.e. 1.0+) of the AMQP spec.</li>
+ * </ul>
+ */
+public final class RabbitMQReceiver {
+
+    private final RabbitMQReceiverOptions options;
+
+    private RabbitMQReceiver(RabbitMQReceiverOptions options) {
+        this.options = options;
+    }
+
+    public static RabbitMQReceiver create(RabbitMQReceiverOptions options) {
+        return new RabbitMQReceiver(options);
+    }
+
+    /**
+     * Receive messages from the given queue with manual settlement control.
+     *
+     * @param queue The name of the queue to consume from
+     * @return A stream of messages that require manual settlement
+     */
+    public Flux<RabbitMQReceiverMessage> receiveManual(String queue) {
+        return receiveManual(new ConsumingSubscriptionFactory(options), queue);
+    }
+
+    private Flux<RabbitMQReceiverMessage> receiveManual(
+            ConsumingSubscriptionFactory subscriptionFactory, String queue) {
+        return Flux.from(it -> it.onSubscribe(subscriptionFactory.create(queue, it)));
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQReceiverMessage.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQReceiverMessage.java
@@ -1,0 +1,87 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Envelope;
+
+/**
+ * A message received from RabbitMQ that has been emitted and requires settlement after processing.
+ * Settlement may either be "ack" (for successful processing), "reject" (for permanent/fatally
+ * failed processing), or "requeue" (for future retrial). Settlement is idempotent, and once
+ * invoked, subsequent invocations will have no effect.
+ */
+public final class RabbitMQReceiverMessage {
+
+    private final boolean redeliver;
+
+    private final String exchange;
+
+    private final String routingKey;
+
+    private final AMQP.BasicProperties properties;
+
+    private final byte[] body;
+
+    private final RabbitMQDeliverySettler deliverySettler;
+
+    private RabbitMQReceiverMessage(
+            boolean redeliver,
+            String exchange,
+            String routingKey,
+            AMQP.BasicProperties properties,
+            byte[] body,
+            RabbitMQDeliverySettler deliverySettler) {
+        this.redeliver = redeliver;
+        this.exchange = exchange;
+        this.routingKey = routingKey;
+        this.properties = properties;
+        this.body = body;
+        this.deliverySettler = deliverySettler;
+    }
+
+    public static RabbitMQReceiverMessage create(
+            Envelope envelope, AMQP.BasicProperties properties, byte[] body, RabbitMQDeliverySettler deliverySettler) {
+        return new RabbitMQReceiverMessage(
+                envelope.isRedeliver(),
+                envelope.getExchange(),
+                envelope.getRoutingKey(),
+                properties,
+                body,
+                deliverySettler);
+    }
+
+    public boolean redeliver() {
+        return redeliver;
+    }
+
+    public String exchange() {
+        return exchange;
+    }
+
+    public String routingKey() {
+        return routingKey;
+    }
+
+    public AMQP.BasicProperties properties() {
+        return properties;
+    }
+
+    public byte[] body() {
+        return body;
+    }
+
+    public void settleWithAck() {
+        deliverySettler.ack();
+    }
+
+    public void settleWithReject() {
+        deliverySettler.reject();
+    }
+
+    public void settleWithRequeue() {
+        deliverySettler.requeue();
+    }
+
+    public RabbitMQDeliverySettler deliverySettler() {
+        return deliverySettler;
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQReceiverOptions.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQReceiverOptions.java
@@ -1,0 +1,175 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.ConnectionFactoryConfigurator;
+import io.atleon.util.Defaults;
+import io.atleon.util.IOSupplier;
+import org.jspecify.annotations.Nullable;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Options used to configure the reactive reception of messages from RabbitMQ.
+ */
+public final class RabbitMQReceiverOptions {
+
+    private static final Duration DEFAULT_CLOSE_TIMEOUT = Duration.ofSeconds(30L);
+
+    private final IOSupplier<Connection> connectionSupplier;
+
+    private final int prefetch;
+
+    private final String consumerTag;
+
+    private final @Nullable Integer priority;
+
+    private final Duration closeTimeout;
+
+    private RabbitMQReceiverOptions(
+            IOSupplier<Connection> connectionSupplier,
+            int prefetch,
+            String consumerTag,
+            @Nullable Integer priority,
+            Duration closeTimeout) {
+        this.connectionSupplier = connectionSupplier;
+        this.prefetch = prefetch;
+        this.consumerTag = consumerTag;
+        this.priority = priority;
+        this.closeTimeout = closeTimeout;
+    }
+
+    public static RabbitMQReceiverOptions defaultOptions() {
+        return newBuilder().build();
+    }
+
+    public static RabbitMQReceiverOptions.Builder newBuilder() {
+        return new RabbitMQReceiverOptions.Builder(
+                it -> ConfigurableConnectionSupplier.load(it, ConfiguratorConnectionSupplier::new));
+    }
+
+    public static RabbitMQReceiverOptions.Builder newBuilder(IOSupplier<Connection> connectionSupplier) {
+        return new RabbitMQReceiverOptions.Builder(__ -> connectionSupplier::get);
+    }
+
+    public Connection createConnection() throws IOException {
+        return connectionSupplier.get();
+    }
+
+    public Scheduler createIOScheduler() {
+        return Schedulers.newSingle("atleon-rabbitmq-receive");
+    }
+
+    /**
+     * @see Builder#prefetch(int)
+     */
+    public int prefetch() {
+        return prefetch;
+    }
+
+    /**
+     * @see Builder#consumerTag(String)
+     */
+    public String consumerTag() {
+        return consumerTag;
+    }
+
+    /**
+     * @see Builder#priority(int)
+     */
+    public Optional<Integer> priority() {
+        return Optional.ofNullable(priority);
+    }
+
+    /**
+     * @see Builder#closeTimeout(Duration)
+     */
+    public Duration closeTimeout() {
+        return closeTimeout;
+    }
+
+    public static final class Builder {
+
+        private final Function<Map<String, Object>, ConfigurableConnectionSupplier> connectionProviderFactory;
+
+        private Map<String, Object> connectionProperties = Collections.emptyMap();
+
+        private int prefetch = Defaults.PREFETCH;
+
+        private String consumerTag = "";
+
+        private @Nullable Integer priority;
+
+        private Duration closeTimeout = DEFAULT_CLOSE_TIMEOUT;
+
+        private Builder(Function<Map<String, Object>, ConfigurableConnectionSupplier> connectionProviderFactory) {
+            this.connectionProviderFactory = connectionProviderFactory;
+        }
+
+        /**
+         * Sets a single native {@link ConnectionFactoryConfigurator ConnectionFactory property}
+         * used to configure supplied {@link ConnectionFactory} instances.
+         */
+        public Builder connectionProperty(String key, Object value) {
+            Map<String, Object> updatedConnectionProperties = new HashMap<>(this.connectionProperties);
+            updatedConnectionProperties.put(key, value);
+            return connectionProperties(updatedConnectionProperties);
+        }
+
+        /**
+         * Sets the native {@link ConnectionFactoryConfigurator ConnectionFactory properties} used
+         * to configure supplied {@link ConnectionFactory} instances.
+         */
+        public Builder connectionProperties(Map<String, Object> connectionProperties) {
+            this.connectionProperties = connectionProperties;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of unacked/unsettled messages that the underlying channel will
+         * allow to be delivered to per consumption.
+         */
+        public Builder prefetch(int prefetch) {
+            this.prefetch = prefetch;
+            return this;
+        }
+
+        /**
+         * Sets the tag used to identify a consumer.
+         */
+        public Builder consumerTag(String consumerTag) {
+            this.consumerTag = consumerTag;
+            return this;
+        }
+
+        /**
+         * Sets the priority for underlying consumption.
+         */
+        public Builder priority(int priority) {
+            this.priority = priority;
+            return this;
+        }
+
+        /**
+         * Sets timeout used on invocations to {@link com.rabbitmq.client.Connection#close(int)}.
+         */
+        public Builder closeTimeout(Duration closeTimeout) {
+            this.closeTimeout = closeTimeout;
+            return this;
+        }
+
+        public RabbitMQReceiverOptions build() {
+            ConfigurableConnectionSupplier connectionSupplier = connectionProviderFactory.apply(connectionProperties);
+            return new RabbitMQReceiverOptions(
+                    connectionSupplier::getConnection, prefetch, consumerTag, priority, closeTimeout);
+        }
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQSender.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQSender.java
@@ -1,0 +1,109 @@
+package io.atleon.rabbitmq;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+
+/**
+ * A reactive sender for RabbitMQ messages, wrapped as {@link RabbitMQSenderMessage}. This class
+ * provides a high-level API for publishing messages to RabbitMQ exchanges in a non-blocking,
+ * asynchronous, and backpressure-aware manner using Reactor.
+ * <p>
+ * Each instance of {@link RabbitMQSender} manages its own RabbitMQ
+ * {@link com.rabbitmq.client.Connection}. Messages can be sent with or without custom correlation
+ * metadata, and results are emitted as {@link RabbitMQSenderResult} objects, which provide access
+ * to RabbitMQ metadata and any error that occurred during sending.
+ * <p>
+ * <b>Unsupported Publishing Features:</b> The following are noteworthy unsupported publishing
+ * features:
+ * <ul>
+ * <li><b>Mandatory:</b> The mandatory flag is not supported due to inherent limitations on how
+ * RabbitMQ implements AMQP. Usage of this flag implies usage of "return listening", which is
+ * decoupled from the concept of confirmation (ack and nack). Ack/Nack corresponds with the broker
+ * saying "I accept this message", whereas "return" means a mandatory message could not be routed,
+ * regardless of whether the broker "accepted" the message. Crucially, nothing in RabbitMQ
+ * guarantees that an unrouted mandatory message will be nack'd (rather than ack'd). In short, it
+ * is not possible to guarantee that a "mandatory" publish that ultimately cannot be routed will
+ * not be nack'd or (more importantly) ack'd prior to invocation of the return listener. In the
+ * case of a preceding nack, we cannot identify that such a result is due to not being routable, so
+ * any error could be misleading. In the case of an ack, we cannot know that a "return" could be
+ * later signaled, which means we have no real-time way of knowing with certainty that a mandatory
+ * message has been successfully routed.</li>
+ * <li><b>Immediate:</b> RabbitMQ explicitly does not support the immediate flag on publish
+ * operations.</li>
+ * </ul>
+ */
+public final class RabbitMQSender {
+
+    private final RabbitMQSenderOptions options;
+
+    private final Mono<SendingConnection> futureConnection;
+
+    private final Sinks.Many<Long> closeSink = Sinks.many().multicast().directBestEffort();
+
+    private RabbitMQSender(RabbitMQSenderOptions options) {
+        this.options = options;
+        this.futureConnection = SendingConnection.create(options)
+                .cacheInvalidateWhen(
+                        it -> closeSink.asFlux().next().then().or(it.closed()), SendingConnection::closeSafelyAsync);
+    }
+
+    public static RabbitMQSender create(RabbitMQSenderOptions options) {
+        return new RabbitMQSender(options);
+    }
+
+    /**
+     * Sends a single {@link RabbitMQSenderMessage} to RabbitMQ. The resulting Mono will either
+     * emit an error if the send operation fails, or a {@link RabbitMQSenderResult} if the send
+     * operation succeeds.
+     *
+     * @param senderMessage The message to send
+     * @param <T>           The type of correlation metadata
+     * @return a {@link Mono} emitting the result of the send operation
+     */
+    public <T> Mono<RabbitMQSenderResult<T>> send(RabbitMQSenderMessage<T> senderMessage) {
+        return Mono.just(senderMessage).as(this::send).single();
+    }
+
+    /**
+     * Sends a stream of {@link RabbitMQSenderMessage}s to RabbitMQ and emits results for each
+     * record as they are acknowledged via the underlying connection/channel(s). Errors are
+     * propagated immediately and terminate the stream.
+     *
+     * @param senderMessages The publisher of messages to send
+     * @param <T>            The type of correlation metadata
+     * @return a {@link Flux} emitting (successful) results for each sent message
+     */
+    public <T> Flux<RabbitMQSenderResult<T>> send(Publisher<RabbitMQSenderMessage<T>> senderMessages) {
+        return futureConnection.flatMapMany(it -> send(it, senderMessages));
+    }
+
+    /**
+     * Sends a stream of {@link RabbitMQSenderMessage}s to RabbitMQ and emits results for each
+     * record as they are acknowledged via the underlying connection/channel(s). Errors (either due
+     * to negative acknowledgement, IO errors, or returned messages) are delegated to the client
+     * for handling by encapsulating both send failures and successes in emitted results.
+     *
+     * @param senderMessages The publisher of messages to send
+     * @param <T>            The type of correlation metadata
+     * @return a {@link Flux} emitting results for each sent message, with errors delegated per message
+     */
+    public <T> Flux<RabbitMQSenderResult<T>> sendDelegateError(Publisher<RabbitMQSenderMessage<T>> senderMessages) {
+        return futureConnection.flatMapMany(it -> sendDelegateError(it, senderMessages));
+    }
+
+    public void close() {
+        closeSink.tryEmitNext(System.currentTimeMillis());
+    }
+
+    private <T> Flux<RabbitMQSenderResult<T>> send(
+            SendingConnection connection, Publisher<RabbitMQSenderMessage<T>> senderMessages) {
+        return connection.useChannel(it -> SendPublisher.immediateError(options, it, senderMessages));
+    }
+
+    private <T> Flux<RabbitMQSenderResult<T>> sendDelegateError(
+            SendingConnection connection, Publisher<RabbitMQSenderMessage<T>> senderMessages) {
+        return connection.useChannel(it -> SendPublisher.delegateError(options, it, senderMessages));
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQSenderMessage.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQSenderMessage.java
@@ -1,0 +1,98 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.AMQP;
+
+/**
+ * A RabbitMQ message that can be sent reactively
+ *
+ * @param <T> The type of correlation metadata propagated by this message
+ */
+public final class RabbitMQSenderMessage<T> {
+
+    private final String exchange;
+
+    private final String routingKey;
+
+    private final AMQP.BasicProperties properties;
+
+    private final byte[] body;
+
+    private final T correlationMetadata;
+
+    private RabbitMQSenderMessage(
+            String exchange, String routingKey, AMQP.BasicProperties properties, byte[] body, T correlationMetadata) {
+        this.exchange = exchange;
+        this.routingKey = routingKey;
+        this.properties = properties;
+        this.body = body;
+        this.correlationMetadata = correlationMetadata;
+    }
+
+    public static <T> Builder<T> newBuilder() {
+        return new Builder<>();
+    }
+
+    public String exchange() {
+        return exchange;
+    }
+
+    public String routingKey() {
+        return routingKey;
+    }
+
+    public AMQP.BasicProperties properties() {
+        return properties;
+    }
+
+    public byte[] body() {
+        return body;
+    }
+
+    public T correlationMetadata() {
+        return correlationMetadata;
+    }
+
+    public static final class Builder<T> {
+
+        private String exchange = "";
+
+        private String routingKey = "";
+
+        private AMQP.BasicProperties properties = null;
+
+        private byte[] body = new byte[0];
+
+        private T correlationMetadata = null;
+
+        private Builder() {}
+
+        public Builder<T> exchange(String exchange) {
+            this.exchange = exchange;
+            return this;
+        }
+
+        public Builder<T> routingKey(String routingKey) {
+            this.routingKey = routingKey;
+            return this;
+        }
+
+        public Builder<T> properties(AMQP.BasicProperties properties) {
+            this.properties = properties;
+            return this;
+        }
+
+        public Builder<T> body(byte[] body) {
+            this.body = body;
+            return this;
+        }
+
+        public Builder<T> correlationMetadata(T correlationMetadata) {
+            this.correlationMetadata = correlationMetadata;
+            return this;
+        }
+
+        public RabbitMQSenderMessage<T> build() {
+            return new RabbitMQSenderMessage<>(exchange, routingKey, properties, body, correlationMetadata);
+        }
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQSenderOptions.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/RabbitMQSenderOptions.java
@@ -1,0 +1,190 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.ConnectionFactoryConfigurator;
+import io.atleon.util.IOSupplier;
+import org.jspecify.annotations.Nullable;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.concurrent.Queues;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Options used to configure the reactive publishing of messages to RabbitMQ.
+ */
+public final class RabbitMQSenderOptions {
+
+    private static final int DEFAULT_MAX_POOLED_CHANNELS = 32;
+
+    private static final Duration DEFAULT_CLOSE_TIMEOUT = Duration.ofSeconds(30L);
+
+    private final IOSupplier<Connection> connectionSupplier;
+
+    private final int maxPooledChannels;
+
+    private final int maxInFlight;
+
+    private final Duration closeTimeout;
+
+    private final Function<@Nullable Object, Consumer<Runnable>> correlationRunnerFactory;
+
+    private RabbitMQSenderOptions(
+            IOSupplier<Connection> connectionSupplier,
+            int maxPooledChannels,
+            int maxInFlight,
+            Duration closeTimeout,
+            Function<@Nullable Object, Consumer<Runnable>> correlationRunnerFactory) {
+        this.connectionSupplier = connectionSupplier;
+        this.maxPooledChannels = maxPooledChannels;
+        this.maxInFlight = maxInFlight;
+        this.closeTimeout = closeTimeout;
+        this.correlationRunnerFactory = correlationRunnerFactory;
+    }
+
+    public static RabbitMQSenderOptions defaultOptions() {
+        return newBuilder().build();
+    }
+
+    public static RabbitMQSenderOptions.Builder newBuilder() {
+        return new Builder(it -> ConfigurableConnectionSupplier.load(it, ConfiguratorConnectionSupplier::new));
+    }
+
+    public static RabbitMQSenderOptions.Builder newBuilder(IOSupplier<Connection> connectionSupplier) {
+        return new Builder(__ -> connectionSupplier::get);
+    }
+
+    public Connection createConnection() throws IOException {
+        return connectionSupplier.get();
+    }
+
+    public Scheduler createIOScheduler() {
+        return Schedulers.newSingle("atleon-rabbitmq-send");
+    }
+
+    /**
+     * @see Builder#maxInFlight(int)
+     */
+    public int maxInFlight() {
+        return maxInFlight;
+    }
+
+    /**
+     * @see Builder#maxPooledChannels(int)
+     */
+    public int maxPooledChannels() {
+        return maxPooledChannels;
+    }
+
+    /**
+     * @see Builder#closeTimeout(Duration)
+     */
+    public Duration closeTimeout() {
+        return closeTimeout;
+    }
+
+    /**
+     * @see Builder#correlationRunnerFactory(Class, Function)
+     */
+    public Consumer<Runnable> createCorrelationRunner(@Nullable Object correlationMetadata) {
+        return correlationRunnerFactory.apply(correlationMetadata);
+    }
+
+    public static final class Builder {
+
+        private final Function<Map<String, Object>, ConfigurableConnectionSupplier> connectionProviderFactory;
+
+        private Map<String, Object> connectionProperties = Collections.emptyMap();
+
+        private int maxPooledChannels = DEFAULT_MAX_POOLED_CHANNELS;
+
+        private int maxInFlight = Queues.SMALL_BUFFER_SIZE;
+
+        private Duration closeTimeout = DEFAULT_CLOSE_TIMEOUT;
+
+        private Function<@Nullable Object, Consumer<Runnable>> correlationRunnerFactory = __ -> Runnable::run;
+
+        private Builder(Function<Map<String, Object>, ConfigurableConnectionSupplier> connectionProviderFactory) {
+            this.connectionProviderFactory = connectionProviderFactory;
+        }
+
+        /**
+         * Sets a single native {@link ConnectionFactoryConfigurator ConnectionFactory property}
+         * used to configure supplied {@link ConnectionFactory} instances.
+         */
+        public Builder connectionProperty(String key, Object value) {
+            Map<String, Object> updatedConnectionProperties = new HashMap<>(this.connectionProperties);
+            updatedConnectionProperties.put(key, value);
+            return connectionProperties(updatedConnectionProperties);
+        }
+
+        /**
+         * Sets the native {@link ConnectionFactoryConfigurator ConnectionFactory properties} used
+         * to configure supplied {@link ConnectionFactory} instances.
+         */
+        public Builder connectionProperties(Map<String, Object> connectionProperties) {
+            this.connectionProperties = connectionProperties;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of channels allowed in sending pool.
+         */
+        public Builder maxPooledChannels(int maxPooledChannels) {
+            this.maxPooledChannels = maxPooledChannels;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of deliveries that are allowed to have their publishing
+         * initiated, and for which we are awaiting a result (of either success or failure).
+         */
+        public Builder maxInFlight(int maxInFlight) {
+            this.maxInFlight = maxInFlight;
+            return this;
+        }
+
+        /**
+         * Sets timeout used on invocations to {@link com.rabbitmq.client.Connection#close(int)}.
+         */
+        public Builder closeTimeout(Duration closeTimeout) {
+            this.closeTimeout = closeTimeout;
+            return this;
+        }
+
+        /**
+         * Sets a factory which is used to create "runners" (immediate invocators of
+         * {@link Runnable#run()}) from individual {@link RabbitMQSenderMessage#correlationMetadata()}
+         * values. This can be useful in cases where correlation metadata may provide execution
+         * context (like thread locals or scoped values) around low-level sending operations, e.g.
+         * distributed tracing.
+         *
+         * @param metadataType The type of correlation metadata from which runners can be created
+         * @param factory      Function used to derive a runner from an instance the metadata type
+         * @return This builder
+         */
+        <T> Builder correlationRunnerFactory(
+                Class<T> metadataType, Function<? super T, ? extends Consumer<Runnable>> factory) {
+            this.correlationRunnerFactory = metadata ->
+                    metadataType.isInstance(metadata) ? factory.apply(metadataType.cast(metadata)) : Runnable::run;
+            return this;
+        }
+
+        public RabbitMQSenderOptions build() {
+            ConfigurableConnectionSupplier connectionSupplier = connectionProviderFactory.apply(connectionProperties);
+            return new RabbitMQSenderOptions(
+                    connectionSupplier::getConnection,
+                    maxPooledChannels,
+                    maxInFlight,
+                    closeTimeout,
+                    correlationRunnerFactory);
+        }
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/ReactiveChannel.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/ReactiveChannel.java
@@ -1,0 +1,122 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.ConfirmListener;
+import com.rabbitmq.client.ReturnListener;
+import com.rabbitmq.client.ShutdownListener;
+import io.atleon.util.IORunnable;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import java.util.function.LongFunction;
+
+/**
+ * A reactive facade around a {@link Channel} being used to interact with RabbitMQ.
+ */
+final class ReactiveChannel {
+
+    /**
+     * <a href="https://www.rabbitmq.com/docs/consumer-priority#how-to-use">Consumer priority</a>
+     */
+    private static final String PRIORITY_ARGUMENT = "x-priority";
+
+    private final Channel channel;
+
+    private final Scheduler ioScheduler;
+
+    private final CompletableFuture<Void> usefulness = new CompletableFuture<>();
+
+    private final Sinks.Empty<Void> closed = Sinks.empty();
+
+    private ReactiveChannel(Channel channel, Scheduler ioScheduler) {
+        this.channel = channel;
+        this.ioScheduler = ioScheduler;
+
+        usefulness.whenComplete((__, error) -> close().subscribe());
+        channel.addShutdownListener(usefulness::completeExceptionally);
+    }
+
+    public static ReactiveChannel create(Channel channel, Scheduler originalIOScheduler) {
+        return new ReactiveChannel(channel, Schedulers.single(originalIOScheduler));
+    }
+
+    public <T extends ConfirmListener & ReturnListener & ShutdownListener> void addPublishListener(T listener) {
+        channel.addConfirmListener(listener);
+        channel.addReturnListener(listener);
+        channel.addShutdownListener(listener);
+    }
+
+    public <T extends ConfirmListener & ReturnListener & ShutdownListener> void removePublishListener(T listener) {
+        channel.removeConfirmListener(listener);
+        channel.removeReturnListener(listener);
+        channel.removeShutdownListener(listener);
+    }
+
+    public Mono<Void> basicPublish(Consumer<Runnable> runner, LongFunction<BasicPublishArguments> argsFactory) {
+        return runIO(() -> runner.accept(() -> {
+            long sequencedDeliveryTag = channel.getNextPublishSeqNo();
+            BasicPublishArguments args = argsFactory.apply(sequencedDeliveryTag);
+            try {
+                channel.basicPublish(args.exchange(), args.routingKey(), false, false, args.properties(), args.body());
+            } catch (IOException e) {
+                throw new PublishException(sequencedDeliveryTag, e);
+            }
+        }));
+    }
+
+    public Mono<Void> basicConsume(BasicConsumeArguments args, com.rabbitmq.client.Consumer consumer) {
+        return runIO(() -> {
+            Map<String, Object> arguments = args.priority()
+                    .<Map<String, Object>>map(it -> Collections.singletonMap(PRIORITY_ARGUMENT, it))
+                    .orElse(Collections.emptyMap());
+            channel.basicConsume(args.queue(), false, args.consumerTag(), false, false, arguments, consumer);
+        });
+    }
+
+    public Mono<Void> basicAck(long deliveryTag, boolean multiple) {
+        return runIO(() -> channel.basicAck(deliveryTag, multiple));
+    }
+
+    public Mono<Void> basicNack(long deliveryTag, boolean multiple, boolean requeue) {
+        return runIO(() -> channel.basicNack(deliveryTag, multiple, requeue));
+    }
+
+    public Mono<Void> closeGracefully() {
+        return Mono.fromRunnable(() -> usefulness.complete(null)).then(closed.asMono());
+    }
+
+    public boolean unusable() {
+        return usefulness.isDone();
+    }
+
+    private Mono<Void> close() {
+        return runIO(() -> {
+            try {
+                if (channel.isOpen()) {
+                    channel.close();
+                }
+            } catch (TimeoutException e) {
+                throw new IOException("Timeout on Channel closure", e);
+            } finally {
+                closed.tryEmitEmpty();
+                ioScheduler.dispose();
+            }
+        });
+    }
+
+    private Mono<Void> runIO(IORunnable runnable) {
+        Mono<Void> call = Mono.fromCallable(() -> {
+            runnable.run();
+            return null;
+        });
+        return call.subscribeOn(ioScheduler);
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/ReactiveConnection.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/ReactiveConnection.java
@@ -1,0 +1,116 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.AlreadyClosedException;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import io.atleon.util.IORunnable;
+import io.atleon.util.IOSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Scheduler;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * A reactive facade around an active {@link Connection} being used to interact with RabbitMQ.
+ */
+abstract class ReactiveConnection {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReactiveConnection.class);
+
+    private final Scheduler ioScheduler;
+
+    private final Connection connection;
+
+    private final int closeTimeoutMillis;
+
+    private final Sinks.Empty<Void> closed = Sinks.empty();
+
+    protected ReactiveConnection(Scheduler ioScheduler, Connection connection, Duration closeTimeout) {
+        this.ioScheduler = ioScheduler;
+        this.connection = connection;
+        this.closeTimeoutMillis = Math.toIntExact(closeTimeout.toMillis());
+
+        connection.addShutdownListener(closed::tryEmitError);
+    }
+
+    public final void closeSafelyAsync() {
+        closeSafely().subscribe();
+    }
+
+    public final Mono<Void> closeSafely() {
+        Mono<Void> ioClosure = Mono.fromRunnable(() -> {
+            runSafely(() -> close(connection, closeTimeoutMillis), "connection::close");
+            runSafely(closed::tryEmitEmpty, "closed::tryEmitEmpty");
+            runSafely(ioScheduler::dispose, "ioScheduler::dispose");
+        });
+        return closeChannelResources().then(ioClosure.subscribeOn(ioScheduler));
+    }
+
+    public final Mono<Void> closed() {
+        return closed.asMono();
+    }
+
+    protected final Mono<ReactiveChannel> createReactiveChannel() {
+        return getIO(this::createChannel).map(it -> ReactiveChannel.create(it, ioScheduler));
+    }
+
+    protected Channel createChannel() throws IOException {
+        return connection.createChannel();
+    }
+
+    protected abstract Mono<Void> closeChannelResources();
+
+    protected static <T extends ReactiveConnection> Mono<T> create(
+            Supplier<Scheduler> ioSchedulerSupplier,
+            IOSupplier<Connection> connectionSupplier,
+            BiFunction<Scheduler, Connection, T> constructor) {
+        return Mono.defer(() -> {
+            // Since we're calling with a deferred subscription, it is safe to create a scheduler
+            // here with subsequent cleanup if creating a connection is anything but successful.
+            // Such cleanup is necessary since it would otherwise be impossible to implement
+            // cleanup correctly without successful connection creation.
+            Scheduler ioScheduler = ioSchedulerSupplier.get();
+
+            return Mono.fromCallable(connectionSupplier::get)
+                    .subscribeOn(ioScheduler)
+                    .map(it -> constructor.apply(ioScheduler, it))
+                    .doFinally(signalType -> {
+                        if (signalType != SignalType.ON_COMPLETE) {
+                            ioScheduler.dispose();
+                        }
+                    });
+        });
+    }
+
+    private <T> Mono<T> getIO(IOSupplier<T> supplier) {
+        return Mono.fromCallable(supplier::get).subscribeOn(ioScheduler);
+    }
+
+    private static void close(Connection connection, int timeoutMillis) throws IOException {
+        try {
+            connection.close(timeoutMillis);
+        } catch (AlreadyClosedException e) {
+            LOGGER.debug("Connection already closed", e);
+        }
+    }
+
+    private static void runSafely(IORunnable task, String name) {
+        runSafely(task, error -> LOGGER.error("Unexpected failure: name={}", name, error));
+    }
+
+    private static void runSafely(IORunnable task, Consumer<Throwable> errorHandler) {
+        try {
+            task.run();
+        } catch (Throwable e) {
+            errorHandler.accept(e);
+        }
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/ReceivingConnection.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/ReceivingConnection.java
@@ -1,0 +1,68 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.Consumer;
+import org.jspecify.annotations.Nullable;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+
+import java.io.IOException;
+
+/**
+ * A reactive facade around an active {@link Connection} being used for reception.
+ */
+final class ReceivingConnection extends ReactiveConnection {
+
+    private final int prefetch;
+
+    private final String consumerTag;
+
+    private final @Nullable Integer priority;
+
+    private final Mono<ReactiveChannel> channel;
+
+    private ReceivingConnection(Scheduler ioScheduler, Connection connection, RabbitMQReceiverOptions options) {
+        super(ioScheduler, connection, options.closeTimeout());
+        this.prefetch = options.prefetch();
+        this.consumerTag = options.consumerTag();
+        this.priority = options.priority().orElse(null);
+        this.channel = createReactiveChannel().cache();
+    }
+
+    public static Mono<ReceivingConnection> create(RabbitMQReceiverOptions options) {
+        return create(
+                options::createIOScheduler,
+                options::createConnection,
+                (scheduler, connection) -> new ReceivingConnection(scheduler, connection, options));
+    }
+
+    public Mono<Void> consume(String queue, Consumer consumer) {
+        BasicConsumeArguments args = new BasicConsumeArguments(queue, consumerTag, priority);
+        return channel.flatMap(it -> it.basicConsume(args, consumer));
+    }
+
+    public Mono<Void> ack(long deliveryTag) {
+        return channel.flatMap(it -> it.basicAck(deliveryTag, false));
+    }
+
+    public Mono<Void> reject(long deliveryTag) {
+        return channel.flatMap(it -> it.basicNack(deliveryTag, false, false));
+    }
+
+    public Mono<Void> requeue(long deliveryTag) {
+        return channel.flatMap(it -> it.basicNack(deliveryTag, false, true));
+    }
+
+    @Override
+    protected Channel createChannel() throws IOException {
+        Channel channel = super.createChannel();
+        channel.basicQos(prefetch);
+        return channel;
+    }
+
+    @Override
+    protected Mono<Void> closeChannelResources() {
+        return Mono.empty();
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/ReturnedOutboundDeliveryException.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/ReturnedOutboundDeliveryException.java
@@ -1,0 +1,11 @@
+package io.atleon.rabbitmq;
+
+/**
+ * Represents publishing failure due to published delivery being returned by broker.
+ */
+public class ReturnedOutboundDeliveryException extends OutboundDeliveryException {
+
+    public ReturnedOutboundDeliveryException(int code, String text) {
+        super(String.format("Outbound Delivery returned with code=%d and text='%s'", code, text));
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/SendPublisher.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/SendPublisher.java
@@ -1,0 +1,374 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.ConfirmListener;
+import com.rabbitmq.client.ReturnListener;
+import com.rabbitmq.client.ShutdownListener;
+import com.rabbitmq.client.ShutdownSignalException;
+import io.atleon.core.SerialQueue;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Operators;
+import reactor.util.context.Context;
+
+import java.util.Iterator;
+import java.util.NavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+final class SendPublisher<T> implements Publisher<RabbitMQSenderResult<T>> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SendPublisher.class);
+
+    private final Publisher<? extends RabbitMQSenderMessage<T>> source;
+
+    private final Function<Subscriber<? super RabbitMQSenderResult<T>>, ? extends Send<T>> sender;
+
+    private SendPublisher(
+            Publisher<? extends RabbitMQSenderMessage<T>> source,
+            Function<Subscriber<? super RabbitMQSenderResult<T>>, ? extends Send<T>> sender) {
+        this.source = source;
+        this.sender = sender;
+    }
+
+    public static <T> SendPublisher<T> immediateError(
+            RabbitMQSenderOptions options,
+            ReactiveChannel channel,
+            Publisher<RabbitMQSenderMessage<T>> senderMessages) {
+        return new SendPublisher<>(senderMessages, it -> new ConditionalSend<>(options, channel, it, false));
+    }
+
+    public static <T> SendPublisher<T> delegateError(
+            RabbitMQSenderOptions options,
+            ReactiveChannel channel,
+            Publisher<RabbitMQSenderMessage<T>> senderMessages) {
+        return new SendPublisher<>(senderMessages, it -> new ConditionalSend<>(options, channel, it, true));
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super RabbitMQSenderResult<T>> actual) {
+        source.subscribe(sender.apply(actual));
+    }
+
+    private static void runSafely(Runnable task, String name) {
+        try {
+            task.run();
+        } catch (Exception e) {
+            LOGGER.error("Unexpected failure: name={}", name, e);
+        }
+    }
+
+    private abstract static class Send<T>
+            implements CoreSubscriber<RabbitMQSenderMessage<T>>,
+                    Subscription,
+                    ConfirmListener,
+                    ReturnListener,
+                    ShutdownListener {
+
+        private enum State {
+            ACTIVE,
+            TERMINABLE,
+            TERMINATED
+        }
+
+        private static final AtomicLongFieldUpdater<Send> IN_FLIGHT =
+                AtomicLongFieldUpdater.newUpdater(Send.class, "inFlight");
+
+        private static final AtomicLongFieldUpdater<Send> OUTSTANDING_DOWNSTREAM_REQUEST =
+                AtomicLongFieldUpdater.newUpdater(Send.class, "outstandingDownstreamRequest");
+
+        private static final AtomicLongFieldUpdater<Send> OUTSTANDING_UPSTREAM_REQUEST =
+                AtomicLongFieldUpdater.newUpdater(Send.class, "outstandingUpstreamRequest");
+
+        private static final AtomicReferenceFieldUpdater<Send, State> SUBSCRIPTION_STATE =
+                AtomicReferenceFieldUpdater.newUpdater(Send.class, State.class, "subscriptionState");
+
+        private static final AtomicIntegerFieldUpdater<Send> SUBSCRIPTION_DRAINS_IN_PROGRESS =
+                AtomicIntegerFieldUpdater.newUpdater(Send.class, "subscriptionDrainsInProgress");
+
+        private final RabbitMQSenderOptions options;
+
+        private final ReactiveChannel channel;
+
+        private final Context subscriberContext;
+
+        private final SerialQueue<Consumer<Subscriber<? super RabbitMQSenderResult<T>>>> emissionQueue;
+
+        private final NavigableMap<Long, OutboundDelivery<T>> inFlightPublishes = new ConcurrentSkipListMap<>();
+
+        private Subscription parent;
+
+        // This counter doubles as both our publishing state (via polarity: positive == ACTIVE,
+        // negative == TERMINABLE, zero == TERMINATED) and our count of in-flight sent records (via
+        // magnitude: subtract 1 if positive, negate if negative). The extra/initializing count of
+        // 1 is in reserve for termination of this subscriber (self). As such, when this becomes
+        // non-positive, it means a terminating signal has been received from upstream OR a fatal
+        // error has been encountered on sending. When it becomes zero, it means termination has
+        // been enqueued to the downstream subscriber.
+        private volatile long inFlight = 1;
+
+        private volatile long outstandingDownstreamRequest = 0;
+
+        private volatile long outstandingUpstreamRequest = 0;
+
+        private volatile State subscriptionState = State.ACTIVE;
+
+        private volatile int subscriptionDrainsInProgress = 0;
+
+        protected Send(
+                RabbitMQSenderOptions options,
+                ReactiveChannel channel,
+                CoreSubscriber<? super RabbitMQSenderResult<T>> actual) {
+            this.options = options;
+            this.channel = channel;
+            this.subscriberContext = actual.currentContext();
+            this.emissionQueue = SerialQueue.on(actual);
+
+            channel.addPublishListener(this);
+        }
+
+        @Override
+        public Context currentContext() {
+            return subscriberContext;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            parent = s;
+            emissionQueue.addAndDrain(subscriber -> subscriber.onSubscribe(this));
+        }
+
+        @Override
+        public void onNext(RabbitMQSenderMessage<T> message) {
+            if (IN_FLIGHT.getAndUpdate(this, it -> it > 0 ? it + 1 : it) <= 0) {
+                return;
+            }
+
+            T correlationMetadata = message.correlationMetadata();
+            Consumer<Runnable> runner = options.createCorrelationRunner(correlationMetadata);
+
+            Mono<Void> publish = channel.basicPublish(runner, deliveryTag -> {
+                BasicPublishArguments args = new BasicPublishArguments(
+                        message.exchange(), message.routingKey(), message.properties(), message.body());
+
+                inFlightPublishes.put(deliveryTag, args.toOutboundDelivery(correlationMetadata));
+
+                return args;
+            });
+
+            publish.subscribe(__ -> {}, error -> {
+                if (error instanceof PublishException) {
+                    PublishException publishException = (PublishException) error;
+                    handleOutboundFailure(publishException.deliveryTag(), false, publishException.getCause());
+                } else {
+                    handleFatalPublishingFailure(error);
+                }
+            });
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            if (IN_FLIGHT.getAndSet(this, 0) != 0) {
+                enqueueTermination(subscriber -> subscriber.onError(t));
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (IN_FLIGHT.getAndUpdate(this, it -> it > 0 ? 1 - it : it) == 1) {
+                enqueueTermination(Subscriber::onComplete);
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            if (Operators.validate(n)) {
+                Operators.addCap(OUTSTANDING_DOWNSTREAM_REQUEST, this, n);
+                drainSubscription();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            if (SUBSCRIPTION_STATE.compareAndSet(this, State.ACTIVE, State.TERMINABLE)) {
+                drainSubscription();
+            }
+        }
+
+        @Override
+        public void handleAck(long deliveryTag, boolean multiple) {
+            enqueueNextFromOutbound(deliveryTag, multiple, RabbitMQSenderResult::success);
+        }
+
+        @Override
+        public void handleNack(long deliveryTag, boolean multiple) {
+            handleOutboundFailure(deliveryTag, multiple, new NackedOutboundDeliveryException(deliveryTag, multiple));
+        }
+
+        @Override
+        public void handleReturn(
+                int replyCode,
+                String replyText,
+                String exchange,
+                String routingKey,
+                AMQP.BasicProperties properties,
+                byte[] body) {
+            handleFatalPublishingFailure(new ReturnedOutboundDeliveryException(replyCode, replyText));
+        }
+
+        @Override
+        public void shutdownCompleted(ShutdownSignalException cause) {
+            handleFatalPublishingFailure(cause);
+        }
+
+        protected final void handleOutboundFailure(long deliveryTag, boolean multiple, Throwable error) {
+            if (shouldEmitFailureAsResult()) {
+                enqueueNextFromOutbound(deliveryTag, multiple, it -> RabbitMQSenderResult.failure(it, error));
+            } else {
+                handleFatalPublishingFailure(error);
+            }
+        }
+
+        protected abstract boolean shouldEmitFailureAsResult();
+
+        private void enqueueNextFromOutbound(
+                long deliveryTag,
+                boolean multiple,
+                Function<OutboundDelivery<T>, RabbitMQSenderResult<T>> senderResultFactory) {
+            NavigableMap<Long, OutboundDelivery<T>> deliveries = multiple
+                    ? inFlightPublishes.headMap(deliveryTag, true)
+                    : inFlightPublishes.subMap(deliveryTag, true, deliveryTag, true);
+
+            Iterator<OutboundDelivery<T>> iterator = deliveries.values().iterator();
+            while (iterator.hasNext()) {
+                RabbitMQSenderResult<T> senderResult = senderResultFactory.apply(iterator.next());
+                enqueueNext(senderResult);
+                iterator.remove();
+            }
+        }
+
+        private void enqueueNext(RabbitMQSenderResult<T> result) {
+            emissionQueue.addAndDrain(subscriber -> {
+                if (inFlight == 0 || subscriptionState != State.ACTIVE) {
+                    return;
+                }
+
+                try {
+                    subscriber.onNext(result);
+                } catch (Throwable error) {
+                    LOGGER.error("Emission failure (violates Reactive Streams §2.13)", error);
+                    handleFatalPublishingFailure(error);
+                    return;
+                }
+
+                long previousInFlight = IN_FLIGHT.getAndUpdate(this, count -> {
+                    if (count > 0) {
+                        return count - 1;
+                    } else if (count == 0) {
+                        return count;
+                    } else {
+                        return count + 1;
+                    }
+                });
+                if (outstandingUpstreamRequest != Long.MAX_VALUE) {
+                    OUTSTANDING_UPSTREAM_REQUEST.decrementAndGet(this);
+                }
+
+                // If the previous in-flight count was positive, then we are not yet eligible for
+                // termination, and we should ensure that any capacity freed by emitting the last
+                // result is reflected by upstream demand. Only if the previous count was exactly
+                // -1 do we know that we are eligible for termination, and that this was the last
+                // in-flight result to emit, so we can emit termination. Note that because onError
+                // and onComplete immediately make the in-flight count non-positive, it will never
+                // be those calling threads that could also invoke drainSubscription (which would
+                // be a violation of §2.3).
+                if (previousInFlight > 0) {
+                    drainSubscription();
+                } else if (previousInFlight == -1 && subscriptionState == State.ACTIVE) {
+                    enqueueTermination(Subscriber::onComplete);
+                }
+            });
+        }
+
+        private void enqueueTermination(Consumer<Subscriber<?>> terminator) {
+            // This is only ever invoked at-most-once after termination has been signaled from
+            // upstream AND inFlight has reached zero. This could race with cancellation, but it's
+            // not a spec violation if upstream termination is concurrent with downstream cancel.
+            enqueueDetachment(subscriber -> runSafely(() -> terminator.accept(subscriber), "Termination"));
+        }
+
+        private void handleFatalPublishingFailure(Throwable error) {
+            cancel();
+            onError(error);
+        }
+
+        private void drainSubscription() {
+            if (subscriptionState == State.TERMINATED || SUBSCRIPTION_DRAINS_IN_PROGRESS.getAndIncrement(this) != 0) {
+                return;
+            }
+
+            int missed = 1;
+            do {
+                if (subscriptionState == State.ACTIVE) {
+                    long toRequest = calculateMaxUpstreamRequest();
+
+                    if (toRequest > 0 && outstandingUpstreamRequest != Long.MAX_VALUE) {
+                        if (outstandingDownstreamRequest != Long.MAX_VALUE) {
+                            OUTSTANDING_DOWNSTREAM_REQUEST.addAndGet(this, -toRequest);
+                        }
+                        Operators.addCap(OUTSTANDING_UPSTREAM_REQUEST, this, toRequest);
+                        runSafely(() -> parent.request(toRequest), "parent::request");
+                    }
+                } else if (SUBSCRIPTION_STATE.compareAndSet(this, State.TERMINABLE, State.TERMINATED)) {
+                    runSafely(parent::cancel, "parent::cancel");
+                    enqueueDetachment(__ -> {});
+                }
+
+                missed = SUBSCRIPTION_DRAINS_IN_PROGRESS.addAndGet(this, -missed);
+            } while (missed != 0);
+        }
+
+        private long calculateMaxUpstreamRequest() {
+            if (options.maxInFlight() == Integer.MAX_VALUE) {
+                return outstandingDownstreamRequest;
+            } else {
+                return Math.min(options.maxInFlight() - outstandingUpstreamRequest, outstandingDownstreamRequest);
+            }
+        }
+
+        private void enqueueDetachment(Consumer<Subscriber<?>> andThen) {
+            emissionQueue.addAndDrain(subscriber -> {
+                runSafely(() -> channel.removePublishListener(this), "channel::removePublishListener");
+                andThen.accept(subscriber);
+            });
+        }
+    }
+
+    private static final class ConditionalSend<T> extends Send<T> {
+
+        private final boolean emitFailuresAsResults;
+
+        public ConditionalSend(
+                RabbitMQSenderOptions options,
+                ReactiveChannel channel,
+                Subscriber<? super RabbitMQSenderResult<T>> actual,
+                boolean emitFailuresAsResults) {
+            super(options, channel, Operators.toCoreSubscriber(actual));
+            this.emitFailuresAsResults = emitFailuresAsResults;
+        }
+
+        @Override
+        protected boolean shouldEmitFailureAsResult() {
+            return emitFailuresAsResults;
+        }
+    }
+}

--- a/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/SendingConnection.java
+++ b/infrastructures/rabbitmq/src/main/java/io/atleon/rabbitmq/SendingConnection.java
@@ -1,0 +1,53 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.pool.Pool;
+import reactor.pool.PoolBuilder;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+/**
+ * Wrapper around a {@link Connection} that is actively being used to publish messages.
+ */
+final class SendingConnection extends ReactiveConnection {
+
+    private final Pool<ReactiveChannel> channelPool;
+
+    private SendingConnection(Scheduler ioScheduler, Connection connection, RabbitMQSenderOptions options) {
+        super(ioScheduler, connection, options.closeTimeout());
+        this.channelPool = PoolBuilder.from(createReactiveChannel())
+                .destroyHandler(ReactiveChannel::closeGracefully)
+                .evictionPredicate((channel, __) -> channel.unusable())
+                .sizeBetween(0, options.maxPooledChannels())
+                .buildPool();
+    }
+
+    public static Mono<SendingConnection> create(RabbitMQSenderOptions options) {
+        return create(
+                options::createIOScheduler,
+                options::createConnection,
+                (scheduler, connection) -> new SendingConnection(scheduler, connection, options));
+    }
+
+    public <T> Flux<T> useChannel(Function<ReactiveChannel, Publisher<T>> user) {
+        return channelPool.withPoolable(user);
+    }
+
+    @Override
+    protected Channel createChannel() throws IOException {
+        Channel channel = super.createChannel();
+        channel.confirmSelect();
+        return channel;
+    }
+
+    @Override
+    protected Mono<Void> closeChannelResources() {
+        return channelPool.disposeLater();
+    }
+}

--- a/infrastructures/rabbitmq/src/test/java/io/atleon/rabbitmq/RabbitMQReceiverTest.java
+++ b/infrastructures/rabbitmq/src/test/java/io/atleon/rabbitmq/RabbitMQReceiverTest.java
@@ -1,0 +1,173 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.BuiltinExchangeType;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import io.atleon.amqp.embedded.EmbeddedAmqp;
+import io.atleon.amqp.embedded.EmbeddedAmqpConfig;
+import io.atleon.util.IOFunction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RabbitMQReceiverTest {
+
+    private static final EmbeddedAmqpConfig EMBEDDED_AMQP_CONFIG = EmbeddedAmqp.start();
+
+    private final String exchange = RabbitMQReceiverTest.class.getSimpleName() + UUID.randomUUID();
+
+    private final String queue = RabbitMQReceiverTest.class.getSimpleName() + UUID.randomUUID();
+
+    private final String routingKey = "key";
+
+    @BeforeEach
+    public void setup() throws IOException {
+        executeOnChannel(it -> {
+            // Configure and declare exchange
+            it.exchangeDeclare(exchange, BuiltinExchangeType.DIRECT, true, false, false, Collections.emptyMap());
+
+            // Configure and declare queue(s)
+            it.queueDeclare(queue, true, false, false, Collections.emptyMap());
+
+            // Bind queue(s) to exchange
+            it.queueBind(queue, exchange, routingKey);
+
+            return Optional.empty();
+        });
+    }
+
+    @Test
+    public void receiveManual_givenMessageSettledWithAck_expectsProcessingContinuation() throws IOException {
+        String bodyText1 = "data1";
+        String bodyText2 = "data2";
+
+        RabbitMQSenderMessage<Object> message1 = RabbitMQSenderMessage.newBuilder()
+                .exchange(exchange)
+                .routingKey(routingKey)
+                .body(bodyText1.getBytes(StandardCharsets.UTF_8))
+                .build();
+        RabbitMQSenderMessage<Object> message2 = RabbitMQSenderMessage.newBuilder()
+                .exchange(exchange)
+                .routingKey(routingKey)
+                .body(bodyText2.getBytes(StandardCharsets.UTF_8))
+                .build();
+
+        sendMessages(message1, message2);
+
+        RabbitMQReceiverOptions options = RabbitMQReceiverOptions.newBuilder()
+                .connectionProperties(EMBEDDED_AMQP_CONFIG.asMap())
+                .build();
+
+        RabbitMQReceiver.create(options)
+                .receiveManual(queue)
+                .doOnNext(RabbitMQReceiverMessage::settleWithAck)
+                .as(StepVerifier::create)
+                .expectNextMatches(it -> Arrays.equals(bodyText1.getBytes(StandardCharsets.UTF_8), it.body()))
+                .thenCancel()
+                .verify();
+
+        RabbitMQReceiver.create(options)
+                .receiveManual(queue)
+                .doOnNext(RabbitMQReceiverMessage::settleWithAck)
+                .as(StepVerifier::create)
+                .expectNextMatches(it -> Arrays.equals(bodyText2.getBytes(StandardCharsets.UTF_8), it.body()))
+                .thenCancel()
+                .verify();
+
+        assertEquals(0, (long) executeOnChannel(it -> it.messageCount(queue)));
+    }
+
+    @Test
+    public void receiveManual_givenMessageSettledWithRequeue_expectsProcessingRepetition() throws IOException {
+        String bodyText1 = "data1";
+
+        RabbitMQSenderMessage<Object> message1 = RabbitMQSenderMessage.newBuilder()
+                .exchange(exchange)
+                .routingKey(routingKey)
+                .body(bodyText1.getBytes(StandardCharsets.UTF_8))
+                .build();
+
+        sendMessages(message1);
+
+        RabbitMQReceiverOptions options = RabbitMQReceiverOptions.newBuilder()
+                .connectionProperties(EMBEDDED_AMQP_CONFIG.asMap())
+                .build();
+
+        RabbitMQReceiver.create(options)
+                .receiveManual(queue)
+                .doOnNext(RabbitMQReceiverMessage::settleWithRequeue)
+                .as(StepVerifier::create)
+                .expectNextMatches(it -> Arrays.equals(bodyText1.getBytes(StandardCharsets.UTF_8), it.body()))
+                .thenCancel()
+                .verify();
+
+        RabbitMQReceiver.create(options)
+                .receiveManual(queue)
+                .doOnNext(RabbitMQReceiverMessage::settleWithRequeue)
+                .as(StepVerifier::create)
+                .expectNextMatches(RabbitMQReceiverMessage::redeliver)
+                .thenCancel()
+                .verify();
+
+        assertEquals(1, (long) executeOnChannel(it -> it.messageCount(queue)));
+    }
+
+    @Test
+    public void receiveManual_givenMessageSettledWithReject_expectsRetainment() throws IOException {
+        String bodyText1 = "data1";
+
+        RabbitMQSenderMessage<Object> message1 = RabbitMQSenderMessage.newBuilder()
+                .exchange(exchange)
+                .routingKey(routingKey)
+                .body(bodyText1.getBytes(StandardCharsets.UTF_8))
+                .build();
+
+        sendMessages(message1);
+
+        RabbitMQReceiverOptions options = RabbitMQReceiverOptions.newBuilder()
+                .connectionProperties(EMBEDDED_AMQP_CONFIG.asMap())
+                .build();
+
+        RabbitMQReceiver.create(options)
+                .receiveManual(queue)
+                .doOnNext(RabbitMQReceiverMessage::settleWithReject)
+                .as(StepVerifier::create)
+                .expectNextMatches(it -> Arrays.equals(bodyText1.getBytes(StandardCharsets.UTF_8), it.body()))
+                .thenCancel()
+                .verify();
+
+        // AMQP handles rejection the same as requeue. Would be better to be able to configure DLQ.
+        assertEquals(1, (long) executeOnChannel(it -> it.messageCount(queue)));
+    }
+
+    @SafeVarargs
+    private static void sendMessages(RabbitMQSenderMessage<Object>... messages) {
+        RabbitMQSenderOptions options = RabbitMQSenderOptions.newBuilder()
+                .connectionProperties(EMBEDDED_AMQP_CONFIG.asMap())
+                .build();
+        RabbitMQSender sender = RabbitMQSender.create(options);
+        try {
+            Flux.just(messages).as(sender::send).then().block();
+        } finally {
+            sender.close();
+        }
+    }
+
+    private static <T> T executeOnChannel(IOFunction<Channel, T> function) throws IOException {
+        ConfiguratorConnectionSupplier connectionSupplier = new ConfiguratorConnectionSupplier();
+        connectionSupplier.configure(EMBEDDED_AMQP_CONFIG.asMap());
+        try (Connection connection = connectionSupplier.getConnection()) {
+            return function.apply(connection.createChannel());
+        }
+    }
+}

--- a/infrastructures/rabbitmq/src/test/java/io/atleon/rabbitmq/RabbitMQSenderTest.java
+++ b/infrastructures/rabbitmq/src/test/java/io/atleon/rabbitmq/RabbitMQSenderTest.java
@@ -1,0 +1,161 @@
+package io.atleon.rabbitmq;
+
+import com.rabbitmq.client.BuiltinExchangeType;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.GetResponse;
+import com.rabbitmq.client.ShutdownSignalException;
+import io.atleon.amqp.embedded.EmbeddedAmqp;
+import io.atleon.amqp.embedded.EmbeddedAmqpConfig;
+import io.atleon.util.IOFunction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.AdditionalAnswers;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RabbitMQSenderTest {
+
+    private static final EmbeddedAmqpConfig EMBEDDED_AMQP_CONFIG = EmbeddedAmqp.start();
+
+    private final String exchange = RabbitMQSenderTest.class.getSimpleName() + UUID.randomUUID();
+
+    private final String queue = RabbitMQSenderTest.class.getSimpleName() + UUID.randomUUID();
+
+    private final String routingKey = RabbitMQSenderTest.class.getSimpleName() + UUID.randomUUID();
+
+    @BeforeEach
+    public void setup() throws IOException {
+        executeOnChannel(it -> {
+            // Configure and declare exchange
+            it.exchangeDeclare(exchange, BuiltinExchangeType.DIRECT, true, false, false, Collections.emptyMap());
+
+            // Configure and declare queue(s)
+            it.queueDeclare(queue, true, false, false, Collections.emptyMap());
+
+            // Bind queue(s) to exchange
+            it.queueBind(queue, exchange, routingKey);
+
+            return Optional.empty();
+        });
+    }
+
+    @Test
+    public void send_givenSuccessfulSend_expectsProducedMessages() throws IOException {
+        String body = UUID.randomUUID().toString();
+
+        RabbitMQSenderMessage<Object> senderMessage = RabbitMQSenderMessage.newBuilder()
+                .exchange(exchange)
+                .routingKey(routingKey)
+                .body(body.getBytes(StandardCharsets.UTF_8))
+                .build();
+
+        RabbitMQSenderOptions senderOptions = RabbitMQSenderOptions.newBuilder()
+                .connectionProperties(EMBEDDED_AMQP_CONFIG.asMap())
+                .build();
+
+        executeOnSender(senderOptions, it -> it.send(senderMessage).block());
+
+        GetResponse result = getMessage(queue);
+
+        assertEquals(body, new String(result.getBody(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void send_givenFailedSendToNonExistentExchange_expectsError() {
+        String body = UUID.randomUUID().toString();
+
+        RabbitMQSenderMessage<Object> senderMessage = RabbitMQSenderMessage.newBuilder()
+                .exchange(UUID.randomUUID().toString())
+                .routingKey(routingKey)
+                .body(body.getBytes(StandardCharsets.UTF_8))
+                .build();
+
+        RabbitMQSenderOptions senderOptions = RabbitMQSenderOptions.newBuilder()
+                .connectionProperties(EMBEDDED_AMQP_CONFIG.asMap())
+                .build();
+
+        Executable send = () ->
+                executeOnSender(senderOptions, it -> it.send(senderMessage).block());
+
+        assertThrows(ShutdownSignalException.class, send);
+    }
+
+    @Test
+    public void sendDelegateError_givenFailedSend_expectsSendResultsToReflectError() {
+        String body = UUID.randomUUID().toString();
+
+        RabbitMQSenderMessage<Object> senderMessage = RabbitMQSenderMessage.newBuilder()
+                .exchange(exchange)
+                .routingKey(routingKey)
+                .body(body.getBytes(StandardCharsets.UTF_8))
+                .build();
+
+        RabbitMQSenderOptions senderOptions = RabbitMQSenderOptions.newBuilder(RabbitMQSenderTest::newBoomingConnection)
+                .build();
+
+        RabbitMQSenderResult<Object> result = executeOnSender(
+                senderOptions,
+                it -> Mono.just(senderMessage).as(it::sendDelegateError).blockFirst());
+
+        assertNotNull(result);
+        assertTrue(result.isFailure());
+    }
+
+    private static <T> T executeOnSender(RabbitMQSenderOptions senderOptions, Function<RabbitMQSender, T> function) {
+        RabbitMQSender sender = RabbitMQSender.create(senderOptions);
+        try {
+            return function.apply(sender);
+        } finally {
+            sender.close();
+        }
+    }
+
+    private static GetResponse getMessage(String queue) throws IOException {
+        return executeOnChannel(channel -> channel.basicGet(queue, false));
+    }
+
+    private static <T> T executeOnChannel(IOFunction<Channel, T> function) throws IOException {
+        try (Connection connection = newConnection()) {
+            return function.apply(connection.createChannel());
+        }
+    }
+
+    private static Connection newBoomingConnection() throws IOException {
+        Connection connection = newConnection();
+        Connection boomingConnection = mock(Connection.class, AdditionalAnswers.delegatesTo(connection));
+        when(boomingConnection.createChannel()).thenAnswer(__ -> newBoomingChannel(connection));
+        return boomingConnection;
+    }
+
+    private static Channel newBoomingChannel(Connection connection) throws IOException {
+        Channel boomingChannel = mock(Channel.class, AdditionalAnswers.delegatesTo(connection.createChannel()));
+        doThrow(new IOException("Boom"))
+                .when(boomingChannel)
+                .basicPublish(anyString(), anyString(), anyBoolean(), anyBoolean(), any(), any());
+        return boomingChannel;
+    }
+
+    private static Connection newConnection() throws IOException {
+        return ConfigurableConnectionSupplier.load(EMBEDDED_AMQP_CONFIG.asMap(), ConfiguratorConnectionSupplier::new)
+                .getConnection();
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -32,6 +32,7 @@
         <rabbitmq-amqp-client.version>5.18.0</rabbitmq-amqp-client.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <reactor.version>3.5.14</reactor.version>
+        <reactor-pool.version>1.0.5</reactor-pool.version>
         <reactor-rabbitmq.version>1.5.6</reactor-rabbitmq.version>
         <scala.version>2.13.15</scala.version>
         <slf4j.version>2.0.11</slf4j.version>
@@ -228,6 +229,11 @@
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-test</artifactId>
                 <version>${reactor.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.projectreactor.addons</groupId>
+                <artifactId>reactor-pool</artifactId>
+                <version>${reactor-pool.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.projectreactor.rabbitmq</groupId>


### PR DESCRIPTION
### :pencil: Description
- Replace/Migrate functionality from (discontinued) reactor-rabbitmq

### :link: Related Issues
#463 
