### PR TITLE
[#544] Make offset commitment calculation lazy

### DIFF
--- a/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaArbitraryParallelism.java
+++ b/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaArbitraryParallelism.java
@@ -85,8 +85,7 @@ public class KafkaArbitraryParallelism {
         AloKafkaSender<String, String> sender = AloKafkaSender.create(kafkaSenderConfig);
         Flux.range(0, NUM_SAMPLES)
                 .subscribeOn(Schedulers.boundedElastic())
-                .map(i -> UUID.randomUUID())
-                .map(UUID::toString)
+                .map(__ -> UUID.randomUUID().toString())
                 .transform(sender.sendValues(TOPIC, Function.identity()))
                 .doFinally(__ -> sender.close())
                 .subscribe();

--- a/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaPerKeyParallelism.java
+++ b/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaPerKeyParallelism.java
@@ -85,8 +85,7 @@ public class KafkaPerKeyParallelism {
         AloKafkaSender<String, String> sender = AloKafkaSender.create(kafkaSenderConfig);
         Flux.range(0, NUM_SAMPLES)
                 .subscribeOn(Schedulers.boundedElastic())
-                .map(i -> UUID.randomUUID())
-                .map(UUID::toString)
+                .map(__ -> UUID.randomUUID().toString())
                 .transform(sender.sendValues(TOPIC, Function.identity()))
                 .doFinally(__ -> sender.close())
                 .subscribe();

--- a/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaTopicPartitionParallelism.java
+++ b/examples/core/src/main/java/io/atleon/examples/parallelism/KafkaTopicPartitionParallelism.java
@@ -80,8 +80,7 @@ public class KafkaTopicPartitionParallelism {
         AloKafkaSender<String, String> sender = AloKafkaSender.create(kafkaSenderConfig);
         Flux.range(0, NUM_SAMPLES)
                 .subscribeOn(Schedulers.boundedElastic())
-                .map(i -> UUID.randomUUID())
-                .map(UUID::toString)
+                .map(__ -> UUID.randomUUID().toString())
                 .transform(sender.sendValues(TOPIC, Function.identity()))
                 .doFinally(__ -> sender.close())
                 .subscribe();

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/AcknowledgedOffset.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/AcknowledgedOffset.java
@@ -3,52 +3,44 @@ package io.atleon.kafka;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 
-import java.util.Objects;
+import java.util.function.LongFunction;
 
 /**
- * An offset for a {@link org.apache.kafka.clients.consumer.ConsumerRecord} from a particular
- * {@link TopicPartition} that has been acknowledged, and contains an {@link OffsetAndMetadata}
- * which may be committed, and is the offset <i>just after</i> the record for which this
- * acknowledgement is associated.
+ * A {@link ConsumerOffset} that has been acknowledged and is eligible to be used as a basis for
+ * commitment. Note that the contained offset itself is <i>not</i> what is committed, but rather
+ * the actual offset to commit is the numerical increment of that offset, along with (lazily
+ * evaluated) metadata.
  */
 final class AcknowledgedOffset {
 
-    private final TopicPartition topicPartition;
+    private final ConsumerOffset consumerOffset;
 
-    private final OffsetAndMetadata nextOffsetAndMetadata;
+    private final LongFunction<String> offsetCommitmentMetadataFactory;
 
-    public AcknowledgedOffset(TopicPartition topicPartition, OffsetAndMetadata nextOffsetAndMetadata) {
-        this.topicPartition = topicPartition;
-        this.nextOffsetAndMetadata = nextOffsetAndMetadata;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        AcknowledgedOffset that = (AcknowledgedOffset) o;
-        return Objects.equals(topicPartition, that.topicPartition)
-                && Objects.equals(nextOffsetAndMetadata, that.nextOffsetAndMetadata);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(topicPartition, nextOffsetAndMetadata);
-    }
-
-    @Override
-    public String toString() {
-        return "AcknowledgedOffset{" + "topicPartition="
-                + topicPartition + ", nextOffsetAndMetadata="
-                + nextOffsetAndMetadata + '}';
+    public AcknowledgedOffset(ConsumerOffset consumerOffset, LongFunction<String> offsetCommitmentMetadataFactory) {
+        this.consumerOffset = consumerOffset;
+        this.offsetCommitmentMetadataFactory = offsetCommitmentMetadataFactory;
     }
 
     public TopicPartition topicPartition() {
-        return topicPartition;
+        return consumerOffset.topicPartition();
     }
 
-    public OffsetAndMetadata nextOffsetAndMetadata() {
-        return nextOffsetAndMetadata;
+    public ConsumerOffset consumerOffset() {
+        return consumerOffset;
+    }
+
+    public OffsetAndMetadata nextOffset() {
+        return nextOffsetAndMetadata(__ -> "");
+    }
+
+    public OffsetAndMetadata commitOffset() {
+        return nextOffsetAndMetadata(offsetCommitmentMetadataFactory);
+    }
+
+    private OffsetAndMetadata nextOffsetAndMetadata(LongFunction<String> nextOffsetMetadataFactory) {
+        long nextOffset = consumerOffset.offset() + 1;
+        String metadata = nextOffsetMetadataFactory.apply(nextOffset);
+        return new OffsetAndMetadata(nextOffset, consumerOffset.leaderEpoch(), metadata);
     }
 }

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
@@ -3,7 +3,6 @@ package io.atleon.kafka;
 import io.atleon.core.AcknowledgementQueue;
 import io.atleon.core.AcknowledgementQueueMode;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -42,7 +41,7 @@ final class ActivePartition {
 
     private final AtomicInteger deactivationDrainsInProgress = new AtomicInteger();
 
-    private final Sinks.Many<OffsetAndMetadata> nextOffsetsOfAcknowledged =
+    private final Sinks.Many<ConsumerOffset> consumerOffsetsOfAcknowledged =
             Sinks.unsafe().many().replay().latest();
 
     private final Sinks.Many<Long> deactivatedRecordCounts =
@@ -58,7 +57,7 @@ final class ActivePartition {
      * This will only return a non-empty result if this partition has not yet been deactivated.
      */
     public <K, V> Optional<KafkaReceiverRecord<K, V>> activateForProcessing(ConsumerRecord<K, V> consumerRecord) {
-        return activate(new OffsetAndMetadata(consumerRecord.offset() + 1, consumerRecord.leaderEpoch(), ""))
+        return activate(new ConsumerOffset(topicPartition, consumerRecord.offset(), consumerRecord.leaderEpoch()))
                 .map(it -> KafkaReceiverRecord.create(consumerRecord, () -> ack(it), error -> nack(it, error)));
     }
 
@@ -88,7 +87,7 @@ final class ActivePartition {
             return deactivateForcefully()
                     .flatMap(it -> it > 0 ? Mono.error(new GracelessTimeoutException()) : Mono.empty());
         } else {
-            Mono<T> acknowledgementCompletion = nextOffsetsOfAcknowledged
+            Mono<T> acknowledgementCompletion = consumerOffsetsOfAcknowledged
                     .asFlux()
                     .onErrorComplete()
                     .then(Mono.<T>empty())
@@ -107,7 +106,7 @@ final class ActivePartition {
             // ensure termination of next offset emission, which may be a no-op if any in-flight
             // records have been negatively acknowledged.
             long previousActivated = activated.getAndSet(0);
-            nextOffsetsOfAcknowledged.tryEmitComplete();
+            consumerOffsetsOfAcknowledged.tryEmitComplete();
 
             // Finally, calculate the number of deactivated records based on the previous count
             // which, if positive, means this partition had not yet been deactivated, so we need
@@ -123,7 +122,7 @@ final class ActivePartition {
      * Returns a publisher of offsets that have been acknowledged and may be directly committed.
      */
     public Flux<AcknowledgedOffset> acknowledgedOffsets() {
-        return nextOffsetsOfAcknowledged.asFlux().map(it -> new AcknowledgedOffset(topicPartition, it));
+        return consumerOffsetsOfAcknowledged.asFlux().map(it -> new AcknowledgedOffset(it, __ -> ""));
     }
 
     public Flux<Long> deactivatedRecordCounts() {
@@ -134,14 +133,14 @@ final class ActivePartition {
         return topicPartition;
     }
 
-    private Optional<AcknowledgementQueue.InFlight> activate(OffsetAndMetadata nextOffset) {
+    private Optional<AcknowledgementQueue.InFlight> activate(ConsumerOffset consumerOffset) {
         // If registration is successful (neither has a possible deactivation not finished, nor has
         // processing been forcibly deactivated), allow processing attempt. Else do not return
         // anything for acknowledgement, which prevents emission for processing.
         if (activated.getAndUpdate(it -> it > 0 ? it + 1 : it) > 0) {
-            Runnable acknowledger = () -> nextOffsetsOfAcknowledged.tryEmitNext(nextOffset);
+            Runnable acknowledger = () -> consumerOffsetsOfAcknowledged.tryEmitNext(consumerOffset);
             Consumer<Throwable> nacknowledger = error -> {
-                nextOffsetsOfAcknowledged.tryEmitError(error);
+                consumerOffsetsOfAcknowledged.tryEmitError(error);
                 deactivateForcefully().subscribe();
             };
             return Optional.of(acknowledgementQueue.add(acknowledger, nacknowledger));
@@ -180,7 +179,7 @@ final class ActivePartition {
             // we should emit termination by checking the polarity of the previous count and
             // whether the sum of completed records and the previous count cancel out.
             if (previousActivated < 0 && completedRecords + previousActivated == 0) {
-                nextOffsetsOfAcknowledged.tryEmitComplete();
+                consumerOffsetsOfAcknowledged.tryEmitComplete();
             }
             return completedRecords;
         });
@@ -192,7 +191,7 @@ final class ActivePartition {
                 // This deactivation is eligible to trigger termination, so attempt to do so,
                 // knowing that this could be a no-op if any in-flight records have been negatively
                 // acknowledged.
-                nextOffsetsOfAcknowledged.tryEmitComplete();
+                consumerOffsetsOfAcknowledged.tryEmitComplete();
             }
             sink.success();
             return 0L;

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/AsyncOffsetCommitter.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/AsyncOffsetCommitter.java
@@ -69,7 +69,7 @@ final class AsyncOffsetCommitter {
         return committableOffsets
                 .asFlux()
                 .windowTimeout(batchSize, period, scheduler)
-                .concatMap(it -> it.collectMap(CommittableOffset::topicPartition, CommittableOffset::sequencedOffset))
+                .concatMap(it -> it.collectMap(CommittableOffset::topicPartition))
                 .subscribe(this::scheduleCommit, errorEmitter);
     }
 
@@ -107,21 +107,21 @@ final class AsyncOffsetCommitter {
         return calculateRemainingCommitAttempts(partition) <= 0;
     }
 
-    private void scheduleCommit(Map<TopicPartition, SequencedOffset> assignedOffsets) {
+    private void scheduleCommit(Map<TopicPartition, CommittableOffset> committableOffsets) {
         // Calculate commit sequence numbers eagerly such that invalidation may happen quickly in
         // the case that commits are being rapidly scheduled.
-        Map<TopicPartition, Long> commitSequences = assignedOffsets.keySet().stream()
+        Map<TopicPartition, Long> commitSequences = committableOffsets.keySet().stream()
                 .collect(Collectors.toMap(Function.identity(), this::incrementAndGetCommit));
         consumerTaskScheduler.schedule(consumer -> {
             // Only need to check assignment sequence number on initial commit attempt, because we
             // are now executing on the polling thread, and therefore any assignment changes are
             // guaranteed to visibly increase associated commit sequence counter(s), so we can rely
             // on that for invalidation (i.e. on retries).
-            Map<TopicPartition, OffsetAndMetadata> validatedOffsets = assignedOffsets.entrySet().stream()
+            Map<TopicPartition, OffsetAndMetadata> validatedOffsets = committableOffsets.entrySet().stream()
                     .filter(it -> it.getValue().sequence() == getAssignment(it.getKey()))
                     .filter(it -> commitSequences.get(it.getKey()) == getCommit(it.getKey()))
                     .collect(Collectors.toMap(
-                            Map.Entry::getKey, it -> it.getValue().offsetAndMetadata()));
+                            Map.Entry::getKey, it -> it.getValue().commitOffset()));
             commit(consumer, validatedOffsets, commitSequences);
         });
     }
@@ -201,40 +201,21 @@ final class AsyncOffsetCommitter {
 
     private static final class CommittableOffset {
 
-        private final TopicPartition topicPartition;
-
-        private final OffsetAndMetadata offsetAndMetadata;
+        private final AcknowledgedOffset acknowledgedOffset;
 
         private final long sequence;
 
         public CommittableOffset(AcknowledgedOffset acknowledgedOffset, long sequence) {
-            this.topicPartition = acknowledgedOffset.topicPartition();
-            this.offsetAndMetadata = acknowledgedOffset.nextOffsetAndMetadata();
+            this.acknowledgedOffset = acknowledgedOffset;
             this.sequence = sequence;
         }
 
         public TopicPartition topicPartition() {
-            return topicPartition;
+            return acknowledgedOffset.topicPartition();
         }
 
-        public SequencedOffset sequencedOffset() {
-            return new SequencedOffset(offsetAndMetadata, sequence);
-        }
-    }
-
-    private static final class SequencedOffset {
-
-        private final OffsetAndMetadata offsetAndMetadata;
-
-        private final long sequence;
-
-        public SequencedOffset(OffsetAndMetadata offsetAndMetadata, long sequence) {
-            this.offsetAndMetadata = offsetAndMetadata;
-            this.sequence = sequence;
-        }
-
-        public OffsetAndMetadata offsetAndMetadata() {
-            return offsetAndMetadata;
+        public OffsetAndMetadata commitOffset() {
+            return acknowledgedOffset.commitOffset();
         }
 
         public long sequence() {

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/ConsumerOffset.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/ConsumerOffset.java
@@ -1,0 +1,61 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Hydrated descriptor of an offset associated with a consumed (or consumable)
+ * {@link org.apache.kafka.clients.consumer.ConsumerRecord}. This includes the originating
+ * {@link TopicPartition}, record offset, and epoch of the partition leader.
+ */
+final class ConsumerOffset {
+
+    private final TopicPartition topicPartition;
+
+    private final long offset;
+
+    private final Optional<Integer> leaderEpoch;
+
+    public ConsumerOffset(TopicPartition topicPartition, long offset, Optional<Integer> leaderEpoch) {
+        this.topicPartition = topicPartition;
+        this.offset = offset;
+        this.leaderEpoch = leaderEpoch;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConsumerOffset that = (ConsumerOffset) o;
+        return offset == that.offset
+                && Objects.equals(topicPartition, that.topicPartition)
+                && Objects.equals(leaderEpoch, that.leaderEpoch);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(topicPartition, offset, leaderEpoch);
+    }
+
+    @Override
+    public String toString() {
+        return "ConsumerOffset{topicPartition=" + topicPartition + ", offset="
+                + offset + ", leaderEpoch="
+                + leaderEpoch + '}';
+    }
+
+    public TopicPartition topicPartition() {
+        return topicPartition;
+    }
+
+    public long offset() {
+        return offset;
+    }
+
+    public Optional<Integer> leaderEpoch() {
+        return leaderEpoch;
+    }
+}

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
@@ -383,7 +383,7 @@ final class PollingSubscriptionFactory<K, V> {
                     .map(it -> it.deactivateLatest(gracePeriod, auxiliaryScheduler, termination.asMono()))
                     .collect(Collectors.collectingAndThen(Collectors.toList(), Publishing::mergeGreedily))
                     .filter(it -> !asyncOffsetCommitter.isCommitTrialExhausted(it.topicPartition()))
-                    .collectMap(AcknowledgedOffset::topicPartition, AcknowledgedOffset::nextOffsetAndMetadata)
+                    .collectMap(AcknowledgedOffset::topicPartition, AcknowledgedOffset::commitOffset)
                     .block();
 
             try {
@@ -472,8 +472,7 @@ final class PollingSubscriptionFactory<K, V> {
             this.transactionalOffsetsSend = acknowledgedOffsets
                     .asFlux()
                     .windowWhen(offsetsState(TxOffsetsState.PROCESSING), __ -> offsetsState(TxOffsetsState.COMMITTING))
-                    .concatMap(it -> it.collectMap(
-                            AcknowledgedOffset::topicPartition, AcknowledgedOffset::nextOffsetAndMetadata))
+                    .concatMap(it -> it.collectMap(AcknowledgedOffset::topicPartition, AcknowledgedOffset::nextOffset))
                     .subscribe(this::maybeSendOffsetsInCurrentTransaction, this::failSafely);
         }
 

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
@@ -84,7 +84,7 @@ class ActivePartitionTest {
         assertEquals(TOPIC_PARTITION, acknowledgedOffsets.get(0).topicPartition());
         assertEquals(
                 consumerRecord.offset() + 1,
-                acknowledgedOffsets.get(0).nextOffsetAndMetadata().offset());
+                acknowledgedOffsets.get(0).nextOffset().offset());
         assertEquals(Collections.singletonList(1L), deactivatedRecordCounts);
     }
 
@@ -114,13 +114,13 @@ class ActivePartitionTest {
         assertEquals(TOPIC_PARTITION, acknowledgedOffsets.get(2).topicPartition());
         assertEquals(
                 receiverRecord1.consumerRecord().offset() + 1,
-                acknowledgedOffsets.get(0).nextOffsetAndMetadata().offset());
+                acknowledgedOffsets.get(0).nextOffset().offset());
         assertEquals(
                 receiverRecord2.consumerRecord().offset() + 1,
-                acknowledgedOffsets.get(1).nextOffsetAndMetadata().offset());
+                acknowledgedOffsets.get(1).nextOffset().offset());
         assertEquals(
                 receiverRecord3.consumerRecord().offset() + 1,
-                acknowledgedOffsets.get(2).nextOffsetAndMetadata().offset());
+                acknowledgedOffsets.get(2).nextOffset().offset());
         assertEquals(Arrays.asList(1L, 2L), deactivatedRecordCounts);
     }
 
@@ -187,7 +187,7 @@ class ActivePartitionTest {
         assertEquals(1, acknowledgedOffsets.size());
         assertEquals(
                 receiverRecord1.consumerRecord().offset() + 1,
-                acknowledgedOffsets.get(0).nextOffsetAndMetadata().offset());
+                acknowledgedOffsets.get(0).nextOffset().offset());
         assertInstanceOf(IllegalStateException.class, acknowledgedOffsetsError.get());
         assertEquals(Arrays.asList(1L, 3L), deactivatedRecordCounts);
         assertNull(deactivatedRecordCountsError.get());
@@ -196,7 +196,7 @@ class ActivePartitionTest {
 
     @Test
     public void deactivateLatest_givenNoInFlightRecords_expectsTerminationWithLastAcknowledgedOffset() {
-        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        List<ConsumerOffset> acknowledgedConsumerOffsets = new ArrayList<>();
         AtomicReference<Throwable> acknowledgedOffsetsError = new AtomicReference<>();
         AtomicBoolean acknowledgedOffsetsCompleted = new AtomicBoolean(false);
         List<Long> deactivatedRecordCounts = new ArrayList<>();
@@ -207,7 +207,7 @@ class ActivePartitionTest {
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
-                        acknowledgedOffsets::add,
+                        it -> acknowledgedConsumerOffsets.add(it.consumerOffset()),
                         acknowledgedOffsetsError::set,
                         () -> acknowledgedOffsetsCompleted.set(true));
         activePartition
@@ -227,7 +227,7 @@ class ActivePartitionTest {
                 .block();
 
         assertNotNull(lastAcknowledgedOffset);
-        assertEquals(Collections.singletonList(lastAcknowledgedOffset), acknowledgedOffsets);
+        assertEquals(Collections.singletonList(lastAcknowledgedOffset.consumerOffset()), acknowledgedConsumerOffsets);
         assertNull(acknowledgedOffsetsError.get());
         assertTrue(acknowledgedOffsetsCompleted.get());
         assertEquals(Collections.singletonList(1L), deactivatedRecordCounts);
@@ -237,7 +237,7 @@ class ActivePartitionTest {
 
     @Test
     public void deactivateLatest_givenGracePeriod_expectsTerminationAfterLastAcknowledgement() {
-        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        List<ConsumerOffset> acknowledgedConsumerOffsets = new ArrayList<>();
         AtomicReference<Throwable> acknowledgedOffsetsError = new AtomicReference<>();
         AtomicBoolean acknowledgedOffsetsCompleted = new AtomicBoolean(false);
         List<Long> deactivatedRecordCounts = new ArrayList<>();
@@ -248,7 +248,7 @@ class ActivePartitionTest {
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
-                        acknowledgedOffsets::add,
+                        it -> acknowledgedConsumerOffsets.add(it.consumerOffset()),
                         acknowledgedOffsetsError::set,
                         () -> acknowledgedOffsetsCompleted.set(true));
         activePartition
@@ -268,21 +268,21 @@ class ActivePartitionTest {
                 .deactivateLatest(Duration.ofDays(1), Schedulers.parallel(), Mono.never())
                 .subscribe(lastAcknowledgedOffset::set);
 
-        assertTrue(acknowledgedOffsets.isEmpty());
+        assertTrue(acknowledgedConsumerOffsets.isEmpty());
         assertTrue(deactivatedRecordCounts.isEmpty());
 
         receiverRecord1.acknowledge();
         receiverRecord2.acknowledge();
 
         assertNotNull(lastAcknowledgedOffset.get());
-        assertEquals(2, acknowledgedOffsets.size());
+        assertEquals(2, acknowledgedConsumerOffsets.size());
         assertEquals(
-                receiverRecord1.consumerRecord().offset() + 1,
-                acknowledgedOffsets.get(0).nextOffsetAndMetadata().offset());
+                receiverRecord1.consumerRecord().offset(),
+                acknowledgedConsumerOffsets.get(0).offset());
         assertEquals(
-                receiverRecord2.consumerRecord().offset() + 1,
-                acknowledgedOffsets.get(1).nextOffsetAndMetadata().offset());
-        assertEquals(lastAcknowledgedOffset.get(), acknowledgedOffsets.get(1));
+                receiverRecord2.consumerRecord().offset(),
+                acknowledgedConsumerOffsets.get(1).offset());
+        assertEquals(lastAcknowledgedOffset.get().consumerOffset(), acknowledgedConsumerOffsets.get(1));
         assertNull(acknowledgedOffsetsError.get());
         assertTrue(acknowledgedOffsetsCompleted.get());
         assertEquals(Arrays.asList(1L, 1L), deactivatedRecordCounts);
@@ -292,7 +292,7 @@ class ActivePartitionTest {
 
     @Test
     public void deactivateLatest_givenManualTimeout_expectsImmediateTerminationWithLastAcknowledgedOffset() {
-        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        List<ConsumerOffset> acknowledgedConsumerOffsets = new ArrayList<>();
         AtomicReference<Throwable> acknowledgedOffsetsError = new AtomicReference<>();
         AtomicBoolean acknowledgedOffsetsCompleted = new AtomicBoolean(false);
         List<Long> deactivatedRecordCounts = new ArrayList<>();
@@ -303,7 +303,7 @@ class ActivePartitionTest {
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
-                        acknowledgedOffsets::add,
+                        it -> acknowledgedConsumerOffsets.add(it.consumerOffset()),
                         acknowledgedOffsetsError::set,
                         () -> acknowledgedOffsetsCompleted.set(true));
         activePartition
@@ -328,7 +328,8 @@ class ActivePartitionTest {
         receiverRecord2.acknowledge();
 
         assertNotNull(lastAcknowledgedOffset.get());
-        assertEquals(Collections.singletonList(lastAcknowledgedOffset.get()), acknowledgedOffsets);
+        assertEquals(
+                Collections.singletonList(lastAcknowledgedOffset.get().consumerOffset()), acknowledgedConsumerOffsets);
         assertNull(acknowledgedOffsetsError.get());
         assertTrue(acknowledgedOffsetsCompleted.get());
         assertEquals(Arrays.asList(1L, 1L), deactivatedRecordCounts);
@@ -338,7 +339,7 @@ class ActivePartitionTest {
 
     @Test
     public void deactivateLatest_givenNoGracePeriod_expectsImmediateTerminationWithLastAcknowledgedOffset() {
-        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        List<ConsumerOffset> acknowledgedConsumerOffsets = new ArrayList<>();
         AtomicReference<Throwable> acknowledgedOffsetsError = new AtomicReference<>();
         AtomicBoolean acknowledgedOffsetsCompleted = new AtomicBoolean(false);
         List<Long> deactivatedRecordCounts = new ArrayList<>();
@@ -349,7 +350,7 @@ class ActivePartitionTest {
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
-                        acknowledgedOffsets::add,
+                        it -> acknowledgedConsumerOffsets.add(it.consumerOffset()),
                         acknowledgedOffsetsError::set,
                         () -> acknowledgedOffsetsCompleted.set(true));
         activePartition
@@ -376,7 +377,8 @@ class ActivePartitionTest {
         receiverRecord2.acknowledge();
 
         assertNotNull(lastAcknowledgedOffset.get());
-        assertEquals(Collections.singletonList(lastAcknowledgedOffset.get()), acknowledgedOffsets);
+        assertEquals(
+                Collections.singletonList(lastAcknowledgedOffset.get().consumerOffset()), acknowledgedConsumerOffsets);
         assertNull(acknowledgedOffsetsError.get());
         assertTrue(acknowledgedOffsetsCompleted.get());
         assertEquals(Arrays.asList(1L, 2L), deactivatedRecordCounts);
@@ -469,7 +471,7 @@ class ActivePartitionTest {
         assertEquals(1, acknowledgedOffsets.size());
         assertEquals(
                 receiverRecord1.consumerRecord().offset() + 1,
-                acknowledgedOffsets.get(0).nextOffsetAndMetadata().offset());
+                acknowledgedOffsets.get(0).nextOffset().offset());
         assertNull(acknowledgedOffsetsError.get());
         assertEquals(Arrays.asList(1L, 2L), deactivatedRecordCounts);
         assertNull(deactivatedRecordCountsError.get());

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/AsyncOffsetCommitterTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/AsyncOffsetCommitterTest.java
@@ -11,6 +11,7 @@ import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -29,6 +30,7 @@ class AsyncOffsetCommitterTest {
     @Test
     public void commit_givenNonRetriableFailure_expectsError() {
         TopicPartition topicPartition = new TopicPartition("topic", 0);
+        ConsumerOffset consumerOffset = new ConsumerOffset(topicPartition, 1L, Optional.empty());
         Consumer<?, ?> consumer = mock(Consumer.class);
         AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -47,7 +49,7 @@ class AsyncOffsetCommitterTest {
 
         committer
                 .acknowledgementHandlerForAssigned(topicPartition)
-                .accept(new AcknowledgedOffset(topicPartition, new OffsetAndMetadata(1L)));
+                .accept(new AcknowledgedOffset(consumerOffset, __ -> ""));
 
         assertInstanceOf(UnsupportedOperationException.class, error.get());
         assertFalse(committer.isCommitTrialExhausted(topicPartition));
@@ -56,6 +58,7 @@ class AsyncOffsetCommitterTest {
     @Test
     public void commit_givenRetriableFailureWithEventualSuccess_expectsRetryAndSuccess() {
         TopicPartition topicPartition = new TopicPartition("topic", 0);
+        ConsumerOffset consumerOffset = new ConsumerOffset(topicPartition, 1L, Optional.empty());
         Consumer<?, ?> consumer = mock(Consumer.class);
         AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -82,7 +85,7 @@ class AsyncOffsetCommitterTest {
 
         committer
                 .acknowledgementHandlerForAssigned(topicPartition)
-                .accept(new AcknowledgedOffset(topicPartition, new OffsetAndMetadata(1L)));
+                .accept(new AcknowledgedOffset(consumerOffset, __ -> ""));
 
         assertEquals(2, commitAttempts.get());
         assertNull(error.get());
@@ -92,6 +95,7 @@ class AsyncOffsetCommitterTest {
     @Test
     public void commit_givenRetriableFailureWithRetriesExhausted_expectsError() {
         TopicPartition topicPartition = new TopicPartition("topic", 0);
+        ConsumerOffset consumerOffset = new ConsumerOffset(topicPartition, 1L, Optional.empty());
         int maxCommitAttempts = 3;
         Consumer<?, ?> consumer = mock(Consumer.class);
         AtomicReference<Throwable> error = new AtomicReference<>();
@@ -114,7 +118,7 @@ class AsyncOffsetCommitterTest {
 
         committer
                 .acknowledgementHandlerForAssigned(topicPartition)
-                .accept(new AcknowledgedOffset(topicPartition, new OffsetAndMetadata(1L)));
+                .accept(new AcknowledgedOffset(consumerOffset, __ -> ""));
 
         assertEquals(maxCommitAttempts, commitAttempts.get());
         assertInstanceOf(KafkaException.class, error.get());

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/TestKafkaConfigSourceFactory.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/TestKafkaConfigSourceFactory.java
@@ -23,6 +23,7 @@ public final class TestKafkaConfigSourceFactory {
                 .with(
                         ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
                         OffsetResetStrategy.EARLIEST.name().toLowerCase())
+                .with(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false) // Avoid flakiness with embedded broker
                 .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
                 .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
                 .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName())


### PR DESCRIPTION
### :pencil: Description
- Update and simplify offset tracking to be consumed -> acknowledged -> committable
- Ensure calculation of `OffsetAndMetadata` to commit is lazy and only executed when absolutely necessary
- Example cleanup
- Attempt to fix flaky Kafka tests with out-of-order embedded broker flakiness
- This serves as first set of pre-work for enabling ahead-of-commit acknowledgement tracking

### :link: Related Issues
#544 