### PR TITLE
[#544] Kafka: Wrap assigned partition with handle to access metadata

### DIFF
--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
@@ -47,8 +47,8 @@ final class ActivePartition {
     private final Sinks.Many<Long> deactivatedRecordCounts =
             Sinks.unsafe().many().unicast().onBackpressureError();
 
-    public ActivePartition(TopicPartition topicPartition, AcknowledgementQueueMode acknowledgementQueueMode) {
-        this.topicPartition = topicPartition;
+    public ActivePartition(AssignedPartition assignedPartition, AcknowledgementQueueMode acknowledgementQueueMode) {
+        this.topicPartition = assignedPartition.topicPartition();
         this.acknowledgementQueue = AcknowledgementQueue.create(acknowledgementQueueMode);
     }
 

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/AssignedPartition.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/AssignedPartition.java
@@ -1,0 +1,35 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * A handle for a partition that has been assigned, and through which metadata about the assignment
+ * can be accessed.
+ */
+public final class AssignedPartition {
+
+    private final TopicPartition topicPartition;
+
+    private final Supplier<Optional<OffsetAndMetadata>> committedOffsetAndMetadata;
+
+    AssignedPartition(TopicPartition topicPartition, Supplier<Optional<OffsetAndMetadata>> committedOffsetAndMetadata) {
+        this.topicPartition = topicPartition;
+        this.committedOffsetAndMetadata = committedOffsetAndMetadata;
+    }
+
+    public TopicPartition topicPartition() {
+        return topicPartition;
+    }
+
+    public Optional<Long> committedOffset() {
+        return committedOffsetAndMetadata.get().map(OffsetAndMetadata::offset);
+    }
+
+    public Optional<String> committedMetadata() {
+        return committedOffsetAndMetadata.get().map(OffsetAndMetadata::metadata);
+    }
+}

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/PollManager.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/PollManager.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.IntSupplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Resource through which management of polling state and polling invocation are delegated. Takes
@@ -53,12 +54,12 @@ final class PollManager<T> {
     }
 
     public void activateAssigned(
-            Consumer<?, ?> consumer, Collection<TopicPartition> partitions, Function<TopicPartition, T> activator) {
-        partitions.forEach(partition -> {
-            if (assignments.containsKey(partition)) {
-                throw new IllegalStateException("TopicPartition already assigned: " + partition);
+            Consumer<?, ?> consumer, Collection<AssignedPartition> assigned, Function<AssignedPartition, T> activator) {
+        assigned.forEach(assignedPartition -> {
+            if (assignments.containsKey(assignedPartition.topicPartition())) {
+                throw new IllegalStateException("TopicPartition already assigned: " + assignedPartition.topicPartition());
             }
-            assignments.put(partition, activator.apply(partition));
+            assignments.put(assignedPartition.topicPartition(), activator.apply(assignedPartition));
         });
 
         // Newly assigned partitions may either be paused due to external control, or need pausing
@@ -67,7 +68,7 @@ final class PollManager<T> {
         // prohibited anyway, and even if they were permitted in the past, they MUST have been
         // previously prohibited due to unassignment (or else exception would be thrown above). Do,
         // however, let the strategy know about newly-assigned poll-permitted partitions.
-        Map<Boolean, ? extends Collection<TopicPartition>> permissibility = partitionByPollPermissibility(partitions);
+        Map<Boolean, ? extends Collection<TopicPartition>> permissibility = partitionByPollPermissibility(assigned);
         Collection<TopicPartition> prohibitedPartitions = permissibility.get(false);
         if (!prohibitedPartitions.isEmpty()) {
             consumer.pause(prohibitedPartitions);
@@ -137,19 +138,20 @@ final class PollManager<T> {
     }
 
     private Map<Boolean, ? extends Collection<TopicPartition>> partitionByPollPermissibility(
-            Collection<TopicPartition> partitions) {
+            Collection<AssignedPartition> assignedPartitions) {
+        Stream<TopicPartition> topicPartitions = assignedPartitions.stream().map(AssignedPartition::topicPartition);
         if (isPausedDueToBackpressure()) {
             Map<Boolean, Collection<TopicPartition>> result = new HashMap<>();
-            result.put(false, partitions);
+            result.put(false, topicPartitions.collect(Collectors.toList()));
             result.put(true, Collections.emptyList());
             return result;
         } else if (forcePaused.isEmpty()) {
             Map<Boolean, Collection<TopicPartition>> result = new HashMap<>();
             result.put(false, Collections.emptyList());
-            result.put(true, partitions);
+            result.put(true, topicPartitions.collect(Collectors.toList()));
             return result;
         } else {
-            return partitions.stream().collect(Collectors.partitioningBy(it -> !forcePaused.contains(it)));
+            return topicPartitions.collect(Collectors.partitioningBy(it -> !forcePaused.contains(it)));
         }
     }
 

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
@@ -132,15 +132,16 @@ final class PollingSubscriptionFactory<K, V> {
         }
 
         @Override
-        public final void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+        public final void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<AssignedPartition> partitions) {
             pollManager.activateAssigned(consumer, partitions, partition -> {
                 ActivePartition activePartition = new ActivePartition(partition, options.acknowledgementQueueMode());
                 onPartitionActivated(consumer, activePartition);
-                listener.onPartitionActivated(partition);
 
+                TopicPartition topicPartition = activePartition.topicPartition();
+                listener.onPartitionActivated(topicPartition);
                 activePartition
                         .deactivatedRecordCounts()
-                        .subscribe(it -> handleRecordsDeactivated(partition, it), this::failSafely);
+                        .subscribe(it -> handleRecordsDeactivated(topicPartition, it), this::failSafely);
 
                 return activePartition;
             });

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/ReceivingConsumer.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/ReceivingConsumer.java
@@ -4,6 +4,7 @@ import io.atleon.core.TaskLoop;
 import io.atleon.util.Proxying;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +14,10 @@ import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
@@ -121,7 +125,10 @@ final class ReceivingConsumer<K, V> implements ConsumerRebalanceListener, Consum
         }
 
         LOGGER.info("Notifying listeners of assigned partitions={}", partitions);
-        onRebalance(partitionListener::onPartitionsAssigned, consumerListener::onPartitionsAssigned, partitions);
+        // Not wrapping with try-catch. If user does something naughty, let the error be emitted.
+        consumerListener.onPartitionsAssigned(externalConsumerProxy, partitions);
+        // Done after external listening to account for possible seeking or metadata updates.
+        partitionListener.onPartitionsAssigned(consumer, toAssignedPartitions(partitions));
     }
 
     @Override
@@ -174,6 +181,27 @@ final class ReceivingConsumer<K, V> implements ConsumerRebalanceListener, Consum
         externalHandler.accept(externalConsumerProxy, partitions);
     }
 
+    private Collection<AssignedPartition> toAssignedPartitions(Collection<TopicPartition> partitions) {
+        // Committed offset metadata lookup is lazy and memoized because:
+        // 1. It could be the case that committed offset metadata is not needed/used
+        // 2. Invocation may require a remote call that we'd prefer to do only once per assignment
+        // 3. Downstream invocation is per-partition
+        // It's safe to use emptiness as a signal that metadata lookup has not yet occurred because
+        // the "committed" invocation is documented to return "null" (or zero) values if/when there
+        // is no committed offset for a given partition. We also know that invocation can't/won't
+        // occur if assignment is empty.
+        Map<TopicPartition, OffsetAndMetadata> committedOffsetsAndMetadata = new HashMap<>();
+        Function<TopicPartition, Optional<OffsetAndMetadata>> committedOffsetAndMetadata = topicPartition -> {
+            if (committedOffsetsAndMetadata.isEmpty()) {
+                committedOffsetsAndMetadata.putAll(consumer.committed(new HashSet<>(partitions)));
+            }
+            return Optional.ofNullable(committedOffsetsAndMetadata.get(topicPartition));
+        };
+        return partitions.stream()
+                .map(it -> new AssignedPartition(it, () -> committedOffsetAndMetadata.apply(it)))
+                .collect(Collectors.toList());
+    }
+
     private Object invokeConsumerFromExternal(Method method, Object[] args) throws ReflectiveOperationException {
         if (!taskLoop.isSourceOfCurrentThread()) {
             throw new UnsupportedOperationException("Kafka Consumer must be invoked from polling thread");
@@ -212,7 +240,7 @@ final class ReceivingConsumer<K, V> implements ConsumerRebalanceListener, Consum
 
     public interface PartitionListener {
 
-        void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions);
+        void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<AssignedPartition> partitions);
 
         void onPartitionsRevoked(Consumer<?, ?> consumer, Collection<TopicPartition> partitions);
 

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
@@ -31,12 +31,14 @@ class ActivePartitionTest {
 
     private static final TopicPartition TOPIC_PARTITION = new TopicPartition("topic", 0);
 
+    private static final AssignedPartition ASSIGNED_PARTITION = new AssignedPartition(TOPIC_PARTITION, Optional::empty);
+
     @Test
     public void activateForProcessing_givenActive_expectsRegisteredReceiverRecord() {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(ASSIGNED_PARTITION, AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -53,7 +55,7 @@ class ActivePartitionTest {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(ASSIGNED_PARTITION, AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -73,7 +75,7 @@ class ActivePartitionTest {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(ASSIGNED_PARTITION, AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -93,7 +95,7 @@ class ActivePartitionTest {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(ASSIGNED_PARTITION, AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -132,7 +134,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(ASSIGNED_PARTITION, AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add, acknowledgedOffsetsError::set);
         activePartition
                 .deactivatedRecordCounts()
@@ -161,7 +163,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(ASSIGNED_PARTITION, AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add, acknowledgedOffsetsError::set);
         activePartition
                 .deactivatedRecordCounts()
@@ -203,7 +205,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(ASSIGNED_PARTITION, AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -244,7 +246,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(ASSIGNED_PARTITION, AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -299,7 +301,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(ASSIGNED_PARTITION, AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -346,7 +348,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(ASSIGNED_PARTITION, AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -395,7 +397,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(ASSIGNED_PARTITION, AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -431,7 +433,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         CompletableFuture<Void> deactivatedRecordCountsCompletion = new CompletableFuture<>();
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(ASSIGNED_PARTITION, AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .publishOn(Schedulers.boundedElastic())

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/PollManagerTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/PollManagerTest.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,29 +29,30 @@ class PollManagerTest {
 
     @Test
     public void activateAssigned_givenAssignedPartitions_expectsCoordinationOfInvocations() {
-        TopicPartition partition1 = new TopicPartition("topic", 0);
-        TopicPartition partition2 = new TopicPartition("topic", 1);
+        AssignedPartition partition1 = new AssignedPartition(new TopicPartition("topic", 0), Optional::empty);
+        AssignedPartition partition2 = new AssignedPartition(new TopicPartition("topic", 1), Optional::empty);
 
         Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
         PollStrategy pollStrategy =
                 Mockito.mock(PollStrategy.class, AdditionalAnswers.delegatesTo(PollStrategy.natural()));
-        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
-        pollManager.forcePause(Collections.singletonList(partition1));
+        PollManager<AssignedPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
+        pollManager.forcePause(Collections.singletonList(partition1.topicPartition()));
 
         pollManager.activateAssigned(consumer, Arrays.asList(partition1, partition2), Function.identity());
 
-        verify(consumer).pause(argThat(it -> it.size() == 1 && it.contains(partition1)));
-        verify(pollStrategy).onPollingPermitted(argThat(it -> it.size() == 1 && it.contains(partition2)));
-        assertEquals(partition1, pollManager.activated(partition1));
-        assertEquals(partition2, pollManager.activated(partition2));
+        verify(consumer).pause(argThat(it -> it.size() == 1 && it.contains(partition1.topicPartition())));
+        verify(pollStrategy)
+                .onPollingPermitted(argThat(it -> it.size() == 1 && it.contains(partition2.topicPartition())));
+        assertEquals(partition1, pollManager.activated(partition1.topicPartition()));
+        assertEquals(partition2, pollManager.activated(partition2.topicPartition()));
     }
 
     @Test
     public void activateAssigned_givenAlreadyAssignedPartition_expectsException() {
-        TopicPartition partition = new TopicPartition("topic", 0);
+        AssignedPartition partition = new AssignedPartition(new TopicPartition("topic", 0), Optional::empty);
         Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
         PollStrategy pollStrategy = Mockito.mock(PollStrategy.class);
-        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
+        PollManager<AssignedPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
 
         pollManager.activateAssigned(consumer, Collections.singletonList(partition), Function.identity());
 
@@ -74,21 +76,23 @@ class PollManagerTest {
 
     @Test
     public void unassigned_givenRevokedPartition_expectsCoordinationOfInvocations() {
-        TopicPartition partition1 = new TopicPartition("topic", 0);
-        TopicPartition partition2 = new TopicPartition("topic", 1);
+        AssignedPartition partition1 = new AssignedPartition(new TopicPartition("topic", 0), Optional::empty);
+        AssignedPartition partition2 = new AssignedPartition(new TopicPartition("topic", 1), Optional::empty);
 
         Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
         PollStrategy pollStrategy =
                 Mockito.mock(PollStrategy.class, AdditionalAnswers.delegatesTo(PollStrategy.natural()));
-        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
+        PollManager<AssignedPartition> pollManager = new PollManager<>(pollStrategy, 1, Duration.ZERO);
         pollManager.activateAssigned(consumer, Arrays.asList(partition1, partition2), Function.identity());
 
-        Collection<TopicPartition> result = pollManager.unassigned(Collections.singletonList(partition1));
+        Collection<AssignedPartition> result =
+                pollManager.unassigned(Collections.singletonList(partition1.topicPartition()));
 
         assertEquals(1, result.size());
         assertTrue(result.contains(partition1));
-        verify(pollStrategy).onPollingProhibited(argThat(it -> it.size() == 1 && it.contains(partition1)));
-        assertEquals(partition2, pollManager.activated(partition2));
+        verify(pollStrategy)
+                .onPollingProhibited(argThat(it -> it.size() == 1 && it.contains(partition1.topicPartition())));
+        assertEquals(partition2, pollManager.activated(partition2.topicPartition()));
     }
 
     @Test
@@ -144,13 +148,13 @@ class PollManagerTest {
 
     @Test
     public void pollWakeably_givenBackpressureTransition_expectsStateUpdate() {
-        TopicPartition partition = new TopicPartition("topic", 0);
+        AssignedPartition partition = new AssignedPartition(new TopicPartition("topic", 0), Optional::empty);
         Consumer<?, ?> consumer = Mockito.mock(Consumer.class);
         when(consumer.poll(any())).thenReturn(ConsumerRecords.empty());
 
         PollStrategy pollStrategy =
                 Mockito.mock(PollStrategy.class, AdditionalAnswers.delegatesTo(PollStrategy.natural()));
-        PollManager<TopicPartition> pollManager = new PollManager<>(pollStrategy, 2, Duration.ZERO);
+        PollManager<AssignedPartition> pollManager = new PollManager<>(pollStrategy, 2, Duration.ZERO);
         pollManager.activateAssigned(consumer, Collections.singletonList(partition), Function.identity());
 
         // First call with sufficient capacity
@@ -159,7 +163,7 @@ class PollManagerTest {
 
         // Second call with insufficient capacity - should pause
         pollManager.pollWakeably(consumer, () -> 1);
-        verify(consumer).pause(argThat(partitions -> partitions.contains(partition)));
+        verify(consumer).pause(argThat(partitions -> partitions.contains(partition.topicPartition())));
     }
 
     @Test

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/ReceivingConsumerTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/ReceivingConsumerTest.java
@@ -4,6 +4,7 @@ import io.atleon.util.Throwing;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
@@ -12,13 +13,17 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -168,6 +173,49 @@ class ReceivingConsumerTest {
     }
 
     @Test
+    public void onPartitionsAssigned_givenCommittedOffsets_expectsQueryableMetadata() {
+        TopicPartition topicPartition1 = new TopicPartition("topic", 0);
+        TopicPartition topicPartition2 = new TopicPartition("topic", 1);
+        MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        mockConsumer.assign(Arrays.asList(topicPartition1, topicPartition2));
+        mockConsumer.commitSync(Collections.singletonMap(topicPartition1, new OffsetAndMetadata(42L, "meta")));
+
+        Collection<AssignedPartition> assigned = new ArrayList<>();
+        ReceivingConsumer.PartitionListener partitionListener = new NoOpPartitionListener() {
+            @Override
+            public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<AssignedPartition> partitions) {
+                assigned.addAll(partitions);
+            }
+        };
+
+        KafkaReceiverOptions<String, String> options = KafkaReceiverOptions.newBuilder(__ -> mockConsumer)
+                .consumerProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "test")
+                .build();
+
+        ReceivingConsumer<String, String> receivingConsumer =
+                new ReceivingConsumer<>(options, partitionListener, this::throwPropagated);
+        receivingConsumer.onPartitionsAssigned(Arrays.asList(topicPartition1, topicPartition2));
+
+        assertEquals(2, assigned.size());
+        AssignedPartition assignedPartition1 = assigned.stream()
+                .filter(it -> it.topicPartition().equals(topicPartition1))
+                .findFirst()
+                .orElseThrow(NullPointerException::new);
+        AssignedPartition assignedPartition2 = assigned.stream()
+                .filter(it -> it.topicPartition().equals(topicPartition2))
+                .findFirst()
+                .orElseThrow(NullPointerException::new);
+
+        assertEquals(topicPartition1, assignedPartition1.topicPartition());
+        assertEquals(Optional.of(42L), assignedPartition1.committedOffset());
+        assertEquals(Optional.of("meta"), assignedPartition1.committedMetadata());
+
+        assertEquals(topicPartition2, assignedPartition2.topicPartition());
+        assertFalse(assignedPartition2.committedOffset().isPresent());
+        assertFalse(assignedPartition2.committedMetadata().isPresent());
+    }
+
+    @Test
     public void init_givenConsumptionError_expectsContinuationOfTaskLoop() {
         MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
 
@@ -235,7 +283,7 @@ class ReceivingConsumerTest {
     public static class NoOpPartitionListener implements ReceivingConsumer.PartitionListener {
 
         @Override
-        public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {}
+        public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<AssignedPartition> partitions) {}
 
         @Override
         public void onPartitionsRevoked(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {}


### PR DESCRIPTION
### :pencil: Description
Second step toward enabling non-volatile honorship of processed records ahead of committed offset

### :link: Related Issues
#544 