### PR TITLE
[#493] Kafka: Indicate explicitly paused partitions on Consumer proxy

### DIFF
--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/PollManager.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/PollManager.java
@@ -128,6 +128,10 @@ final class PollManager<T> {
         forcePaused.removeAll(partitions);
     }
 
+    public Collection<TopicPartition> forcePaused() {
+        return Collections.unmodifiableCollection(forcePaused);
+    }
+
     public T activated(TopicPartition topicPartition) {
         return assignments.get(topicPartition);
     }

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
@@ -183,6 +183,11 @@ final class PollingSubscriptionFactory<K, V> {
             pollManager.allowResumption(partitions);
         }
 
+        @Override
+        public final Collection<TopicPartition> grantedPartitionPauses() {
+            return pollManager.forcePaused();
+        }
+
         protected abstract void onPartitionActivated(Consumer<?, ?> consumer, ActivePartition partition);
 
         protected abstract void onActivePartitionsRevoked(


### PR DESCRIPTION
### :pencil: Description

### :link: Related Issues
#493