### PR TITLE
[#539] Implement new AloFlux::groupByWithAutoComplete operator

### DIFF
--- a/base/core/src/main/java/io/atleon/core/AloFlux.java
+++ b/base/core/src/main/java/io/atleon/core/AloFlux.java
@@ -479,6 +479,44 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
     }
 
     /**
+     * Group {@link Alo} elements by a key derived from their data into serialized
+     * {@link AloGroupedFlux} sub-streams, where each emitted group automatically completes once
+     * every element ever routed to it has signaled processing completion via positive or negative
+     * acknowledgement. If the same key is observed again after its prior group has auto-completed,
+     * a fresh {@link AloGroupedFlux} is emitted downstream for that key.
+     *
+     * <p>In contrast to {@link #groupBy(Function, int)} (which relies on
+     * {@link Flux#groupBy(Function)} and therefore retains every group for the lifetime of the
+     * source), this operator leverages the acknowledgement signal carried by every {@link Alo} to
+     * release per-group resources as soon as a group becomes quiescent. This makes it suitable for
+     * streams with high or unbounded key cardinality.
+     *
+     * <p>The {@code concurrency} parameter controls how many groups can be concurrently consumed
+     * by subsequent {@link GroupFlux#flatMapAlo} operations. It does <i>not</i> bound the number
+     * of distinct keys observed at the source; The amount of elements requested from the source is
+     * rather unbounded, and it is therefore necessary that downstream group operators do <i>not</i>
+     * restrict request count in an absolute manner. In other words, downstream group operators
+     * should either request infinite elements, or continue requesting elements as long as they are
+     * emitted into a given group. Otherwise, this can result in dropped elements that will never
+     * be processed/acknowledged, which can lead to stream hanging.
+     *
+     * <p>Upon upstream error or downstream cancellation, active groups are completed (rather than
+     * errored) and no attempt is made to positively or negatively acknowledge in-flight elements;
+     * the upstream source is responsible for any necessary re-emission. See
+     * {@link AloGroupByWithAutoCompleteOperator} for the full set of usage assumptions this
+     * operator makes.
+     *
+     * @param keyExtractor function used to derive a grouping key from each element's data
+     * @param concurrency  the number of groups that may be concurrently consumed downstream
+     * @param <K>          the type of key produced by {@code keyExtractor}
+     * @return a {@link GroupFlux} of self-completing {@link AloGroupedFlux} sub-streams keyed by {@code K}
+     */
+    public <K> GroupFlux<K, T> groupByWithAutoComplete(Function<? super T, ? extends K> keyExtractor, int concurrency) {
+        return new GroupFlux<>(
+                new AloGroupByWithAutoCompleteOperator<>(wrapped, Integer.MAX_VALUE, keyExtractor), concurrency);
+    }
+
+    /**
      * @see Flux#publishOn(Scheduler)
      */
     public AloFlux<T> publishOn(Scheduler scheduler) {

--- a/base/core/src/main/java/io/atleon/core/AloFlux.java
+++ b/base/core/src/main/java/io/atleon/core/AloFlux.java
@@ -512,8 +512,8 @@ public class AloFlux<T> implements Publisher<Alo<T>> {
      * @return a {@link GroupFlux} of self-completing {@link AloGroupedFlux} sub-streams keyed by {@code K}
      */
     public <K> GroupFlux<K, T> groupByWithAutoComplete(Function<? super T, ? extends K> keyExtractor, int concurrency) {
-        return new GroupFlux<>(
-                new AloGroupByWithAutoCompleteOperator<>(wrapped, Integer.MAX_VALUE, keyExtractor), concurrency);
+        Grouping<T, K> grouping = Grouping.simple(keyExtractor);
+        return new GroupFlux<>(new AloGroupByWithAutoCompleteOperator<>(wrapped, grouping), concurrency);
     }
 
     /**

--- a/base/core/src/main/java/io/atleon/core/AloGroupByWithAutoCompleteOperator.java
+++ b/base/core/src/main/java/io/atleon/core/AloGroupByWithAutoCompleteOperator.java
@@ -1,0 +1,418 @@
+package io.atleon.core;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxOperator;
+import reactor.core.publisher.Operators;
+import reactor.core.publisher.SignalType;
+import reactor.core.publisher.Sinks;
+import reactor.util.context.Context;
+
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Enables grouping of related {@link Alo} elements into serialized {@link AloGroupedFlux} streams.
+ * In contrast to standard {@link Flux#groupBy(Function)}, this operator leverages the fact that
+ * emitted elements must signal processing completion through acknowledgement, which enables
+ * automatic resource cleanup (i.e. completion of processing groups) when all emitted elements in a
+ * processing group have completed processing.
+ * <p>
+ * This operator makes the following assumptions about streams to which it may be applied:
+ * <ul>
+ *     <li>It is desired that upstream errors terminate in-flight processing before propagating
+ *     such errors to the downstream group emission subscriber.</li>
+ *     <li>Downstream cancellation of group emission is intended to signal both upstream
+ *     cancellation and termination of emitted processing groups.</li>
+ *     <li>Upon termination of processing due to either upstream error or downstream cancellation,
+ *     the upstream source handles any necessary re-emission of emitted elements that were
+ *     in-flight at time of termination.</li>
+ *     <li>Downstream group processing operators do <i>not</i> impose absolute request limiting,
+ *     i.e. downstream operators on emitted groups either request infinite elements, or never stop
+ *     requesting elements while emission continues.</li>
+ * </ul>
+ * Given the above usage assumptions, this operator does <i>not</i> make thorough attempts to
+ * positively or negatively acknowledge emitted {@link Alo} elements on either upstream
+ * errors or downstream cancellation.
+ *
+ * @param <K> Type of keys extracted from upstream {@link Alo} elements used for process grouping
+ * @param <T> Type of data referenced by upstream {@link Alo} elements
+ */
+final class AloGroupByWithAutoCompleteOperator<K, T> extends FluxOperator<Alo<T>, AloGroupedFlux<K, T>> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AloGroupByWithAutoCompleteOperator.class);
+
+    private final int maxInFlight;
+
+    private final Function<? super T, ? extends K> keyExtractor;
+
+    AloGroupByWithAutoCompleteOperator(
+            Flux<Alo<T>> source, int maxInFlight, Function<? super T, ? extends K> keyExtractor) {
+        super(source);
+        this.maxInFlight = maxInFlight;
+        this.keyExtractor = keyExtractor;
+    }
+
+    @Override
+    public void subscribe(CoreSubscriber<? super AloGroupedFlux<K, T>> actual) {
+        source.subscribe(new AloGroupByWithAutoCompleteSubscriber<>(maxInFlight, keyExtractor, actual));
+    }
+
+    private static void runSafely(Runnable task, String name) {
+        try {
+            task.run();
+        } catch (Exception e) {
+            LOGGER.error("Unexpected failure: name={}", name, e);
+        }
+    }
+
+    private static final class AloGroupByWithAutoCompleteSubscriber<K, T>
+            implements CoreSubscriber<Alo<T>>, ProcessingGroupListener<K, Alo<T>>, Subscription {
+
+        private static final long IN_FLIGHT_CAPACITY_UPSTREAM_TERMINATED = -1;
+
+        private static final long IN_FLIGHT_CAPACITY_PUBLISHING_ERROR = -2;
+
+        private static final long IN_FLIGHT_CAPACITY_DOWNSTREAM_CANCELED = -3;
+
+        private static final AtomicLongFieldUpdater<AloGroupByWithAutoCompleteSubscriber> FREE_IN_FLIGHT_CAPACITY =
+                AtomicLongFieldUpdater.newUpdater(AloGroupByWithAutoCompleteSubscriber.class, "freeInFlightCapacity");
+
+        private static final AtomicLongFieldUpdater<AloGroupByWithAutoCompleteSubscriber> REQUEST_OUTSTANDING =
+                AtomicLongFieldUpdater.newUpdater(AloGroupByWithAutoCompleteSubscriber.class, "requestOutstanding");
+
+        private static final AtomicIntegerFieldUpdater<AloGroupByWithAutoCompleteSubscriber> DRAINS_IN_PROGRESS =
+                AtomicIntegerFieldUpdater.newUpdater(AloGroupByWithAutoCompleteSubscriber.class, "drainsInProgress");
+
+        private static final AtomicReferenceFieldUpdater<AloGroupByWithAutoCompleteSubscriber, Throwable> ERROR =
+                AtomicReferenceFieldUpdater.newUpdater(
+                        AloGroupByWithAutoCompleteSubscriber.class, Throwable.class, "error");
+
+        private final int maxInFlight;
+
+        private final Function<? super T, ? extends K> keyExtractor;
+
+        private final CoreSubscriber<? super AloGroupedFlux<K, T>> actual;
+
+        private final Queue<Alo<T>> nextQueue = new ConcurrentLinkedQueue<>();
+
+        private final Map<K, ProcessingGroup<K, Alo<T>>> processingGroups = new HashMap<>();
+
+        private final Queue<ProcessingGroup<K, Alo<T>>> emittableGroups = new ArrayDeque<>();
+
+        private final Queue<ProcessingGroup<K, Alo<T>>> emptiedGroups = new ConcurrentLinkedQueue<>();
+
+        // Intentionally not volatile per Reactor convention
+        private Subscription parent;
+
+        // This counter doubles as both our publishing state (via polarity: non-negative == ACTIVE,
+        // negative == TERMINABLE or TERMINATED) and (when non-negative) our count of available
+        // upstream request capacity. As such, when this first becomes negative, it means we have
+        // entered a TERMINABLE state (error or cancellation). When it is set to Long.MIN_VALUE it
+        // means we have signaled (or are signaling) termination to either/both upstream source and
+        // downstream subscriber.
+        private volatile long freeInFlightCapacity;
+
+        private volatile long requestOutstanding;
+
+        private volatile int drainsInProgress;
+
+        private volatile Throwable error;
+
+        private AloGroupByWithAutoCompleteSubscriber(
+                int maxInFlight,
+                Function<? super T, ? extends K> keyExtractor,
+                CoreSubscriber<? super AloGroupedFlux<K, T>> actual) {
+            if (maxInFlight <= 0) {
+                throw new IllegalArgumentException("maxInFlight must be > 0");
+            }
+            this.maxInFlight = maxInFlight;
+            this.keyExtractor = keyExtractor;
+            this.actual = actual;
+        }
+
+        @Override
+        public Context currentContext() {
+            return actual.currentContext();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            if (!Operators.validate(parent, s)) {
+                return;
+            }
+
+            parent = s;
+            FREE_IN_FLIGHT_CAPACITY.set(this, maxInFlight == Integer.MAX_VALUE ? Long.MAX_VALUE : maxInFlight);
+            actual.onSubscribe(this);
+        }
+
+        @Override
+        public void onNext(Alo<T> alo) {
+            nextQueue.add(alo);
+            drain();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            // It is important that the error CAS comes before entering terminable state, since
+            // it's possible that another thread is concurrently draining, and we don't want to
+            // risk such a thread seeing a terminable state and erroneously emitting completion
+            // when we're about to set an error. Note that this could race with downstream
+            // cancellation, but it's not a spec violation if upstream termination is concurrent
+            // with downstream cancel.
+            if (ERROR.compareAndSet(this, null, t) && enterTerminableStateFromUpstreamSignal()) {
+                drain();
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (enterTerminableStateFromUpstreamSignal()) {
+                drain();
+            }
+        }
+
+        @Override
+        public void onFatalEmissionFailure(Throwable error) {
+            handleFatalPublishingFailure(error);
+        }
+
+        @Override
+        public void onElementCompletedProcessing(ProcessingGroup<K, Alo<T>> group, boolean groupEmptied) {
+            long previousFreeInFlightCapacity = maxInFlight != Integer.MAX_VALUE
+                    ? FREE_IN_FLIGHT_CAPACITY.getAndUpdate(this, it -> it >= 0 ? it + 1 : it)
+                    : Long.MAX_VALUE;
+            if (groupEmptied) {
+                emptiedGroups.add(group);
+                drain();
+            } else if (previousFreeInFlightCapacity != Long.MAX_VALUE) {
+                drain();
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            if (!Operators.validate(n)) {
+                return;
+            }
+
+            Operators.addCap(REQUEST_OUTSTANDING, this, n);
+            drain();
+        }
+
+        @Override
+        public void cancel() {
+            if (enterTerminableState(IN_FLIGHT_CAPACITY_DOWNSTREAM_CANCELED)) {
+                drain();
+            }
+        }
+
+        private void handleFatalPublishingFailure(Throwable error) {
+            if (enterTerminableState(IN_FLIGHT_CAPACITY_PUBLISHING_ERROR)) {
+                onError(error);
+                drain();
+            }
+        }
+
+        private void drain() {
+            if (DRAINS_IN_PROGRESS.getAndIncrement(this) != 0) {
+                return;
+            }
+
+            int missed = 1;
+            do {
+                // Complete any groups that have been emptied (and still are). A group that WAS
+                // emptied may not still be empty in the case that the drain loop was just
+                // previously invoked with a group that was emptied after this check, but then
+                // had more elements emitted into it (in the next code block).
+                ProcessingGroup<K, Alo<T>> emptied;
+                while ((emptied = emptiedGroups.poll()) != null) {
+                    if (!emptied.isEmpty()) {
+                        continue;
+                    }
+                    ProcessingGroup<K, Alo<T>> removed = processingGroups.remove(emptied.key());
+                    if (removed != null) {
+                        runSafely(removed::complete, "group::complete");
+                    }
+                }
+
+                // Emit next Alos into corresponding groups, enqueuing new groups for emission
+                Alo<T> next;
+                while (mayContinueEmission() && (next = nextQueue.poll()) != null) {
+                    try {
+                        T t = next.get();
+                        AloFactory<T> propagator = next.propagator();
+                        processingGroups
+                                .computeIfAbsent(keyExtractor.apply(t), this::enqueueEmittableGroup)
+                                .next(next.getAcknowledger(), next.getNacknowledger(), it -> newAlo(propagator, t, it));
+                    } catch (Throwable publishingError) {
+                        handleFatalPublishingFailure(publishingError);
+                    }
+                }
+
+                // Emit as many queued groups as possible and update outstanding request
+                long maxToEmit = requestOutstanding;
+                long emitted = 0L;
+                ProcessingGroup<K, Alo<T>> emittable;
+                while (emitted < maxToEmit && mayContinueEmission() && (emittable = emittableGroups.poll()) != null) {
+                    try {
+                        actual.onNext(new AloGroupedFlux<>(emittable.elements(), emittable.key()));
+                        emitted++;
+                    } catch (Throwable publishingError) {
+                        handleFatalPublishingFailure(publishingError);
+                    }
+                }
+                Operators.produced(REQUEST_OUTSTANDING, this, emitted);
+
+                // Propagate subscription signals to parent and/or emit termination signals if now
+                // is the time to do so.
+                long nvFreeInFlightCapacity = freeInFlightCapacity;
+                if (nvFreeInFlightCapacity > 0) {
+                    parent.request(nvFreeInFlightCapacity);
+                    FREE_IN_FLIGHT_CAPACITY.updateAndGet(this, it -> it >= 0 ? it - nvFreeInFlightCapacity : it);
+                } else if (nvFreeInFlightCapacity < 0) {
+                    if (nvFreeInFlightCapacity == IN_FLIGHT_CAPACITY_DOWNSTREAM_CANCELED) {
+                        FREE_IN_FLIGHT_CAPACITY.set(this, Long.MIN_VALUE);
+                        runSafely(parent::cancel, "parent::cancel");
+                        terminateProcessingGroups(ProcessingGroup::complete, "complete");
+                        return;
+                    } else if (nvFreeInFlightCapacity == IN_FLIGHT_CAPACITY_PUBLISHING_ERROR) {
+                        runSafely(parent::cancel, "parent::cancel");
+                    }
+
+                    Throwable nvError = error;
+                    if (nvError != null) {
+                        FREE_IN_FLIGHT_CAPACITY.set(this, Long.MIN_VALUE);
+                        terminateProcessingGroups(ProcessingGroup::complete, "error");
+                        terminateActual(it -> it.onError(nvError), "error");
+                        return;
+                    } else if (processingGroups.isEmpty()) {
+                        FREE_IN_FLIGHT_CAPACITY.set(this, Long.MIN_VALUE);
+                        terminateActual(Subscriber::onComplete, "complete");
+                        return;
+                    }
+                }
+
+                missed = DRAINS_IN_PROGRESS.addAndGet(this, -missed);
+            } while (missed != 0);
+        }
+
+        private ProcessingGroup<K, Alo<T>> enqueueEmittableGroup(K key) {
+            ProcessingGroup<K, Alo<T>> emittable = new ProcessingGroup<>(key, this);
+            emittableGroups.add(emittable);
+            return emittable;
+        }
+
+        private void terminateProcessingGroups(Consumer<ProcessingGroup<?, ?>> groupConsumer, String method) {
+            processingGroups.values().forEach(it -> runSafely(() -> groupConsumer.accept(it), "group::" + method));
+        }
+
+        private void terminateActual(Consumer<Subscriber<?>> actualConsumer, String method) {
+            runSafely(() -> actualConsumer.accept(actual), "actual::" + method);
+        }
+
+        private boolean mayContinueEmission() {
+            return freeInFlightCapacity >= IN_FLIGHT_CAPACITY_UPSTREAM_TERMINATED;
+        }
+
+        private boolean enterTerminableStateFromUpstreamSignal() {
+            return enterTerminableState(IN_FLIGHT_CAPACITY_UPSTREAM_TERMINATED);
+        }
+
+        private boolean enterTerminableState(long targetState) {
+            return FREE_IN_FLIGHT_CAPACITY.getAndUpdate(this, it -> Math.min(it, targetState)) > targetState;
+        }
+
+        private static <T> Alo<T> newAlo(AloFactory<T> aloFactory, T t, Acknowledgement acknowledgement) {
+            return aloFactory.create(t, acknowledgement::positive, acknowledgement::negative);
+        }
+    }
+
+    private static final class ProcessingGroup<K, T> {
+
+        private static final AtomicLongFieldUpdater<ProcessingGroup> IN_FLIGHT =
+                AtomicLongFieldUpdater.newUpdater(ProcessingGroup.class, "inFlight");
+
+        private final K key;
+
+        private final ProcessingGroupListener<K, T> listener;
+
+        private final Sinks.Many<T> sink = Sinks.unsafe().many().unicast().onBackpressureBuffer();
+
+        private volatile long inFlight;
+
+        public ProcessingGroup(K key, ProcessingGroupListener<K, T> listener) {
+            this.key = key;
+            this.listener = listener;
+        }
+
+        public void next(
+                Runnable acknowledger,
+                Consumer<? super Throwable> nacknowledger,
+                Function<Acknowledgement, T> elementFactory) {
+            IN_FLIGHT.incrementAndGet(this);
+
+            Acknowledgement acknowledgement = Acknowledgement.create(
+                    () -> {
+                        acknowledger.run();
+                        elementCompletedProcessing();
+                    },
+                    error -> {
+                        nacknowledger.accept(error);
+                        elementCompletedProcessing();
+                    });
+
+            sink.emitNext(elementFactory.apply(acknowledgement), this::handleEmissionFailure);
+        }
+
+        public void complete() {
+            sink.emitComplete(this::handleEmissionFailure);
+        }
+
+        public K key() {
+            return key;
+        }
+
+        public Flux<T> elements() {
+            return sink.asFlux();
+        }
+
+        public boolean isEmpty() {
+            return inFlight == 0;
+        }
+
+        private boolean handleEmissionFailure(SignalType signal, Sinks.EmitResult result) {
+            String message = String.format("Emission failure: key=%s signal=%s result=%s", key, signal, result);
+            if (signal != SignalType.ON_NEXT && result == Sinks.EmitResult.FAIL_CANCELLED) {
+                LOGGER.debug(message);
+            } else {
+                listener.onFatalEmissionFailure(new IllegalStateException(message));
+            }
+            return false;
+        }
+
+        private void elementCompletedProcessing() {
+            listener.onElementCompletedProcessing(this, IN_FLIGHT.decrementAndGet(this) == 0L);
+        }
+    }
+
+    private interface ProcessingGroupListener<K, T> {
+
+        void onFatalEmissionFailure(Throwable error);
+
+        void onElementCompletedProcessing(ProcessingGroup<K, T> group, boolean groupEmptied);
+    }
+}

--- a/base/core/src/main/java/io/atleon/core/AloGroupByWithAutoCompleteOperator.java
+++ b/base/core/src/main/java/io/atleon/core/AloGroupByWithAutoCompleteOperator.java
@@ -1,9 +1,9 @@
 package io.atleon.core;
 
-import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxOperator;
@@ -54,20 +54,16 @@ final class AloGroupByWithAutoCompleteOperator<K, T> extends FluxOperator<Alo<T>
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AloGroupByWithAutoCompleteOperator.class);
 
-    private final int maxInFlight;
+    private final Grouping<? super T, ? extends K> grouping;
 
-    private final Function<? super T, ? extends K> keyExtractor;
-
-    AloGroupByWithAutoCompleteOperator(
-            Flux<Alo<T>> source, int maxInFlight, Function<? super T, ? extends K> keyExtractor) {
+    AloGroupByWithAutoCompleteOperator(Flux<Alo<T>> source, Grouping<? super T, ? extends K> grouping) {
         super(source);
-        this.maxInFlight = maxInFlight;
-        this.keyExtractor = keyExtractor;
+        this.grouping = grouping;
     }
 
     @Override
     public void subscribe(CoreSubscriber<? super AloGroupedFlux<K, T>> actual) {
-        source.subscribe(new AloGroupByWithAutoCompleteSubscriber<>(maxInFlight, keyExtractor, actual));
+        source.subscribe(new AloGroupByWithAutoCompleteSubscriber<>(grouping, actual));
     }
 
     private static void runSafely(Runnable task, String name) {
@@ -100,9 +96,9 @@ final class AloGroupByWithAutoCompleteOperator<K, T> extends FluxOperator<Alo<T>
                 AtomicReferenceFieldUpdater.newUpdater(
                         AloGroupByWithAutoCompleteSubscriber.class, Throwable.class, "error");
 
-        private final int maxInFlight;
+        private final Grouping<? super T, ? extends K> grouping;
 
-        private final Function<? super T, ? extends K> keyExtractor;
+        private final int inFlightPrefetch;
 
         private final CoreSubscriber<? super AloGroupedFlux<K, T>> actual;
 
@@ -132,15 +128,13 @@ final class AloGroupByWithAutoCompleteOperator<K, T> extends FluxOperator<Alo<T>
         private volatile Throwable error;
 
         private AloGroupByWithAutoCompleteSubscriber(
-                int maxInFlight,
-                Function<? super T, ? extends K> keyExtractor,
-                CoreSubscriber<? super AloGroupedFlux<K, T>> actual) {
-            if (maxInFlight <= 0) {
-                throw new IllegalArgumentException("maxInFlight must be > 0");
-            }
-            this.maxInFlight = maxInFlight;
-            this.keyExtractor = keyExtractor;
+                Grouping<? super T, ? extends K> grouping, CoreSubscriber<? super AloGroupedFlux<K, T>> actual) {
+            this.grouping = grouping;
+            this.inFlightPrefetch = grouping.sourcePrefetch().orElse(Integer.MAX_VALUE);
             this.actual = actual;
+            if (inFlightPrefetch <= 0) {
+                throw new IllegalArgumentException("inFlightPrefetch must be > 0");
+            }
         }
 
         @Override
@@ -155,7 +149,7 @@ final class AloGroupByWithAutoCompleteOperator<K, T> extends FluxOperator<Alo<T>
             }
 
             parent = s;
-            FREE_IN_FLIGHT_CAPACITY.set(this, maxInFlight == Integer.MAX_VALUE ? Long.MAX_VALUE : maxInFlight);
+            freeInFlightCapacity = inFlightPrefetch == Integer.MAX_VALUE ? Long.MAX_VALUE : inFlightPrefetch;
             actual.onSubscribe(this);
         }
 
@@ -192,7 +186,7 @@ final class AloGroupByWithAutoCompleteOperator<K, T> extends FluxOperator<Alo<T>
 
         @Override
         public void onElementCompletedProcessing(ProcessingGroup<K, Alo<T>> group, boolean groupEmptied) {
-            long previousFreeInFlightCapacity = maxInFlight != Integer.MAX_VALUE
+            long previousFreeInFlightCapacity = inFlightPrefetch != Integer.MAX_VALUE
                     ? FREE_IN_FLIGHT_CAPACITY.getAndUpdate(this, it -> it >= 0 ? it + 1 : it)
                     : Long.MAX_VALUE;
             if (groupEmptied) {
@@ -245,19 +239,29 @@ final class AloGroupByWithAutoCompleteOperator<K, T> extends FluxOperator<Alo<T>
                     }
                     ProcessingGroup<K, Alo<T>> removed = processingGroups.remove(emptied.key());
                     if (removed != null) {
-                        runSafely(removed::complete, "group::complete");
+                        removed.completeSafely();
                     }
                 }
 
-                // Emit next Alos into corresponding groups, enqueuing new groups for emission
+                // Emit next Alos into corresponding groups, enqueuing new groups for emission, and
+                // completing any groups for which the latest element is configured to do so.
                 Alo<T> next;
                 while (mayContinueEmission() && (next = nextQueue.poll()) != null) {
                     try {
                         T t = next.get();
+                        K key = grouping.extractKey(t);
+                        ProcessingGroup<K, Alo<T>> group = processingGroups.computeIfAbsent(key, it -> {
+                            ProcessingGroup<K, Alo<T>> emittable = new ProcessingGroup<>(it, this);
+                            emittableGroups.add(emittable);
+                            return emittable;
+                        });
+
                         AloFactory<T> propagator = next.propagator();
-                        processingGroups
-                                .computeIfAbsent(keyExtractor.apply(t), this::enqueueEmittableGroup)
-                                .next(next.getAcknowledger(), next.getNacknowledger(), it -> newAlo(propagator, t, it));
+                        group.next(next.getAcknowledger(), next.getNacknowledger(), it -> newAlo(propagator, t, it));
+                        if (grouping.completesGroup(t)) {
+                            processingGroups.remove(key);
+                            group.completeSafely();
+                        }
                     } catch (Throwable publishingError) {
                         handleFatalPublishingFailure(publishingError);
                     }
@@ -275,7 +279,9 @@ final class AloGroupByWithAutoCompleteOperator<K, T> extends FluxOperator<Alo<T>
                         handleFatalPublishingFailure(publishingError);
                     }
                 }
-                Operators.produced(REQUEST_OUTSTANDING, this, emitted);
+                if (maxToEmit != Long.MAX_VALUE) {
+                    REQUEST_OUTSTANDING.addAndGet(this, -emitted);
+                }
 
                 // Propagate subscription signals to parent and/or emit termination signals if now
                 // is the time to do so.
@@ -287,7 +293,7 @@ final class AloGroupByWithAutoCompleteOperator<K, T> extends FluxOperator<Alo<T>
                     if (nvFreeInFlightCapacity == IN_FLIGHT_CAPACITY_DOWNSTREAM_CANCELED) {
                         FREE_IN_FLIGHT_CAPACITY.set(this, Long.MIN_VALUE);
                         runSafely(parent::cancel, "parent::cancel");
-                        terminateProcessingGroups(ProcessingGroup::complete, "complete");
+                        completeGroupsSafely();
                         return;
                     } else if (nvFreeInFlightCapacity == IN_FLIGHT_CAPACITY_PUBLISHING_ERROR) {
                         runSafely(parent::cancel, "parent::cancel");
@@ -296,12 +302,12 @@ final class AloGroupByWithAutoCompleteOperator<K, T> extends FluxOperator<Alo<T>
                     Throwable nvError = error;
                     if (nvError != null) {
                         FREE_IN_FLIGHT_CAPACITY.set(this, Long.MIN_VALUE);
-                        terminateProcessingGroups(ProcessingGroup::complete, "error");
-                        terminateActual(it -> it.onError(nvError), "error");
+                        completeGroupsSafely();
+                        runSafely(() -> actual.onError(error), "actual::onError");
                         return;
                     } else if (processingGroups.isEmpty()) {
                         FREE_IN_FLIGHT_CAPACITY.set(this, Long.MIN_VALUE);
-                        terminateActual(Subscriber::onComplete, "complete");
+                        runSafely(actual::onComplete, "actual::onComplete");
                         return;
                     }
                 }
@@ -310,18 +316,8 @@ final class AloGroupByWithAutoCompleteOperator<K, T> extends FluxOperator<Alo<T>
             } while (missed != 0);
         }
 
-        private ProcessingGroup<K, Alo<T>> enqueueEmittableGroup(K key) {
-            ProcessingGroup<K, Alo<T>> emittable = new ProcessingGroup<>(key, this);
-            emittableGroups.add(emittable);
-            return emittable;
-        }
-
-        private void terminateProcessingGroups(Consumer<ProcessingGroup<?, ?>> groupConsumer, String method) {
-            processingGroups.values().forEach(it -> runSafely(() -> groupConsumer.accept(it), "group::" + method));
-        }
-
-        private void terminateActual(Consumer<Subscriber<?>> actualConsumer, String method) {
-            runSafely(() -> actualConsumer.accept(actual), "actual::" + method);
+        private void completeGroupsSafely() {
+            processingGroups.values().forEach(ProcessingGroup::completeSafely);
         }
 
         private boolean mayContinueEmission() {
@@ -378,8 +374,8 @@ final class AloGroupByWithAutoCompleteOperator<K, T> extends FluxOperator<Alo<T>
             sink.emitNext(elementFactory.apply(acknowledgement), this::handleEmissionFailure);
         }
 
-        public void complete() {
-            sink.emitComplete(this::handleEmissionFailure);
+        public void completeSafely() {
+            runSafely(() -> sink.emitComplete(this::handleEmissionFailure), "group::complete");
         }
 
         public K key() {
@@ -396,8 +392,9 @@ final class AloGroupByWithAutoCompleteOperator<K, T> extends FluxOperator<Alo<T>
 
         private boolean handleEmissionFailure(SignalType signal, Sinks.EmitResult result) {
             String message = String.format("Emission failure: key=%s signal=%s result=%s", key, signal, result);
-            if (signal != SignalType.ON_NEXT && result == Sinks.EmitResult.FAIL_CANCELLED) {
-                LOGGER.debug(message);
+            if (result == Sinks.EmitResult.FAIL_CANCELLED) {
+                Level logLevel = signal == SignalType.ON_NEXT ? Level.INFO : Level.DEBUG;
+                LOGGER.atLevel(logLevel).log(message);
             } else {
                 listener.onFatalEmissionFailure(new IllegalStateException(message));
             }

--- a/base/core/src/main/java/io/atleon/core/AloGroupedFlux.java
+++ b/base/core/src/main/java/io/atleon/core/AloGroupedFlux.java
@@ -20,7 +20,7 @@ public class AloGroupedFlux<K, T> extends AloFlux<T> {
 
     private final K key;
 
-    private AloGroupedFlux(Flux<Alo<T>> flux, K key) {
+    AloGroupedFlux(Flux<Alo<T>> flux, K key) {
         super(flux);
         this.key = key;
     }

--- a/base/core/src/main/java/io/atleon/core/Grouping.java
+++ b/base/core/src/main/java/io/atleon/core/Grouping.java
@@ -1,0 +1,72 @@
+package io.atleon.core;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Specifies how to group elements from some source emitting elements of type T into groups keyed
+ * by type K.
+ *
+ * @param <T> The type of elements on which grouping is applied
+ * @param <K> The type of key indicating group membership
+ */
+interface Grouping<T, K> {
+
+    static <T, K> Grouping<T, K> simple(Function<? super T, ? extends K> keyExtractor) {
+        return new Composed<>(keyExtractor, __ -> false, null);
+    }
+
+    /**
+     * Extracts a group-identifying key for the provided element for emission.
+     */
+    K extractKey(T element);
+
+    /**
+     * Indicates whether the provided element should be the completing element for the group to
+     * which it belongs.
+     */
+    boolean completesGroup(T element);
+
+    /**
+     * Specifies the number of elements to request from the source for grouping. An empty value
+     * indicates usage of operator-specific default. A present value of Integer.MAX_VALUE indicates
+     * unbounded request.
+     */
+    Optional<Integer> sourcePrefetch();
+
+    final class Composed<T, K> implements Grouping<T, K> {
+
+        private final Function<? super T, ? extends K> keyExtractor;
+
+        private final Predicate<? super T> completesGroup;
+
+        private final @Nullable Integer sourcePrefetch;
+
+        private Composed(
+                Function<? super T, ? extends K> keyExtractor,
+                Predicate<? super T> completesGroup,
+                @Nullable Integer sourcePrefetch) {
+            this.keyExtractor = keyExtractor;
+            this.completesGroup = completesGroup;
+            this.sourcePrefetch = sourcePrefetch;
+        }
+
+        @Override
+        public K extractKey(T element) {
+            return keyExtractor.apply(element);
+        }
+
+        @Override
+        public boolean completesGroup(T element) {
+            return completesGroup.test(element);
+        }
+
+        @Override
+        public Optional<Integer> sourcePrefetch() {
+            return Optional.ofNullable(sourcePrefetch);
+        }
+    }
+}

--- a/base/core/src/test/java/io/atleon/core/AloGroupByWithAutoCompleteOperatorTest.java
+++ b/base/core/src/test/java/io/atleon/core/AloGroupByWithAutoCompleteOperatorTest.java
@@ -1,5 +1,6 @@
 package io.atleon.core;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
@@ -10,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -20,7 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -41,8 +43,9 @@ class AloGroupByWithAutoCompleteOperatorTest {
         AtomicReference<Throwable> zeroError = new AtomicReference<>();
         AtomicReference<Throwable> negativeError = new AtomicReference<>();
 
-        new AloGroupByWithAutoCompleteOperator<>(source, 0, Function.identity()).subscribe(group -> {}, zeroError::set);
-        new AloGroupByWithAutoCompleteOperator<>(source, -1, Function.identity())
+        new AloGroupByWithAutoCompleteOperator<>(source, new IdentityGrouping<>(0))
+                .subscribe(group -> {}, zeroError::set);
+        new AloGroupByWithAutoCompleteOperator<>(source, new IdentityGrouping<>(-1))
                 .subscribe(group -> {}, negativeError::set);
 
         assertNotNull(zeroError.get());
@@ -56,8 +59,7 @@ class AloGroupByWithAutoCompleteOperatorTest {
         Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
         List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
 
-        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
-                .subscribe(groups::add);
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), new IdentityGrouping<>()).subscribe(groups::add);
 
         source.tryEmitNext(new TestAlo("A"));
         source.tryEmitNext(new TestAlo("A"));
@@ -79,8 +81,7 @@ class AloGroupByWithAutoCompleteOperatorTest {
         Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
         List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
 
-        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
-                .subscribe(groups::add);
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), new IdentityGrouping<>()).subscribe(groups::add);
 
         source.tryEmitNext(new TestAlo("A"));
         source.tryEmitNext(new TestAlo("B"));
@@ -97,8 +98,7 @@ class AloGroupByWithAutoCompleteOperatorTest {
         Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
         List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
 
-        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
-                .subscribe(groups::add);
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), new IdentityGrouping<>()).subscribe(groups::add);
 
         TestAlo a = new TestAlo("A");
         source.tryEmitNext(a);
@@ -121,8 +121,7 @@ class AloGroupByWithAutoCompleteOperatorTest {
         Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
         List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
 
-        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
-                .subscribe(groups::add);
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), new IdentityGrouping<>()).subscribe(groups::add);
 
         TestAlo a = new TestAlo("A");
         source.tryEmitNext(a);
@@ -144,8 +143,7 @@ class AloGroupByWithAutoCompleteOperatorTest {
         Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
         List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
 
-        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
-                .subscribe(groups::add);
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), new IdentityGrouping<>()).subscribe(groups::add);
 
         source.tryEmitNext(new TestAlo("A"));
         source.tryEmitNext(new TestAlo("A"));
@@ -169,16 +167,15 @@ class AloGroupByWithAutoCompleteOperatorTest {
         List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
         List<List<String>> receivedPerGroup = new ArrayList<>();
 
-        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
-                .subscribe(group -> {
-                    groups.add(group);
-                    List<String> sink = new ArrayList<>();
-                    receivedPerGroup.add(sink);
-                    group.unwrap().subscribe(alo -> {
-                        sink.add(alo.get());
-                        Alo.acknowledge(alo);
-                    });
-                });
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), new IdentityGrouping<>()).subscribe(group -> {
+            groups.add(group);
+            List<String> sink = new ArrayList<>();
+            receivedPerGroup.add(sink);
+            group.unwrap().subscribe(alo -> {
+                sink.add(alo.get());
+                Alo.acknowledge(alo);
+            });
+        });
 
         source.tryEmitNext(new TestAlo("A"));
         source.tryEmitNext(new TestAlo("A"));
@@ -192,12 +189,118 @@ class AloGroupByWithAutoCompleteOperatorTest {
     }
 
     @Test
+    public void subscribe_givenCompletesGroupElement_expectsEagerGroupCompletion() {
+        Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
+        List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
+
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), new IdentityGrouping<>("DONE"::equals))
+                .subscribe(groups::add);
+
+        TestAlo done = new TestAlo("DONE");
+        source.tryEmitNext(done);
+
+        AtomicBoolean groupCompleted = new AtomicBoolean(false);
+        List<Alo<String>> received = new ArrayList<>();
+        groups.get(0).unwrap().doOnComplete(() -> groupCompleted.set(true)).subscribe(received::add);
+
+        assertEquals(1, received.size());
+        assertEquals("DONE", received.get(0).get());
+        assertTrue(groupCompleted.get(), "Group should complete eagerly when an element matches completesGroup");
+        assertFalse(done.isAcknowledged(), "Eager completion should not require acknowledgement");
+    }
+
+    @Test
+    public void subscribe_givenCompletesGroupElement_expectsAcknowledgementStillPropagates() {
+        Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
+        List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
+
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), new IdentityGrouping<>(__ -> true))
+                .subscribe(groups::add);
+
+        TestAlo a = new TestAlo("A");
+        source.tryEmitNext(a);
+
+        List<Alo<String>> received = new ArrayList<>();
+        groups.get(0).unwrap().subscribe(received::add);
+
+        Alo.acknowledge(received.get(0));
+
+        assertTrue(a.isAcknowledged(), "Acknowledgement should still flow upstream after eager group completion");
+    }
+
+    @Test
+    public void subscribe_givenCompletesGroupAmongstUnmarkedElements_expectsAllEmittedThenCompletion() {
+        Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
+        List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
+
+        Grouping<String, String> grouping = new Grouping<String, String>() {
+            @Override
+            public String extractKey(String element) {
+                return element.substring(0, 1);
+            }
+
+            @Override
+            public boolean completesGroup(String element) {
+                return element.endsWith("!");
+            }
+
+            @Override
+            public Optional<Integer> sourcePrefetch() {
+                return Optional.empty();
+            }
+        };
+
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), grouping).subscribe(groups::add);
+
+        source.tryEmitNext(new TestAlo("A1"));
+        source.tryEmitNext(new TestAlo("A2"));
+        source.tryEmitNext(new TestAlo("A!"));
+
+        assertEquals(1, groups.size(), "All emissions share key 'A' and should land in a single group");
+
+        AtomicBoolean groupCompleted = new AtomicBoolean(false);
+        List<String> received = new ArrayList<>();
+        groups.get(0).unwrap().doOnComplete(() -> groupCompleted.set(true)).subscribe(alo -> received.add(alo.get()));
+
+        assertEquals(Arrays.asList("A1", "A2", "A!"), received);
+        assertTrue(groupCompleted.get(), "Group should complete after a completesGroup element is emitted into it");
+    }
+
+    @Test
+    public void subscribe_givenSameKeyAfterCompletesGroup_expectsFreshGroupEmission() {
+        Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
+        List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
+        List<List<String>> receivedPerGroup = new ArrayList<>();
+        List<AtomicBoolean> groupCompletions = new ArrayList<>();
+
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), new IdentityGrouping<>(__ -> true))
+                .subscribe(group -> {
+                    groups.add(group);
+                    List<String> values = new ArrayList<>();
+                    AtomicBoolean completed = new AtomicBoolean(false);
+                    receivedPerGroup.add(values);
+                    groupCompletions.add(completed);
+                    group.unwrap().doOnComplete(() -> completed.set(true)).subscribe(alo -> values.add(alo.get()));
+                });
+
+        source.tryEmitNext(new TestAlo("A"));
+        source.tryEmitNext(new TestAlo("A"));
+
+        assertEquals(2, groups.size(), "Each emission should produce a fresh group after eager completion");
+        assertNotSame(groups.get(0), groups.get(1));
+        assertEquals(Arrays.asList("A"), receivedPerGroup.get(0));
+        assertEquals(Arrays.asList("A"), receivedPerGroup.get(1));
+        assertTrue(groupCompletions.get(0).get());
+        assertTrue(groupCompletions.get(1).get());
+    }
+
+    @Test
     public void subscribe_givenUpstreamCompletionAndAllElementsAcknowledged_expectsStreamCompletion() {
         TestAlo a = new TestAlo("A");
         List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
         AtomicBoolean completed = new AtomicBoolean(false);
 
-        new AloGroupByWithAutoCompleteOperator<String, String>(Flux.just(a), Integer.MAX_VALUE, Function.identity())
+        new AloGroupByWithAutoCompleteOperator<>(Flux.just(a), new IdentityGrouping<>())
                 .doOnComplete(() -> completed.set(true))
                 .subscribe(groups::add);
 
@@ -217,7 +320,7 @@ class AloGroupByWithAutoCompleteOperatorTest {
         List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
         AtomicReference<Throwable> downstreamError = new AtomicReference<>();
 
-        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), new IdentityGrouping<>())
                 .subscribe(groups::add, downstreamError::set);
 
         source.tryEmitNext(new TestAlo("A"));
@@ -244,9 +347,9 @@ class AloGroupByWithAutoCompleteOperatorTest {
         AtomicReference<Throwable> downstreamError = new AtomicReference<>();
         RuntimeException boom = new RuntimeException("Key extractor boom");
 
-        new AloGroupByWithAutoCompleteOperator<String, String>(source.asFlux(), Integer.MAX_VALUE, value -> {
+        new AloGroupByWithAutoCompleteOperator<String, String>(source.asFlux(), Grouping.simple(__ -> {
                     throw boom;
-                })
+                }))
                 .subscribe(group -> {}, downstreamError::set);
 
         source.tryEmitNext(new TestAlo("A"));
@@ -261,9 +364,8 @@ class AloGroupByWithAutoCompleteOperatorTest {
         Flux<Alo<String>> sourceFlux = source.asFlux().doOnCancel(() -> upstreamCanceled.set(true));
 
         List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
-        Disposable disposable = new AloGroupByWithAutoCompleteOperator<>(
-                        sourceFlux, Integer.MAX_VALUE, Function.identity())
-                .subscribe(groups::add);
+        Disposable disposable =
+                new AloGroupByWithAutoCompleteOperator<>(sourceFlux, new IdentityGrouping<>()).subscribe(groups::add);
 
         source.tryEmitNext(new TestAlo("A"));
 
@@ -283,7 +385,7 @@ class AloGroupByWithAutoCompleteOperatorTest {
         Flux<Alo<String>> sourceFlux = source.asFlux().doOnRequest(totalRequested::addAndGet);
 
         List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
-        new AloGroupByWithAutoCompleteOperator<>(sourceFlux, 2, Function.identity()).subscribe(groups::add);
+        new AloGroupByWithAutoCompleteOperator<>(sourceFlux, new IdentityGrouping<>(2)).subscribe(groups::add);
 
         assertEquals(2L, totalRequested.get(), "Initial request should be capped at maxInFlight");
 
@@ -310,8 +412,7 @@ class AloGroupByWithAutoCompleteOperatorTest {
         Map<String, List<String>> received = new ConcurrentHashMap<>();
         AtomicInteger consumed = new AtomicInteger(0);
 
-        new AloGroupByWithAutoCompleteOperator<String, String>(
-                        Flux.fromIterable(alos), Integer.MAX_VALUE, Function.identity())
+        new AloGroupByWithAutoCompleteOperator<String, String>(Flux.fromIterable(alos), new IdentityGrouping<>())
                 .flatMap(
                         group -> group.unwrap().publishOn(Schedulers.parallel()).doOnNext(alo -> {
                             received.computeIfAbsent(group.key(), k -> new CopyOnWriteArrayList<>())
@@ -338,13 +439,10 @@ class AloGroupByWithAutoCompleteOperatorTest {
             List<Alo<String>> received = new CopyOnWriteArrayList<>();
             AtomicInteger groupCompletions = new AtomicInteger(0);
 
-            new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
-                    .subscribe(group -> {
-                        groups.add(group);
-                        group.unwrap()
-                                .doOnComplete(groupCompletions::incrementAndGet)
-                                .subscribe(received::add);
-                    });
+            new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), new IdentityGrouping<>()).subscribe(group -> {
+                groups.add(group);
+                group.unwrap().doOnComplete(groupCompletions::incrementAndGet).subscribe(received::add);
+            });
 
             TestAlo first = new TestAlo("K");
             TestAlo second = new TestAlo("K");
@@ -400,6 +498,45 @@ class AloGroupByWithAutoCompleteOperatorTest {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
+        }
+    }
+
+    private static final class IdentityGrouping<T> implements Grouping<T, T> {
+
+        private final Predicate<T> completesGroup;
+
+        private final @Nullable Integer sourcePrefetch;
+
+        public IdentityGrouping() {
+            this(__ -> false, null);
+        }
+
+        public IdentityGrouping(int sourcePrefetch) {
+            this(__ -> false, sourcePrefetch);
+        }
+
+        public IdentityGrouping(Predicate<T> completesGroup) {
+            this(completesGroup, null);
+        }
+
+        public IdentityGrouping(Predicate<T> completesGroup, @Nullable Integer sourcePrefetch) {
+            this.completesGroup = completesGroup;
+            this.sourcePrefetch = sourcePrefetch;
+        }
+
+        @Override
+        public T extractKey(T element) {
+            return element;
+        }
+
+        @Override
+        public boolean completesGroup(T element) {
+            return completesGroup.test(element);
+        }
+
+        @Override
+        public Optional<Integer> sourcePrefetch() {
+            return Optional.ofNullable(sourcePrefetch);
         }
     }
 }

--- a/base/core/src/test/java/io/atleon/core/AloGroupByWithAutoCompleteOperatorTest.java
+++ b/base/core/src/test/java/io/atleon/core/AloGroupByWithAutoCompleteOperatorTest.java
@@ -1,0 +1,405 @@
+package io.atleon.core;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AloGroupByWithAutoCompleteOperatorTest {
+
+    @Test
+    public void subscribe_givenInvalidMaxInFlight_expectsSubscriberError() {
+        Flux<Alo<String>> source = Flux.empty();
+        AtomicReference<Throwable> zeroError = new AtomicReference<>();
+        AtomicReference<Throwable> negativeError = new AtomicReference<>();
+
+        new AloGroupByWithAutoCompleteOperator<>(source, 0, Function.identity()).subscribe(group -> {}, zeroError::set);
+        new AloGroupByWithAutoCompleteOperator<>(source, -1, Function.identity())
+                .subscribe(group -> {}, negativeError::set);
+
+        assertNotNull(zeroError.get());
+        assertInstanceOf(IllegalArgumentException.class, zeroError.get());
+        assertNotNull(negativeError.get());
+        assertInstanceOf(IllegalArgumentException.class, negativeError.get());
+    }
+
+    @Test
+    public void subscribe_givenElementsWithSameKey_expectsEmissionInSingleGroup() {
+        Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
+        List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
+
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
+                .subscribe(groups::add);
+
+        source.tryEmitNext(new TestAlo("A"));
+        source.tryEmitNext(new TestAlo("A"));
+
+        assertEquals(1, groups.size());
+        assertEquals("A", groups.get(0).key());
+
+        List<String> values = new ArrayList<>();
+        groups.get(0).subscribe(alo -> {
+            values.add(alo.get());
+            Alo.acknowledge(alo);
+        });
+
+        assertEquals(Arrays.asList("A", "A"), values);
+    }
+
+    @Test
+    public void subscribe_givenElementsWithDifferentKeys_expectsEmissionInSeparateGroups() {
+        Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
+        List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
+
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
+                .subscribe(groups::add);
+
+        source.tryEmitNext(new TestAlo("A"));
+        source.tryEmitNext(new TestAlo("B"));
+        source.tryEmitNext(new TestAlo("C"));
+
+        assertEquals(3, groups.size());
+        assertEquals(
+                Arrays.asList("A", "B", "C"),
+                groups.stream().map(AloGroupedFlux::key).collect(Collectors.toList()));
+    }
+
+    @Test
+    public void subscribe_givenAllGroupElementsAcknowledged_expectsGroupAutoCompletion() {
+        Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
+        List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
+
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
+                .subscribe(groups::add);
+
+        TestAlo a = new TestAlo("A");
+        source.tryEmitNext(a);
+
+        AtomicBoolean groupCompleted = new AtomicBoolean(false);
+        List<Alo<String>> received = new ArrayList<>();
+        groups.get(0).unwrap().doOnComplete(() -> groupCompleted.set(true)).subscribe(received::add);
+
+        assertFalse(groupCompleted.get());
+        assertFalse(a.isAcknowledged());
+
+        Alo.acknowledge(received.get(0));
+
+        assertTrue(a.isAcknowledged());
+        assertTrue(groupCompleted.get());
+    }
+
+    @Test
+    public void subscribe_givenAllGroupElementsNacknowledged_expectsGroupAutoCompletion() {
+        Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
+        List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
+
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
+                .subscribe(groups::add);
+
+        TestAlo a = new TestAlo("A");
+        source.tryEmitNext(a);
+
+        AtomicBoolean groupCompleted = new AtomicBoolean(false);
+        List<Alo<String>> received = new ArrayList<>();
+        groups.get(0).unwrap().doOnComplete(() -> groupCompleted.set(true)).subscribe(received::add);
+
+        RuntimeException boom = new RuntimeException("Boom");
+        Alo.nacknowledge(received.get(0), boom);
+
+        assertTrue(a.isNacknowledged());
+        assertSame(boom, a.getError().orElse(null));
+        assertTrue(groupCompleted.get(), "Group should still complete normally on nack");
+    }
+
+    @Test
+    public void subscribe_givenSiblingElementInFlight_expectsGroupRemainsOpen() {
+        Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
+        List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
+
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
+                .subscribe(groups::add);
+
+        source.tryEmitNext(new TestAlo("A"));
+        source.tryEmitNext(new TestAlo("A"));
+
+        AtomicBoolean groupCompleted = new AtomicBoolean(false);
+        List<Alo<String>> received = new ArrayList<>();
+        groups.get(0).unwrap().doOnComplete(() -> groupCompleted.set(true)).subscribe(received::add);
+
+        assertEquals(2, received.size());
+
+        Alo.acknowledge(received.get(0));
+        assertFalse(groupCompleted.get(), "Group should not auto-complete while a sibling element is in flight");
+
+        Alo.acknowledge(received.get(1));
+        assertTrue(groupCompleted.get());
+    }
+
+    @Test
+    public void subscribe_givenKeySeenAgainAfterAutoCompletion_expectsFreshGroupEmission() {
+        Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
+        List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
+        List<List<String>> receivedPerGroup = new ArrayList<>();
+
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
+                .subscribe(group -> {
+                    groups.add(group);
+                    List<String> sink = new ArrayList<>();
+                    receivedPerGroup.add(sink);
+                    group.unwrap().subscribe(alo -> {
+                        sink.add(alo.get());
+                        Alo.acknowledge(alo);
+                    });
+                });
+
+        source.tryEmitNext(new TestAlo("A"));
+        source.tryEmitNext(new TestAlo("A"));
+
+        assertEquals(2, groups.size(), "Each emission should produce a fresh group after auto-complete");
+        assertNotSame(groups.get(0), groups.get(1));
+        assertEquals("A", groups.get(0).key());
+        assertEquals("A", groups.get(1).key());
+        assertEquals(Arrays.asList("A"), receivedPerGroup.get(0));
+        assertEquals(Arrays.asList("A"), receivedPerGroup.get(1));
+    }
+
+    @Test
+    public void subscribe_givenUpstreamCompletionAndAllElementsAcknowledged_expectsStreamCompletion() {
+        TestAlo a = new TestAlo("A");
+        List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
+        AtomicBoolean completed = new AtomicBoolean(false);
+
+        new AloGroupByWithAutoCompleteOperator<String, String>(Flux.just(a), Integer.MAX_VALUE, Function.identity())
+                .doOnComplete(() -> completed.set(true))
+                .subscribe(groups::add);
+
+        assertFalse(completed.get(), "Should not complete while an element is in flight");
+
+        List<Alo<String>> received = new ArrayList<>();
+        groups.get(0).unwrap().subscribe(received::add);
+        Alo.acknowledge(received.get(0));
+
+        assertTrue(completed.get());
+        assertTrue(a.isAcknowledged());
+    }
+
+    @Test
+    public void subscribe_givenUpstreamError_expectsErrorPropagationAndActiveGroupCompletion() {
+        Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
+        List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
+        AtomicReference<Throwable> downstreamError = new AtomicReference<>();
+
+        new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
+                .subscribe(groups::add, downstreamError::set);
+
+        source.tryEmitNext(new TestAlo("A"));
+
+        AtomicBoolean groupCompleted = new AtomicBoolean(false);
+        AtomicReference<Throwable> groupError = new AtomicReference<>();
+        groups.get(0)
+                .unwrap()
+                .doOnComplete(() -> groupCompleted.set(true))
+                .doOnError(groupError::set)
+                .subscribe(alo -> {}, e -> {});
+
+        RuntimeException boom = new RuntimeException("Boom");
+        source.tryEmitError(boom);
+
+        assertSame(boom, downstreamError.get(), "Downstream group-emission should receive the upstream error");
+        assertTrue(groupCompleted.get(), "Active groups should be completed (not errored) on upstream error");
+        assertNull(groupError.get());
+    }
+
+    @Test
+    public void subscribe_givenKeyExtractorFailure_expectsStreamErrorTermination() {
+        Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
+        AtomicReference<Throwable> downstreamError = new AtomicReference<>();
+        RuntimeException boom = new RuntimeException("Key extractor boom");
+
+        new AloGroupByWithAutoCompleteOperator<String, String>(source.asFlux(), Integer.MAX_VALUE, value -> {
+                    throw boom;
+                })
+                .subscribe(group -> {}, downstreamError::set);
+
+        source.tryEmitNext(new TestAlo("A"));
+
+        assertSame(boom, downstreamError.get());
+    }
+
+    @Test
+    public void subscribe_givenDownstreamCancellation_expectsUpstreamCancellationAndGroupCompletion() {
+        AtomicBoolean upstreamCanceled = new AtomicBoolean(false);
+        Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
+        Flux<Alo<String>> sourceFlux = source.asFlux().doOnCancel(() -> upstreamCanceled.set(true));
+
+        List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
+        Disposable disposable = new AloGroupByWithAutoCompleteOperator<>(
+                        sourceFlux, Integer.MAX_VALUE, Function.identity())
+                .subscribe(groups::add);
+
+        source.tryEmitNext(new TestAlo("A"));
+
+        AtomicBoolean groupCompleted = new AtomicBoolean(false);
+        groups.get(0).unwrap().doOnComplete(() -> groupCompleted.set(true)).subscribe(alo -> {});
+
+        disposable.dispose();
+
+        assertTrue(upstreamCanceled.get());
+        assertTrue(groupCompleted.get());
+    }
+
+    @Test
+    public void subscribe_givenBoundedMaxInFlight_expectsUpstreamRequestsCappedAndReplenishedOnAcknowledgement() {
+        AtomicLong totalRequested = new AtomicLong(0);
+        Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
+        Flux<Alo<String>> sourceFlux = source.asFlux().doOnRequest(totalRequested::addAndGet);
+
+        List<AloGroupedFlux<String, String>> groups = new ArrayList<>();
+        new AloGroupByWithAutoCompleteOperator<>(sourceFlux, 2, Function.identity()).subscribe(groups::add);
+
+        assertEquals(2L, totalRequested.get(), "Initial request should be capped at maxInFlight");
+
+        source.tryEmitNext(new TestAlo("A"));
+        assertEquals(2L, totalRequested.get(), "Emitting in-flight element should not increase request count");
+
+        List<Alo<String>> received = new ArrayList<>();
+        groups.get(0).unwrap().subscribe(received::add);
+        Alo.acknowledge(received.get(0));
+
+        assertEquals(3L, totalRequested.get(), "Acknowledgement should free one in-flight slot and request one more");
+    }
+
+    @Test
+    public void subscribe_givenConcurrentAcknowledgementAcrossKeys_expectsNoLostElementsAndStreamCompletion()
+            throws Exception {
+        int numElements = 500;
+        int numKeys = 8;
+
+        List<TestAlo> alos = IntStream.range(0, numElements)
+                .mapToObj(i -> new TestAlo("K" + (i % numKeys)))
+                .collect(Collectors.toList());
+
+        Map<String, List<String>> received = new ConcurrentHashMap<>();
+        AtomicInteger consumed = new AtomicInteger(0);
+
+        new AloGroupByWithAutoCompleteOperator<String, String>(
+                        Flux.fromIterable(alos), Integer.MAX_VALUE, Function.identity())
+                .flatMap(
+                        group -> group.unwrap().publishOn(Schedulers.parallel()).doOnNext(alo -> {
+                            received.computeIfAbsent(group.key(), k -> new CopyOnWriteArrayList<>())
+                                    .add(alo.get());
+                            consumed.incrementAndGet();
+                            Alo.acknowledge(alo);
+                        }))
+                .blockLast();
+
+        assertEquals(numElements, consumed.get());
+        assertEquals(numElements, alos.stream().filter(TestAlo::isAcknowledged).count());
+        assertEquals(numKeys, received.size());
+        int totalReceived = received.values().stream().mapToInt(List::size).sum();
+        assertEquals(numElements, totalReceived);
+    }
+
+    @Test
+    public void subscribe_givenConcurrentAckAndEmissionForSameKey_expectsExactlyOneCompletionPerEmittedGroup()
+            throws Exception {
+        int iterations = 200;
+        for (int i = 0; i < iterations; i++) {
+            Sinks.Many<Alo<String>> source = Sinks.many().unicast().onBackpressureBuffer();
+            List<AloGroupedFlux<String, String>> groups = new CopyOnWriteArrayList<>();
+            List<Alo<String>> received = new CopyOnWriteArrayList<>();
+            AtomicInteger groupCompletions = new AtomicInteger(0);
+
+            new AloGroupByWithAutoCompleteOperator<>(source.asFlux(), Integer.MAX_VALUE, Function.identity())
+                    .subscribe(group -> {
+                        groups.add(group);
+                        group.unwrap()
+                                .doOnComplete(groupCompletions::incrementAndGet)
+                                .subscribe(received::add);
+                    });
+
+            TestAlo first = new TestAlo("K");
+            TestAlo second = new TestAlo("K");
+            source.tryEmitNext(first);
+            assertEquals(1, received.size());
+
+            ExecutorService pool = Executors.newFixedThreadPool(2);
+            try {
+                CountDownLatch ready = new CountDownLatch(2);
+                CountDownLatch go = new CountDownLatch(1);
+                pool.submit(() -> {
+                    ready.countDown();
+                    awaitUninterruptibly(go);
+                    Alo.acknowledge(received.get(0));
+                });
+                pool.submit(() -> {
+                    ready.countDown();
+                    awaitUninterruptibly(go);
+                    source.tryEmitNext(second);
+                });
+                ready.await();
+                go.countDown();
+                pool.shutdown();
+                assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS));
+
+                // Always: both elements acknowledged eventually, both received, group count >= 1
+                assertTrue(first.isAcknowledged());
+                // Drain remaining: ack the second
+                Alo<String> remaining = received.size() > 1 ? received.get(1) : null;
+                if (remaining != null) {
+                    Alo.acknowledge(remaining);
+                }
+                assertTrue(second.isAcknowledged(), "Second element must be processed even under race");
+                assertEquals(2, received.size(), "Both emitted elements must reach a subscriber");
+
+                // Either 1 group (no auto-complete in between) or 2 groups (auto-complete fired before second emit)
+                assertTrue(
+                        groups.size() == 1 || groups.size() == 2,
+                        "Iteration " + i + ": unexpected group count " + groups.size());
+                assertEquals(
+                        groups.size(),
+                        groupCompletions.get(),
+                        "Iteration " + i + ": each emitted group must have completed exactly once");
+            } finally {
+                pool.shutdownNow();
+            }
+        }
+    }
+
+    private static void awaitUninterruptibly(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
### :pencil: Description
- Enable arbitrary per-key concurrency on Alo-based stream processes
- Leverage acknowledgement signals to realize automatic "processing group" cleanup

### :link: Related Issues
#539 
