### PR TITLE
[#534] Core: Refactor AloKafkaBoundedReceiverTest

### DIFF
--- a/base/core/src/main/java/io/atleon/core/ErrorEmitter.java
+++ b/base/core/src/main/java/io/atleon/core/ErrorEmitter.java
@@ -40,14 +40,6 @@ public final class ErrorEmitter<T> {
         return Flux.from(publisher).mergeWith(sink.asMono());
     }
 
-    public void safelyComplete() {
-        try {
-            sink.emitEmpty(Sinks.EmitFailureHandler.busyLooping(timeout));
-        } catch (Sinks.EmissionException emissionException) {
-            LOGGER.info("Failed to emit completion due to reason={}", emissionException.getReason());
-        }
-    }
-
     public void safelyEmit(Throwable error) {
         try {
             sink.emitError(error, Sinks.EmitFailureHandler.busyLooping(timeout));

--- a/base/core/src/test/java/io/atleon/core/ErrorEmitterTest.java
+++ b/base/core/src/test/java/io/atleon/core/ErrorEmitterTest.java
@@ -1,0 +1,60 @@
+package io.atleon.core;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+
+class ErrorEmitterTest {
+
+    @Test
+    public void safelyEmit_givenActiveSubscriber_expectsErrorPropagated() {
+        ErrorEmitter<String> emitter = ErrorEmitter.create();
+        Sinks.Many<String> sink = Sinks.many().multicast().onBackpressureBuffer();
+        RuntimeException error = new RuntimeException("test error");
+
+        Flux<String> merged = emitter.applyTo(sink.asFlux());
+
+        StepVerifier.create(merged)
+                .then(() -> {
+                    sink.tryEmitNext("a");
+                    emitter.safelyEmit(error);
+                })
+                .expectNext("a")
+                .expectErrorMatches(e -> e == error)
+                .verify(Duration.ofSeconds(5));
+    }
+
+    @Test
+    public void safelyEmit_givenSinkAlreadyTerminated_expectsNoException() {
+        ErrorEmitter<String> emitter = ErrorEmitter.create(Duration.ofMillis(100));
+
+        // First emission succeeds (even without a subscriber, the sink accepts it)
+        emitter.safelyEmit(new RuntimeException("first"));
+
+        // Second emission should not throw — failure is logged and swallowed
+        emitter.safelyEmit(new RuntimeException("second"));
+    }
+
+    @Test
+    public void safelyEmit_givenOngoingStream_expectsStreamTerminated() {
+        ErrorEmitter<Integer> emitter = ErrorEmitter.create();
+        Sinks.Many<Integer> sink = Sinks.many().multicast().onBackpressureBuffer();
+        IllegalStateException error = new IllegalStateException("stream failed");
+
+        Flux<Integer> merged = emitter.applyTo(sink.asFlux());
+
+        StepVerifier.create(merged)
+                .then(() -> {
+                    sink.tryEmitNext(1);
+                    sink.tryEmitNext(2);
+                })
+                .expectNext(1, 2)
+                .then(() -> emitter.safelyEmit(error))
+                .expectErrorMatches(e ->
+                        e instanceof IllegalStateException && e.getMessage().equals("stream failed"))
+                .verify(Duration.ofSeconds(5));
+    }
+}

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/AloKafkaBoundedReceiver.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/AloKafkaBoundedReceiver.java
@@ -3,13 +3,13 @@ package io.atleon.kafka;
 import io.atleon.core.Alo;
 import io.atleon.core.AloFlux;
 import io.atleon.core.ComposedAlo;
-import io.atleon.core.ErrorEmitter;
 import io.atleon.util.Consuming;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.TopicPartition;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -103,12 +103,12 @@ public class AloKafkaBoundedReceiver<K, V> {
             ReactiveAdmin admin, String groupId, RecordRange recordRange) {
         Map<TopicPartition, Long> offsetsToCommit =
                 Collections.singletonMap(recordRange.topicPartition(), recordRange.maxInclusive() + 1);
-        ErrorEmitter<Alo<ConsumerRecord<K, V>>> errorEmitter = ErrorEmitter.create();
+        Sinks.Empty<Alo<ConsumerRecord<K, V>>> termination = Sinks.empty();
         Runnable acknowledger = () -> admin.alterRawConsumerGroupOffsets(groupId, offsetsToCommit)
-                .subscribe(Consuming.noOp(), errorEmitter::safelyEmit, errorEmitter::safelyComplete);
-        return AloFlux.just(new ComposedAlo<>(recordRange, acknowledger, errorEmitter::safelyEmit))
+                .subscribe(Consuming.noOp(), termination::tryEmitError, termination::tryEmitEmpty);
+        return AloFlux.just(new ComposedAlo<>(recordRange, acknowledger, termination::tryEmitError))
                 .concatMap(KafkaBoundedReceiver.<K, V>create(configSource)::receiveRecordsInRange)
-                .transform(errorEmitter::applyTo);
+                .transform(it -> it.unwrap().mergeWith(termination.asMono()));
     }
 
     private static OffsetRange toOffsetRange(long rawMinInclusive, OffsetCriteria maxInclusive) {

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/AloKafkaBoundedReceiverTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/AloKafkaBoundedReceiverTest.java
@@ -33,44 +33,81 @@ class AloKafkaBoundedReceiverTest {
     private static final String BOOTSTRAP_CONNECT = EmbeddedKafka.startAndGetBootstrapServersConnect(10092);
 
     @Test
-    public void recordsCanBeConsumedAndCommittedForAConsumerGroup() {
+    public void receiveAloRecordsUpTo_givenEarliestToLatestReception_expectsSnapshot() {
         String topic = UUID.randomUUID().toString();
-        List<Long> producedValues1 = produceRecordsFromValues(
+        String groupId = AloKafkaBoundedReceiverTest.class.getSimpleName() + UUID.randomUUID();
+
+        List<Long> producedValues = produceRecordsFromValues(
+                newProducerConfigs(LongSerializer.class, LongSerializer.class),
+                createRandomLongValues(1, Collectors.toList()),
+                value -> new ProducerRecord<>(topic, 0, value, value));
+
+        List<Long> result =
+                receiveAloValuesAsLongs(topic, groupId, OffsetResetStrategy.EARLIEST, OffsetCriteria.latest());
+
+        assertEquals(producedValues, result);
+    }
+
+    @Test
+    public void receiveAloRecordsUpTo_givenLatestReceptionAndGroupHasNotBeenUsed_expectsNoReception() {
+        String topic = UUID.randomUUID().toString();
+        String groupId = AloKafkaBoundedReceiverTest.class.getSimpleName() + UUID.randomUUID();
+
+        produceRecordsFromValues(
                 newProducerConfigs(LongSerializer.class, LongSerializer.class),
                 createRandomLongValues(4, Collectors.toList()),
                 value -> new ProducerRecord<>(topic, 0, value, value));
 
-        assertTrue(receiveAloValuesAsLongs(topic, OffsetResetStrategy.NONE, OffsetCriteria.latest())
-                .isEmpty());
-        assertTrue(receiveAloValuesAsLongs(topic, OffsetResetStrategy.LATEST, OffsetCriteria.latest())
-                .isEmpty());
-        assertEquals(
-                producedValues1, receiveAloValuesAsLongs(topic, OffsetResetStrategy.EARLIEST, OffsetCriteria.latest()));
-        assertTrue(receiveAloValuesAsLongs(topic, OffsetResetStrategy.EARLIEST, OffsetCriteria.latest())
-                .isEmpty());
+        List<Long> noneToLatest =
+                receiveAloValuesAsLongs(topic, groupId, OffsetResetStrategy.NONE, OffsetCriteria.latest());
+        List<Long> latestToLatest =
+                receiveAloValuesAsLongs(topic, groupId, OffsetResetStrategy.LATEST, OffsetCriteria.latest());
 
-        List<Long> producedValues2 = produceRecordsFromValues(
+        assertTrue(noneToLatest.isEmpty());
+        assertTrue(latestToLatest.isEmpty());
+    }
+
+    @Test
+    public void receiveAloRecordsUpTo_givenEarliestToLatestAfterGroupHasBeenUsed_expectsNoRepeatedReception() {
+        String topic = UUID.randomUUID().toString();
+        String groupId = AloKafkaBoundedReceiverTest.class.getSimpleName() + UUID.randomUUID();
+
+        List<Long> producedValues = produceRecordsFromValues(
                 newProducerConfigs(LongSerializer.class, LongSerializer.class),
-                createRandomLongValues(1, Collectors.toList()),
+                createRandomLongValues(4, Collectors.toList()),
                 value -> new ProducerRecord<>(topic, 0, value, value));
 
-        assertEquals(
-                producedValues2, receiveAloValuesAsLongs(topic, OffsetResetStrategy.EARLIEST, OffsetCriteria.latest()));
+        List<Long> firstResult =
+                receiveAloValuesAsLongs(topic, groupId, OffsetResetStrategy.EARLIEST, OffsetCriteria.latest());
+        List<Long> secondResult =
+                receiveAloValuesAsLongs(topic, groupId, OffsetResetStrategy.EARLIEST, OffsetCriteria.latest());
 
-        List<Long> producedValues3 = produceRecordsFromValues(
+        assertEquals(producedValues, firstResult);
+        assertTrue(secondResult.isEmpty());
+    }
+
+    @Test
+    public void receiveAloRecordsUpTo_givenEarliestToLatestAfterNoCommittedPriorUsage_expectsSnapshot() {
+        String topic = UUID.randomUUID().toString();
+        String groupId = AloKafkaBoundedReceiverTest.class.getSimpleName() + UUID.randomUUID();
+
+        List<Long> producedValues = produceRecordsFromValues(
                 newProducerConfigs(LongSerializer.class, LongSerializer.class),
                 createRandomLongValues(1, Collectors.toList()),
                 value -> new ProducerRecord<>(topic, 1, value, value));
 
-        assertTrue(receiveAloValuesAsLongs(topic, OffsetResetStrategy.NONE, OffsetCriteria.latest())
-                .isEmpty());
-        assertEquals(
-                producedValues3, receiveAloValuesAsLongs(topic, OffsetResetStrategy.EARLIEST, OffsetCriteria.latest()));
+        List<Long> noneToLatest =
+                receiveAloValuesAsLongs(topic, groupId, OffsetResetStrategy.NONE, OffsetCriteria.latest());
+        List<Long> earliestToLatest =
+                receiveAloValuesAsLongs(topic, groupId, OffsetResetStrategy.EARLIEST, OffsetCriteria.latest());
+
+        assertTrue(noneToLatest.isEmpty());
+        assertEquals(producedValues, earliestToLatest);
     }
 
     private List<Long> receiveAloValuesAsLongs(
-            String topic, OffsetResetStrategy resetStrategy, OffsetCriteria maxInclusive) {
-        return newConsumerConfigSource(ByteArrayDeserializer.class, LongDeserializer.class)
+            String topic, String groupId, OffsetResetStrategy resetStrategy, OffsetCriteria maxInclusive) {
+        return newConsumerConfigSource(groupId, ByteArrayDeserializer.class, LongDeserializer.class)
                 .with(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, resetStrategy.toString())
                 .as(AloKafkaBoundedReceiver::<Object, Long>create)
                 .receiveAloRecordsUpTo(topic, maxInclusive)
@@ -80,28 +117,30 @@ class AloKafkaBoundedReceiverTest {
                 .block();
     }
 
-    private KafkaConfigSource newProducerConfigs(
+    private static KafkaConfigSource newProducerConfigs(
             Class<? extends Serializer<?>> keySerializer, Class<? extends Serializer<?>> valueSerializer) {
         return newBaseConfigSource()
                 .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializer.getName())
                 .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer.getName());
     }
 
-    private KafkaConfigSource newConsumerConfigSource(
-            Class<? extends Deserializer<?>> keyDeserializer, Class<? extends Deserializer<?>> valueDeserializer) {
+    private static KafkaConfigSource newConsumerConfigSource(
+            String groupId,
+            Class<? extends Deserializer<?>> keyDeserializer,
+            Class<? extends Deserializer<?>> valueDeserializer) {
         return newBaseConfigSource()
-                .with(ConsumerConfig.GROUP_ID_CONFIG, AloKafkaBoundedReceiverTest.class.getSimpleName())
+                .with(ConsumerConfig.GROUP_ID_CONFIG, groupId)
                 .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.getName())
                 .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.getName());
     }
 
-    private KafkaConfigSource newBaseConfigSource() {
+    private static KafkaConfigSource newBaseConfigSource() {
         return KafkaConfigSource.useClientIdAsName()
                 .withClientId(KafkaBoundedReceiverTest.class.getSimpleName())
                 .withBootstrapServers(BOOTSTRAP_CONNECT);
     }
 
-    private <T, C extends Collection<T>> C produceRecordsFromValues(
+    private static <T, C extends Collection<T>> C produceRecordsFromValues(
             KafkaConfigSource configSource, C data, Function<T, ProducerRecord<Object, T>> recordCreator) {
         try (AloKafkaSender<Object, T> sender = AloKafkaSender.create(configSource)) {
             Flux.fromIterable(data)
@@ -113,7 +152,7 @@ class AloKafkaBoundedReceiverTest {
         return data;
     }
 
-    private <T> T createRandomLongValues(int count, Collector<Long, ?, T> collector) {
+    private static <T> T createRandomLongValues(int count, Collector<Long, ?, T> collector) {
         Random random = new Random();
         return IntStream.range(0, count).mapToObj(unused -> random.nextLong()).collect(collector);
     }


### PR DESCRIPTION
### :pencil: Description
- Make test a little more robust to group ID reusage
- Remove dependence on ErrorEmitter to enable future optimization

### :link: Related Issues
#534 