### PR TITLE
[#544] Kafka: Enable honoring completed processing of records with offsets ahead of commit

### DIFF
--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
@@ -29,6 +29,8 @@ final class ActivePartition {
 
     private final AcknowledgementQueue acknowledgementQueue;
 
+    private final PartitionProcessingMetadataManager processingMetadataManager;
+
     // This counter doubles as both our publishing state (via polarity: positive == ACTIVE,
     // negative == TERMINABLE, zero == TERMINATED) and our count of activated in-flight records
     // (via magnitude: subtract 1 if positive, negate if negative). The extra/initializing count of
@@ -47,18 +49,31 @@ final class ActivePartition {
     private final Sinks.Many<Long> deactivatedRecordCounts =
             Sinks.unsafe().many().unicast().onBackpressureError();
 
-    public ActivePartition(TopicPartition topicPartition, AcknowledgementQueueMode acknowledgementQueueMode) {
+    public ActivePartition(
+            TopicPartition topicPartition,
+            AcknowledgementQueueMode acknowledgementQueueMode,
+            PartitionProcessingMetadataManager processingMetadataManager) {
         this.topicPartition = topicPartition;
         this.acknowledgementQueue = AcknowledgementQueue.create(acknowledgementQueueMode);
+        this.processingMetadataManager = processingMetadataManager;
     }
 
     /**
      * Activates a {@link ConsumerRecord} for processing, which is a prerequisite for emission.
-     * This will only return a non-empty result if this partition has not yet been deactivated.
+     * This will only return a non-empty result if the provided record has not been previously
+     * processed (per the initialized processing manager) and if this partition has not yet been
+     * deactivated.
      */
     public <K, V> Optional<KafkaReceiverRecord<K, V>> activateForProcessing(ConsumerRecord<K, V> consumerRecord) {
-        return activate(ConsumerOffset.create(topicPartition, consumerRecord))
-                .map(it -> KafkaReceiverRecord.create(consumerRecord, () -> ack(it), error -> nack(it, error)));
+        return activate(ConsumerOffset.create(topicPartition, consumerRecord)).map(it -> {
+            if (processingMetadataManager.previouslyProcessed(consumerRecord.offset())) {
+                ack(consumerRecord.offset(), it);
+                return null;
+            } else {
+                long offset = consumerRecord.offset();
+                return KafkaReceiverRecord.create(consumerRecord, () -> ack(offset, it), error -> nack(it, error));
+            }
+        });
     }
 
     /**
@@ -119,10 +134,16 @@ final class ActivePartition {
     }
 
     /**
-     * Returns a publisher of offsets that have been acknowledged and may be directly committed.
+     * Returns a publisher of offsets that have been acknowledged and may be directly committed. If
+     * previous processing is tracked (via processing metadata manager), then the resulting
+     * publisher may start with an offset that hasn't actually been acknowledged by this process,
+     * but is safe to commit in order to facilitate commitment of lazily evaluated commit metadata.
      */
     public Flux<AcknowledgedOffset> acknowledgedOffsets() {
-        return consumerOffsetsOfAcknowledged.asFlux().map(it -> new AcknowledgedOffset(it, __ -> ""));
+        return Mono.justOrEmpty(processingMetadataManager.initialAcknowledgeableOffset())
+                .map(it -> new ConsumerOffset(topicPartition, it))
+                .concatWith(consumerOffsetsOfAcknowledged.asFlux())
+                .map(it -> new AcknowledgedOffset(it, processingMetadataManager::updateAndGetMetadataOnCommit));
     }
 
     public Flux<Long> deactivatedRecordCounts() {
@@ -149,7 +170,8 @@ final class ActivePartition {
         }
     }
 
-    private void ack(AcknowledgementQueue.InFlight inFlight) {
+    private void ack(long offset, AcknowledgementQueue.InFlight inFlight) {
+        processingMetadataManager.processed(offset);
         acknowledge(queue -> queue.complete(inFlight));
     }
 

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/AloKafkaReceiver.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/AloKafkaReceiver.java
@@ -151,6 +151,15 @@ public class AloKafkaReceiver<K, V> {
     public static final String MAX_COMMIT_ATTEMPTS_CONFIG = CONFIG_PREFIX + "max.commit.attempts";
 
     /**
+     * Non-zero values activate non-volatile tracking of completed record processing ahead of
+     * committed offset(s).
+     *
+     * @see KafkaReceiverOptions#honoredProcessingAheadOfCommit()
+     */
+    public static final String HONORED_PROCESSING_AHEAD_OF_COMMIT_CONFIG =
+            CONFIG_PREFIX + "honored.processing.ahead.of.commit";
+
+    /**
      * Closing the underlying Kafka Consumer is a fallible process. In order to not infinitely
      * deadlock a Consumer during this process (which can lead to non-consumption of assigned
      * partitions), we use a default equal to what's used in KafkaConsumer::close
@@ -483,6 +492,8 @@ public class AloKafkaReceiver<K, V> {
                     .commitPeriod(config.loadDuration(COMMIT_INTERVAL_CONFIG).orElse(defaultOptions.commitPeriod()))
                     .maxCommitAttempts(
                             config.loadInt(MAX_COMMIT_ATTEMPTS_CONFIG).orElse(defaultOptions.maxCommitAttempts()))
+                    .honoredProcessingAheadOfCommit(config.loadInt(HONORED_PROCESSING_AHEAD_OF_COMMIT_CONFIG)
+                            .orElse(defaultOptions.honoredProcessingAheadOfCommit()))
                     .revocationGracePeriod(loadRevocationGracePeriod().orElse(defaultOptions.revocationGracePeriod()))
                     .terminationGracePeriod(config.loadDuration(TERMINATION_GRACE_PERIOD_CONFIG)
                             .orElse(defaultOptions.terminationGracePeriod()))

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/KafkaReceiverOptions.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/KafkaReceiverOptions.java
@@ -70,6 +70,8 @@ public final class KafkaReceiverOptions<K, V> {
 
     private final boolean commitlessOffsets;
 
+    private final int honoredProcessingAheadOfCommit;
+
     private final Duration revocationGracePeriod;
 
     private final Duration terminationGracePeriod;
@@ -92,6 +94,7 @@ public final class KafkaReceiverOptions<K, V> {
             Duration commitTimeout,
             int maxCommitAttempts,
             boolean commitlessOffsets,
+            int honoredProcessingAheadOfCommit,
             Duration revocationGracePeriod,
             Duration terminationGracePeriod,
             Duration closeTimeout) {
@@ -110,6 +113,7 @@ public final class KafkaReceiverOptions<K, V> {
         this.commitTimeout = commitTimeout;
         this.maxCommitAttempts = maxCommitAttempts;
         this.commitlessOffsets = commitlessOffsets;
+        this.honoredProcessingAheadOfCommit = honoredProcessingAheadOfCommit;
         this.revocationGracePeriod = revocationGracePeriod;
         this.terminationGracePeriod = terminationGracePeriod;
         this.closeTimeout = closeTimeout;
@@ -149,6 +153,7 @@ public final class KafkaReceiverOptions<K, V> {
                 .commitTimeout(commitTimeout)
                 .maxCommitAttempts(maxCommitAttempts)
                 .commitlessOffsets(commitlessOffsets)
+                .honoredProcessingAheadOfCommit(honoredProcessingAheadOfCommit)
                 .revocationGracePeriod(revocationGracePeriod)
                 .terminationGracePeriod(terminationGracePeriod)
                 .closeTimeout(closeTimeout);
@@ -278,6 +283,13 @@ public final class KafkaReceiverOptions<K, V> {
     }
 
     /**
+     * @see Builder#honoredProcessingAheadOfCommit(int)
+     */
+    public int honoredProcessingAheadOfCommit() {
+        return honoredProcessingAheadOfCommit;
+    }
+
+    /**
      * @see Builder#revocationGracePeriod(Duration)
      */
     public Duration revocationGracePeriod() {
@@ -309,6 +321,7 @@ public final class KafkaReceiverOptions<K, V> {
         validatePositive(commitBatchSize, "commitBatchSize");
         validatePositive(commitPeriod, "commitPeriod");
         validatePositive(maxCommitAttempts, "maxCommitAttempts");
+        validateNonNegative(honoredProcessingAheadOfCommit, "honoredProcessingAheadOfCommit");
         validateNonNegative(revocationGracePeriod, "revocationGracePeriod");
 
         if (!terminationGracePeriod.isZero() && terminationGracePeriod.compareTo(closeTimeout) >= 0) {
@@ -325,6 +338,12 @@ public final class KafkaReceiverOptions<K, V> {
     private static void validatePositive(Duration value, String name) {
         if (value.isZero() || value.isNegative()) {
             throw new IllegalArgumentException(name + " must be positive");
+        }
+    }
+
+    private static void validateNonNegative(long value, String name) {
+        if (value < 0) {
+            throw new IllegalArgumentException(name + " must be non-negative");
         }
     }
 
@@ -365,6 +384,8 @@ public final class KafkaReceiverOptions<K, V> {
         private int maxCommitAttempts = DEFAULT_MAX_COMMIT_ATTEMPTS;
 
         private boolean commitlessOffsets = false;
+
+        private int honoredProcessingAheadOfCommit = 0;
 
         private Duration revocationGracePeriod = DEFAULT_REVOCATION_GRACE_PERIOD;
 
@@ -544,6 +565,23 @@ public final class KafkaReceiverOptions<K, V> {
         }
 
         /**
+         * Configures the maximum number of records for which completed processing ahead of the
+         * committed offset for a given partition will be honored. This is implemented by keeping
+         * track of the offsets of records ahead of the committed offset which have been
+         * acknowledged, and storing this as commit metadata. It is reasonable to set this value
+         * to {@link Integer#MAX_VALUE} if the maximum number of acknowledged records ahead of
+         * what can be committed is known to be bounded (i.e. {@link #maxActiveInFlight(long)}).
+         * Otherwise, the max value of this setting is governed by the broker-side configuration
+         * {@code offset.metadata.max.bytes}. The offsets of completed records are stored using a
+         * base 64 string wrapping a byte array representing those offsets in sorted order,
+         * leveraging varint and delta-run encoding for optimal storage.
+         */
+        public Builder<K, V> honoredProcessingAheadOfCommit(int honoredProcessingAheadOfCommit) {
+            this.honoredProcessingAheadOfCommit = honoredProcessingAheadOfCommit;
+            return this;
+        }
+
+        /**
          * Configures the maximum amount of time that will be awaited for in-flight records to be
          * acknowledged from a partition whose assignment is being revoked. The latest acknowledged
          * offsets from such a partition are then used to issue one last commit before
@@ -598,6 +636,7 @@ public final class KafkaReceiverOptions<K, V> {
                     commitTimeout,
                     maxCommitAttempts,
                     commitlessOffsets,
+                    honoredProcessingAheadOfCommit,
                     revocationGracePeriod,
                     terminationGracePeriod,
                     closeTimeout);

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/OffsetMetadataEncoding.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/OffsetMetadataEncoding.java
@@ -1,0 +1,230 @@
+package io.atleon.kafka;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.zip.CRC32;
+import java.util.zip.CheckedOutputStream;
+import java.util.zip.Checksum;
+
+/**
+ * Utilities for encoding and decoding metadata associated with committed Kafka offsets. Such
+ * metadata is a compact, string-valued field.
+ *
+ * <p>For ahead-of-commit encoding, offsets are serialized to a binary format and then
+ * Base64-encoded for storage. Within that binary format, a sequence of offsets is written as a
+ * version, a count, and the offsets themselves expressed as deltas relative to the committed
+ * (anchor) offset, rather than as absolute values. Consecutive deltas of equal magnitude are
+ * further compressed via run-length encoding, and each integral value is written as an unsigned
+ * variable-length long so that small numbers occupy fewer bytes. A CRC checksum, seeded with the
+ * anchor offset, is appended so that decoding can detect corruption or a mismatched anchor and
+ * fail safely.
+ */
+final class OffsetMetadataEncoding {
+
+    private static final byte VERSION = 1;
+
+    private static final byte RUN_MARKER = 0;
+
+    private static final byte[] EMPTY_BYTES = new byte[0];
+
+    private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder().withoutPadding();
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OffsetMetadataEncoding.class);
+
+    private OffsetMetadataEncoding() {}
+
+    public static String encodeProcessed(long commitOffset, SortedSet<Long> processedOffsets, int limit) {
+        return BASE64_ENCODER.encodeToString(serializeProcessed(commitOffset, processedOffsets, limit));
+    }
+
+    public static List<Long> decodeProcessed(long assignmentOffset, String metadata, int limit) {
+        try {
+            return deserializeProcessed(assignmentOffset, Base64.getDecoder().decode(metadata), limit);
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Invalid Base64 offset metadata: {}", metadata);
+            return Collections.emptyList();
+        }
+    }
+
+    public static byte[] serializeProcessed(long commitOffset, SortedSet<Long> processedOffsets, int limit) {
+        int size = Math.min(processedOffsets.size(), limit);
+        return size <= 0 ? EMPTY_BYTES : serializeProcessedUnsafe(commitOffset, processedOffsets, size);
+    }
+
+    public static List<Long> deserializeProcessed(long assignmentOffset, byte[] metadata, int limit) {
+        try {
+            return metadata.length == 0
+                    ? Collections.emptyList()
+                    : deserializeProcessedUnsafe(assignmentOffset, metadata, limit);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to deserialize processed offsets from metadata", e);
+            return Collections.emptyList();
+        }
+    }
+
+    private static byte[] serializeProcessedUnsafe(long commitOffset, SortedSet<Long> processedOffsets, int limit) {
+        long firstProcessedOffset = processedOffsets.first();
+        if (commitOffset > firstProcessedOffset) {
+            throw new IllegalArgumentException("Processed offsets must be at least commit offset");
+        }
+
+        // Initialize with version and count of offsets that will be serialized
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        CheckedOutputStream checkedStream = new CheckedOutputStream(byteStream, initializeChecksum(commitOffset));
+        writeByte(checkedStream, VERSION);
+        writeUnsignedVarLong(checkedStream, limit);
+
+        // Write all delta-runs while keeping checksum updated
+        long previousOffset = commitOffset - 1;
+        long currentRunDelta = firstProcessedOffset - previousOffset;
+        long currentRunLength = 0;
+        for (Iterator<Long> iterator = processedOffsets.iterator(); iterator.hasNext() && limit > 0; limit--) {
+            long offset = iterator.next();
+            long delta = offset - previousOffset;
+            if (delta <= 0) {
+                throw new IllegalArgumentException("Processed offsets must be monotonically increasing");
+            } else if (delta == currentRunDelta) {
+                currentRunLength++;
+            } else {
+                flushDeltaOrRun(checkedStream, currentRunDelta, currentRunLength);
+                currentRunDelta = delta;
+                currentRunLength = 1;
+            }
+            previousOffset = offset;
+        }
+        flushDeltaOrRun(checkedStream, currentRunDelta, currentRunLength);
+
+        // Include checksum at end for deserialization validation
+        writeLeastSignificantInt(byteStream, checkedStream.getChecksum().getValue());
+
+        return byteStream.toByteArray();
+    }
+
+    private static List<Long> deserializeProcessedUnsafe(long assignmentOffset, byte[] metadata, int limit) {
+        // Validate checksum first for fail-fast behavior
+        ByteBuffer buffer = ByteBuffer.wrap(metadata, metadata.length - Integer.BYTES, Integer.BYTES);
+        Checksum expectedChecksum = initializeChecksum(assignmentOffset);
+        expectedChecksum.update(metadata, 0, buffer.position());
+        if (readLeastSignificantInt(buffer) != expectedChecksum.getValue()) {
+            throw new IllegalArgumentException("Checksum validation failed");
+        }
+
+        // Initialize data deserialization with version check
+        buffer.position(0).limit(metadata.length - Integer.BYTES);
+        byte version = buffer.get();
+        if (version != VERSION) {
+            throw new IllegalArgumentException("Incompatible version in offset commit metadata: " + version);
+        }
+
+        // Read number of offsets that have been encoded
+        long remaining = readUnsignedVarLong(buffer);
+        List<Long> values = new ArrayList<>(Math.min(limit, Math.toIntExact(remaining)));
+
+        // Read all delta-runs while calculating effective offsets
+        long previousOffset = assignmentOffset - 1;
+        while (remaining > 0) {
+            long deltaOrMarker = readUnsignedVarLong(buffer);
+
+            boolean running = deltaOrMarker == RUN_MARKER;
+            long delta = running ? readUnsignedVarLong(buffer) : deltaOrMarker;
+            long length = running ? readUnsignedVarLong(buffer) : 1;
+
+            remaining -= length;
+            while (values.size() < limit && length-- > 0) {
+                values.add(previousOffset += delta);
+            }
+        }
+
+        // Validate full consumption
+        if (buffer.hasRemaining()) {
+            throw new IllegalArgumentException("Buffer not fully consumed");
+        }
+
+        return values;
+    }
+
+    private static void flushDeltaOrRun(OutputStream out, long delta, long count) {
+        if (count == 1) {
+            writeUnsignedVarLong(out, delta);
+        } else if (count == 2) {
+            writeUnsignedVarLong(out, delta);
+            writeUnsignedVarLong(out, delta);
+        } else {
+            writeUnsignedVarLong(out, RUN_MARKER);
+            writeUnsignedVarLong(out, delta);
+            writeUnsignedVarLong(out, count);
+        }
+    }
+
+    private static void writeUnsignedVarLong(OutputStream out, long value) {
+        while ((value & ~0x7FL) != 0) {
+            writeByte(out, (int) ((value & 0x7F) | 0x80));
+            value >>>= 7;
+        }
+        writeByte(out, (int) value);
+    }
+
+    private static long readUnsignedVarLong(ByteBuffer buffer) {
+        long value = 0;
+        for (int shift = 0; shift < 64 && buffer.hasRemaining(); shift += 7) {
+            byte nextByte = buffer.get();
+            value |= (long) (nextByte & 0x7F) << shift;
+            if ((nextByte & 0x80) == 0) {
+                return value;
+            }
+        }
+        throw new IllegalArgumentException("Malformed VarLong");
+    }
+
+    private static void writeLeastSignificantInt(OutputStream out, long value) {
+        writeByte(out, (int) value >>> 24);
+        writeByte(out, (int) value >>> 16);
+        writeByte(out, (int) value >>> 8);
+        writeByte(out, (int) value);
+    }
+
+    private static long readLeastSignificantInt(ByteBuffer buffer) {
+        int value = 0;
+        value |= (buffer.get() & 0xFF) << 24;
+        value |= (buffer.get() & 0xFF) << 16;
+        value |= (buffer.get() & 0xFF) << 8;
+        value |= (buffer.get() & 0xFF);
+        return Integer.toUnsignedLong(value);
+    }
+
+    private static void writeByte(OutputStream out, int value) {
+        try {
+            out.write(value);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to write byte to OutputStream", e);
+        }
+    }
+
+    private static Checksum initializeChecksum(long offset) {
+        Checksum checksum = new CRC32();
+        update(checksum, offset);
+        return checksum;
+    }
+
+    private static void update(Checksum checksum, long value) {
+        checksum.update((int) (value >>> 56));
+        checksum.update((int) (value >>> 48));
+        checksum.update((int) (value >>> 40));
+        checksum.update((int) (value >>> 32));
+        checksum.update((int) (value >>> 24));
+        checksum.update((int) (value >>> 16));
+        checksum.update((int) (value >>> 8));
+        checksum.update((int) value);
+    }
+}

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/PartitionProcessingMetadataManager.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/PartitionProcessingMetadataManager.java
@@ -1,0 +1,135 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Per-partition manager of processing metadata. Each instance is specific to a single assignment
+ * lifecycle of a partition being consumed/processed. Non-trivial implementations may keep track of
+ * record offsets that have been processed, and expose that state as serializable metadata.
+ */
+interface PartitionProcessingMetadataManager {
+
+    static Map<TopicPartition, PartitionProcessingMetadataManager> create(
+            int honorshipAheadOfCommit, Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+        return honorshipAheadOfCommit <= 0 || partitions.isEmpty()
+                ? Collections.emptyMap()
+                : AheadOfCommit.create(honorshipAheadOfCommit, consumer, partitions);
+    }
+
+    static PartitionProcessingMetadataManager noOp() {
+        return NoOp.INSTANCE;
+    }
+
+    void processed(long offset);
+
+    String updateAndGetMetadataOnCommit(long commitOffset);
+
+    boolean previouslyProcessed(long offset);
+
+    Optional<Long> initialAcknowledgeableOffset();
+
+    final class NoOp implements PartitionProcessingMetadataManager {
+
+        private static final PartitionProcessingMetadataManager INSTANCE = new NoOp();
+
+        private NoOp() {}
+
+        @Override
+        public void processed(long offset) {}
+
+        @Override
+        public String updateAndGetMetadataOnCommit(long commitOffset) {
+            return "";
+        }
+
+        @Override
+        public boolean previouslyProcessed(long offset) {
+            return false;
+        }
+
+        @Override
+        public Optional<Long> initialAcknowledgeableOffset() {
+            return Optional.empty();
+        }
+    }
+
+    final class AheadOfCommit implements PartitionProcessingMetadataManager {
+
+        private final int honorship;
+
+        private final long initialPosition;
+
+        private final List<Long> sortedPreviouslyProcessedOffsets;
+
+        private final Set<Long> processedOffsets;
+
+        private AheadOfCommit(int honorship, long initialPosition, List<Long> sortedPreviouslyProcessedOffsets) {
+            this.honorship = honorship;
+            this.initialPosition = initialPosition;
+            this.sortedPreviouslyProcessedOffsets = sortedPreviouslyProcessedOffsets;
+            this.processedOffsets = ConcurrentHashMap.newKeySet();
+            processedOffsets.addAll(sortedPreviouslyProcessedOffsets);
+        }
+
+        private static Map<TopicPartition, PartitionProcessingMetadataManager> create(
+                int honorship, Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+            Map<TopicPartition, OffsetAndMetadata> committedOffsets = consumer.committed(new HashSet<>(partitions));
+            return partitions.stream().collect(Collectors.toMap(Function.identity(), partition -> {
+                long initialPosition = consumer.position(partition);
+                List<Long> sortedPreviouslyProcessedOffsets = Optional.ofNullable(committedOffsets.get(partition))
+                        .map(it -> OffsetMetadataEncoding.decodeProcessed(initialPosition, it.metadata(), honorship))
+                        .orElse(Collections.emptyList());
+                return new AheadOfCommit(honorship, initialPosition, sortedPreviouslyProcessedOffsets);
+            }));
+        }
+
+        @Override
+        public void processed(long offset) {
+            processedOffsets.add(offset);
+        }
+
+        @Override
+        public String updateAndGetMetadataOnCommit(long commitOffset) {
+            SortedSet<Long> processedOffsetsToEncode = new TreeSet<>();
+            Iterator<Long> iterator = processedOffsets.iterator();
+            while (iterator.hasNext()) {
+                long processedOffset = iterator.next();
+                if (processedOffset < commitOffset) {
+                    iterator.remove();
+                } else {
+                    processedOffsetsToEncode.add(processedOffset);
+                }
+            }
+            return OffsetMetadataEncoding.encodeProcessed(commitOffset, processedOffsetsToEncode, honorship);
+        }
+
+        @Override
+        public boolean previouslyProcessed(long offset) {
+            int previouslyProcessedOffsetsSize = sortedPreviouslyProcessedOffsets.size();
+            return previouslyProcessedOffsetsSize > 0
+                    && offset <= sortedPreviouslyProcessedOffsets.get(previouslyProcessedOffsetsSize - 1)
+                    && Collections.binarySearch(sortedPreviouslyProcessedOffsets, offset) >= 0;
+        }
+
+        @Override
+        public Optional<Long> initialAcknowledgeableOffset() {
+            return Optional.of(initialPosition - 1);
+        }
+    }
+}

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
@@ -133,8 +133,14 @@ final class PollingSubscriptionFactory<K, V> {
 
         @Override
         public final void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+            Map<TopicPartition, PartitionProcessingMetadataManager> processingMetadataManagers =
+                    PartitionProcessingMetadataManager.create(honorshipAheadOfCommit(), consumer, partitions);
+
             pollManager.activateAssigned(consumer, partitions, partition -> {
-                ActivePartition activePartition = new ActivePartition(partition, options.acknowledgementQueueMode());
+                PartitionProcessingMetadataManager processingMetadataManager =
+                        processingMetadataManagers.getOrDefault(partition, PartitionProcessingMetadataManager.noOp());
+                ActivePartition activePartition =
+                        new ActivePartition(partition, options.acknowledgementQueueMode(), processingMetadataManager);
                 onPartitionActivated(consumer, activePartition);
                 listener.onPartitionActivated(partition);
 
@@ -186,6 +192,10 @@ final class PollingSubscriptionFactory<K, V> {
         @Override
         public final Collection<TopicPartition> grantedPartitionPauses() {
             return pollManager.forcePaused();
+        }
+
+        protected int honorshipAheadOfCommit() {
+            return options.commitlessOffsets() ? 0 : options.honoredProcessingAheadOfCommit();
         }
 
         protected abstract void onPartitionActivated(Consumer<?, ?> consumer, ActivePartition partition);
@@ -474,6 +484,11 @@ final class PollingSubscriptionFactory<K, V> {
                     .windowWhen(offsetsState(TxOffsetsState.PROCESSING), __ -> offsetsState(TxOffsetsState.COMMITTING))
                     .concatMap(it -> it.collectMap(AcknowledgedOffset::topicPartition, AcknowledgedOffset::nextOffset))
                     .subscribe(this::maybeSendOffsetsInCurrentTransaction, this::failSafely);
+        }
+
+        @Override
+        protected int honorshipAheadOfCommit() {
+            return 0; // Honoring completed processing ahead of commit is not applicable to TXs
         }
 
         @Override

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
@@ -12,8 +12,10 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -26,6 +28,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ActivePartitionTest {
 
@@ -36,7 +41,8 @@ class ActivePartitionTest {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(
+                TOPIC_PARTITION, AcknowledgementQueueMode.STRICT, PartitionProcessingMetadataManager.noOp());
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -53,7 +59,8 @@ class ActivePartitionTest {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(
+                TOPIC_PARTITION, AcknowledgementQueueMode.STRICT, PartitionProcessingMetadataManager.noOp());
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -69,11 +76,68 @@ class ActivePartitionTest {
     }
 
     @Test
+    public void activateForProcessing_givenPreviouslyProcessed_expectsNoReceiverRecordButAccountedForAcknowledgement() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        List<Long> deactivatedRecordCounts = new ArrayList<>();
+
+        ActivePartition activePartition = new ActivePartition(
+                TOPIC_PARTITION, AcknowledgementQueueMode.STRICT, managerWithPreviouslyProcessed(1L));
+        activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
+        activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
+
+        // The first record is activated for processing, but not yet acknowledged.
+        KafkaReceiverRecord<String, String> receiverRecord1 =
+                activePartition.activateForProcessing(newConsumerRecord(0)).get();
+
+        // The second record was previously processed, so it is not activated for emission/
+        // processing, but it is still accounted for in acknowledgement queueing.
+        ConsumerRecord<String, String> previouslyProcessedRecord = newConsumerRecord(1);
+        Optional<KafkaReceiverRecord<String, String>> previouslyProcessedActivated =
+                activePartition.activateForProcessing(previouslyProcessedRecord);
+
+        // The third record is activated for processing, but not yet acknowledged.
+        KafkaReceiverRecord<String, String> receiverRecord3 =
+                activePartition.activateForProcessing(newConsumerRecord(2)).get();
+
+        assertFalse(previouslyProcessedActivated.isPresent());
+
+        // Nothing is acknowledged yet: strict ordering keeps the previously processed second record
+        // queued behind the not-yet-acknowledged first record.
+        assertTrue(acknowledgedOffsets.isEmpty());
+        assertTrue(deactivatedRecordCounts.isEmpty());
+
+        // Acknowledging the first record drains it along with the previously processed second
+        // record, in offset order, proving the previously processed record was accounted for in
+        // acknowledgement queueing.
+        receiverRecord1.acknowledge();
+        assertEquals(2, acknowledgedOffsets.size());
+        assertEquals(TOPIC_PARTITION, acknowledgedOffsets.get(0).topicPartition());
+        assertEquals(
+                receiverRecord1.consumerRecord().offset() + 1,
+                acknowledgedOffsets.get(0).nextOffset().offset());
+        assertEquals(TOPIC_PARTITION, acknowledgedOffsets.get(1).topicPartition());
+        assertEquals(
+                previouslyProcessedRecord.offset() + 1,
+                acknowledgedOffsets.get(1).nextOffset().offset());
+        assertEquals(Collections.singletonList(2L), deactivatedRecordCounts);
+
+        // Acknowledging the third record drains it after the previously verified behavior.
+        receiverRecord3.acknowledge();
+        assertEquals(3, acknowledgedOffsets.size());
+        assertEquals(TOPIC_PARTITION, acknowledgedOffsets.get(2).topicPartition());
+        assertEquals(
+                receiverRecord3.consumerRecord().offset() + 1,
+                acknowledgedOffsets.get(2).nextOffset().offset());
+        assertEquals(Arrays.asList(2L, 1L), deactivatedRecordCounts);
+    }
+
+    @Test
     public void acknowledge_givenActivatedRecordIsAcknowledged_expectsCorrectAcknowledgements() {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(
+                TOPIC_PARTITION, AcknowledgementQueueMode.STRICT, PartitionProcessingMetadataManager.noOp());
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -93,7 +157,8 @@ class ActivePartitionTest {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(
+                TOPIC_PARTITION, AcknowledgementQueueMode.STRICT, PartitionProcessingMetadataManager.noOp());
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -132,7 +197,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(
+                TOPIC_PARTITION, AcknowledgementQueueMode.STRICT, PartitionProcessingMetadataManager.noOp());
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add, acknowledgedOffsetsError::set);
         activePartition
                 .deactivatedRecordCounts()
@@ -161,7 +227,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(
+                TOPIC_PARTITION, AcknowledgementQueueMode.STRICT, PartitionProcessingMetadataManager.noOp());
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add, acknowledgedOffsetsError::set);
         activePartition
                 .deactivatedRecordCounts()
@@ -203,7 +270,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(
+                TOPIC_PARTITION, AcknowledgementQueueMode.STRICT, PartitionProcessingMetadataManager.noOp());
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -244,7 +312,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(
+                TOPIC_PARTITION, AcknowledgementQueueMode.STRICT, PartitionProcessingMetadataManager.noOp());
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -299,7 +368,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(
+                TOPIC_PARTITION, AcknowledgementQueueMode.STRICT, PartitionProcessingMetadataManager.noOp());
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -346,7 +416,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(
+                TOPIC_PARTITION, AcknowledgementQueueMode.STRICT, PartitionProcessingMetadataManager.noOp());
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -395,7 +466,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(
+                TOPIC_PARTITION, AcknowledgementQueueMode.STRICT, PartitionProcessingMetadataManager.noOp());
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -431,7 +503,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         CompletableFuture<Void> deactivatedRecordCountsCompletion = new CompletableFuture<>();
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(
+                TOPIC_PARTITION, AcknowledgementQueueMode.STRICT, PartitionProcessingMetadataManager.noOp());
         activePartition
                 .acknowledgedOffsets()
                 .publishOn(Schedulers.boundedElastic())
@@ -479,5 +552,13 @@ class ActivePartitionTest {
 
     private static ConsumerRecord<String, String> newConsumerRecord(int offset) {
         return new ConsumerRecord<>(TOPIC_PARTITION.topic(), TOPIC_PARTITION.partition(), offset, "key", "value");
+    }
+
+    private static PartitionProcessingMetadataManager managerWithPreviouslyProcessed(Long... offsets) {
+        Set<Long> previouslyProcessed = new HashSet<>(Arrays.asList(offsets));
+        PartitionProcessingMetadataManager processingMetadataManager = mock(PartitionProcessingMetadataManager.class);
+        when(processingMetadataManager.previouslyProcessed(anyLong()))
+                .thenAnswer(it -> previouslyProcessed.contains(it.<Long>getArgument(0)));
+        return processingMetadataManager;
     }
 }

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/KafkaReceiverTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/KafkaReceiverTest.java
@@ -19,6 +19,8 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -374,6 +376,122 @@ class KafkaReceiverTest {
                     .block();
             assertEquals(1, maxOffset);
         }
+    }
+
+    @Test
+    public void receiveManual_givenAcknowledgedRecordAheadOfCommit_expectsHonoredProcessingOnResubscription() {
+        String topic = UUID.randomUUID().toString();
+        String groupId = UUID.randomUUID().toString();
+
+        // All records share the same key so that they are produced to (and consumed from) the same
+        // partition, where ahead-of-commit honorship applies.
+        KafkaSenderRecord<String, String, Object> senderRecord1 =
+                KafkaSenderRecord.create(topic, "key", "value1", null);
+        KafkaSenderRecord<String, String, Object> senderRecord2 =
+                KafkaSenderRecord.create(topic, "key", "value2", null);
+        KafkaSenderRecord<String, String, Object> senderRecord3 =
+                KafkaSenderRecord.create(topic, "key", "value3", null);
+        KafkaSenderRecord<String, String, Object> senderRecord4 =
+                KafkaSenderRecord.create(topic, "key", "value4", null);
+        KafkaSenderRecord<String, String, Object> senderRecord5 =
+                KafkaSenderRecord.create(topic, "key", "value5", null);
+
+        sendStrings(senderRecord1, senderRecord2, senderRecord3, senderRecord4, senderRecord5);
+
+        ConsumerListener.Closure closureListener = ConsumerListener.closure();
+        KafkaReceiverOptions<String, String> receiverOptions = KafkaReceiverOptions.<String, String>newBuilder()
+                .consumerListener(closureListener)
+                .consumerProperties(newStringConsumerProperties(groupId))
+                .honoredProcessingAheadOfCommit(Integer.MAX_VALUE)
+                .build();
+
+        // Receive all five records, then acknowledge the first and the fourth. Strict acknowledgement
+        // ordering advances the committed offset only past the first record, while the fourth record's
+        // completed processing is recorded ahead of the committed offset as commit metadata.
+        List<KafkaReceiverRecord<String, String>> receivedRecords = new ArrayList<>();
+        KafkaReceiver.create(receiverOptions)
+                .receiveManual(Collections.singletonList(topic))
+                .as(StepVerifier::create)
+                .consumeNextWith(receivedRecords::add)
+                .consumeNextWith(receivedRecords::add)
+                .consumeNextWith(receivedRecords::add)
+                .consumeNextWith(receivedRecords::add)
+                .consumeNextWith(receivedRecords::add)
+                .then(() -> {
+                    receivedRecords.get(0).acknowledge();
+                    receivedRecords.get(3).acknowledge();
+                })
+                .thenCancel()
+                .verify();
+
+        assertEquals(
+                Arrays.asList("value1", "value2", "value3", "value4", "value5"),
+                receivedRecords.stream().map(KafkaReceiverRecord::value).collect(Collectors.toList()));
+        assertNull(closureListener.closed().block());
+
+        // On resubscription, consumption resumes from the committed offset (past the first record),
+        // and the honored fourth record is not re-emitted, leaving the second, third, and fifth.
+        KafkaReceiver.create(receiverOptions)
+                .receiveManual(Collections.singletonList(topic))
+                .as(StepVerifier::create)
+                .consumeNextWith(it -> assertEquals(senderRecord2.value(), it.value()))
+                .consumeNextWith(it -> assertEquals(senderRecord3.value(), it.value()))
+                .consumeNextWith(it -> assertEquals(senderRecord5.value(), it.value()))
+                .thenCancel()
+                .verify();
+    }
+
+    @Test
+    public void receiveManual_givenAcknowledgedRecordAheadOfNoCommit_expectsHonoredProcessingOnResubscription() {
+        String topic = UUID.randomUUID().toString();
+        String groupId = UUID.randomUUID().toString();
+
+        // All records share the same key so that they are produced to (and consumed from) the same
+        // partition, where ahead-of-commit honorship applies.
+        KafkaSenderRecord<String, String, Object> senderRecord1 =
+                KafkaSenderRecord.create(topic, "key", "value1", null);
+        KafkaSenderRecord<String, String, Object> senderRecord2 =
+                KafkaSenderRecord.create(topic, "key", "value2", null);
+        KafkaSenderRecord<String, String, Object> senderRecord3 =
+                KafkaSenderRecord.create(topic, "key", "value3", null);
+
+        sendStrings(senderRecord1, senderRecord2, senderRecord3);
+
+        ConsumerListener.Closure closureListener = ConsumerListener.closure();
+        KafkaReceiverOptions<String, String> receiverOptions = KafkaReceiverOptions.<String, String>newBuilder()
+                .consumerListener(closureListener)
+                .consumerProperties(newStringConsumerProperties(groupId))
+                .honoredProcessingAheadOfCommit(Integer.MAX_VALUE)
+                .build();
+
+        // Receive all three records, then acknowledge the second. Since the first is not
+        // acknowledged the committed offset will not advance, but we should still end up honoring
+        // uncommitted progress.
+        List<KafkaReceiverRecord<String, String>> receivedRecords = new ArrayList<>();
+        KafkaReceiver.create(receiverOptions)
+                .receiveManual(Collections.singletonList(topic))
+                .as(StepVerifier::create)
+                .consumeNextWith(receivedRecords::add)
+                .consumeNextWith(receivedRecords::add)
+                .consumeNextWith(receivedRecords::add)
+                .then(() -> receivedRecords.get(1).acknowledge())
+                .thenCancel()
+                .verify();
+
+        assertEquals(
+                Arrays.asList("value1", "value2", "value3"),
+                receivedRecords.stream().map(KafkaReceiverRecord::value).collect(Collectors.toList()));
+        assertNull(closureListener.closed().block());
+
+        // On resubscription, consumption resumes from the initializing offset ("earliest")
+        // and the honored second record is not re-emitted, leaving the first and third.
+        KafkaReceiver.create(receiverOptions)
+                .receiveManual(Collections.singletonList(topic))
+                .as(StepVerifier::create)
+                .consumeNextWith(it -> assertEquals(senderRecord1.value(), it.value()))
+                .consumeNextWith(it -> assertEquals(senderRecord3.value(), it.value()))
+                .thenCancel()
+                .verify();
     }
 
     @ParameterizedTest

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/OffsetMetadataEncodingTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/OffsetMetadataEncodingTest.java
@@ -1,0 +1,260 @@
+package io.atleon.kafka;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OffsetMetadataEncodingTest {
+
+    @Test
+    public void serializeProcessed_givenSingleOffsetAtCommitOffset_expectsRoundTrip() {
+        SortedSet<Long> processedOffsets = sortedSetOf(5L);
+
+        byte[] serialized = OffsetMetadataEncoding.serializeProcessed(5L, processedOffsets, Integer.MAX_VALUE);
+        List<Long> deserialized = OffsetMetadataEncoding.deserializeProcessed(5L, serialized, Integer.MAX_VALUE);
+
+        assertEquals(Collections.singletonList(5L), deserialized);
+    }
+
+    @Test
+    public void serializeProcessed_givenContiguousOffsets_expectsRoundTrip() {
+        SortedSet<Long> processedOffsets = sortedSetOf(10L, 11L, 12L, 13L, 14L);
+
+        byte[] serialized = OffsetMetadataEncoding.serializeProcessed(10L, processedOffsets, Integer.MAX_VALUE);
+        List<Long> deserialized = OffsetMetadataEncoding.deserializeProcessed(10L, serialized, Integer.MAX_VALUE);
+
+        assertEquals(new ArrayList<>(processedOffsets), deserialized);
+    }
+
+    @Test
+    public void serializeProcessed_givenTwoContiguousOffsets_expectsRoundTrip() {
+        SortedSet<Long> processedOffsets = sortedSetOf(5L, 6L);
+
+        byte[] serialized = OffsetMetadataEncoding.serializeProcessed(5L, processedOffsets, Integer.MAX_VALUE);
+        List<Long> deserialized = OffsetMetadataEncoding.deserializeProcessed(5L, serialized, Integer.MAX_VALUE);
+
+        assertEquals(Arrays.asList(5L, 6L), deserialized);
+    }
+
+    @Test
+    public void serializeProcessed_givenSparseOffsets_expectsRoundTrip() {
+        SortedSet<Long> processedOffsets = sortedSetOf(10L, 13L, 14L, 20L, 100L);
+
+        byte[] serialized = OffsetMetadataEncoding.serializeProcessed(10L, processedOffsets, Integer.MAX_VALUE);
+        List<Long> deserialized = OffsetMetadataEncoding.deserializeProcessed(10L, serialized, Integer.MAX_VALUE);
+
+        assertEquals(new ArrayList<>(processedOffsets), deserialized);
+    }
+
+    @Test
+    public void serializeProcessed_givenMixedRunsAndSingles_expectsRoundTrip() {
+        // A run of three contiguous, then a gap, then a single.
+        SortedSet<Long> processedOffsets = sortedSetOf(10L, 11L, 12L, 20L);
+
+        byte[] serialized = OffsetMetadataEncoding.serializeProcessed(10L, processedOffsets, Integer.MAX_VALUE);
+        List<Long> deserialized = OffsetMetadataEncoding.deserializeProcessed(10L, serialized, Integer.MAX_VALUE);
+
+        assertEquals(Arrays.asList(10L, 11L, 12L, 20L), deserialized);
+    }
+
+    @Test
+    public void serializeProcessed_givenGapBetweenCommitAndFirstOffset_expectsRoundTrip() {
+        SortedSet<Long> processedOffsets = sortedSetOf(15L, 16L, 17L);
+
+        byte[] serialized = OffsetMetadataEncoding.serializeProcessed(10L, processedOffsets, Integer.MAX_VALUE);
+        List<Long> deserialized = OffsetMetadataEncoding.deserializeProcessed(10L, serialized, Integer.MAX_VALUE);
+
+        assertEquals(Arrays.asList(15L, 16L, 17L), deserialized);
+    }
+
+    @Test
+    public void serializeProcessed_givenLargeOffsetsRequiringMultiByteVarLong_expectsRoundTrip() {
+        SortedSet<Long> processedOffsets = sortedSetOf(1_000_000_000L, 1_000_000_001L, 2_000_000_000L);
+
+        byte[] serialized =
+                OffsetMetadataEncoding.serializeProcessed(1_000_000_000L, processedOffsets, Integer.MAX_VALUE);
+        List<Long> deserialized =
+                OffsetMetadataEncoding.deserializeProcessed(1_000_000_000L, serialized, Integer.MAX_VALUE);
+
+        assertEquals(new ArrayList<>(processedOffsets), deserialized);
+    }
+
+    @Test
+    public void serializeProcessed_givenLongRunOfContiguousOffsets_expectsCompactRoundTrip() {
+        SortedSet<Long> processedOffsets = new TreeSet<>();
+        for (long offset = 0L; offset < 1000L; offset++) {
+            processedOffsets.add(offset);
+        }
+
+        byte[] serialized = OffsetMetadataEncoding.serializeProcessed(0L, processedOffsets, Integer.MAX_VALUE);
+        List<Long> deserialized = OffsetMetadataEncoding.deserializeProcessed(0L, serialized, Integer.MAX_VALUE);
+
+        assertEquals(new ArrayList<>(processedOffsets), deserialized);
+        // Run-length encoding keeps a 1000-offset contiguous run far smaller than one byte per offset.
+        assertTrue(serialized.length < 50, "Expected compact run encoding but was " + serialized.length + " bytes");
+    }
+
+    @Test
+    public void serializeProcessed_givenEmptyOffsets_expectsEmptyOutput() {
+        byte[] serialized = OffsetMetadataEncoding.serializeProcessed(5L, new TreeSet<>(), Integer.MAX_VALUE);
+
+        assertEquals(0, serialized.length);
+        assertTrue(OffsetMetadataEncoding.deserializeProcessed(5L, serialized, Integer.MAX_VALUE)
+                .isEmpty());
+    }
+
+    @Test
+    public void serializeProcessed_givenZeroLimit_expectsEmptyOutput() {
+        byte[] serialized = OffsetMetadataEncoding.serializeProcessed(5L, sortedSetOf(5L, 6L, 7L), 0);
+
+        assertEquals(0, serialized.length);
+        assertTrue(OffsetMetadataEncoding.deserializeProcessed(5L, serialized, Integer.MAX_VALUE)
+                .isEmpty());
+    }
+
+    @Test
+    public void serializeProcessed_givenLimitSmallerThanSet_expectsOnlySmallestOffsets() {
+        SortedSet<Long> processedOffsets = sortedSetOf(10L, 11L, 12L, 13L, 14L);
+
+        byte[] serialized = OffsetMetadataEncoding.serializeProcessed(10L, processedOffsets, 3);
+        List<Long> deserialized = OffsetMetadataEncoding.deserializeProcessed(10L, serialized, Integer.MAX_VALUE);
+
+        assertEquals(Arrays.asList(10L, 11L, 12L), deserialized);
+    }
+
+    @Test
+    public void deserializeProcessed_givenLimitSmallerThanEncoded_expectsOnlySmallestOffsets() {
+        SortedSet<Long> processedOffsets = sortedSetOf(10L, 11L, 12L, 13L, 14L);
+
+        // Encoded under a larger honorship/limit than the limit used to decode (e.g. config lowered between runs).
+        byte[] serialized = OffsetMetadataEncoding.serializeProcessed(10L, processedOffsets, Integer.MAX_VALUE);
+        List<Long> deserialized = OffsetMetadataEncoding.deserializeProcessed(10L, serialized, 3);
+
+        assertEquals(Arrays.asList(10L, 11L, 12L), deserialized);
+    }
+
+    @Test
+    public void deserializeProcessed_givenLimitSmallerThanEncodedSparseOffsets_expectsOnlySmallestOffsets() {
+        SortedSet<Long> processedOffsets = sortedSetOf(10L, 13L, 14L, 20L, 100L);
+
+        // Exercises the limit boundary falling within a single-delta region rather than a run.
+        byte[] serialized = OffsetMetadataEncoding.serializeProcessed(10L, processedOffsets, Integer.MAX_VALUE);
+        List<Long> deserialized = OffsetMetadataEncoding.deserializeProcessed(10L, serialized, 2);
+
+        assertEquals(Arrays.asList(10L, 13L), deserialized);
+    }
+
+    @Test
+    public void deserializeProcessed_givenLimitTruncatingWithinRunFollowedBySingles_expectsOnlySmallestOffsets() {
+        // A run of four contiguous offsets, then two sparse singles. Limiting within the run forces decoding to
+        // keep consuming the trailing singles (advancing to the CRC) even though no further offsets are retained.
+        SortedSet<Long> processedOffsets = sortedSetOf(10L, 11L, 12L, 13L, 20L, 30L);
+
+        byte[] serialized = OffsetMetadataEncoding.serializeProcessed(10L, processedOffsets, Integer.MAX_VALUE);
+        List<Long> deserialized = OffsetMetadataEncoding.deserializeProcessed(10L, serialized, 2);
+
+        assertEquals(Arrays.asList(10L, 11L), deserialized);
+    }
+
+    @Test
+    public void serializeProcessed_givenCommitOffsetGreaterThanFirstProcessed_expectsException() {
+        SortedSet<Long> processedOffsets = sortedSetOf(5L, 6L);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> OffsetMetadataEncoding.serializeProcessed(6L, processedOffsets, Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void deserializeProcessed_givenEmptyBytes_expectsEmptyList() {
+        assertTrue(OffsetMetadataEncoding.deserializeProcessed(5L, new byte[0], Integer.MAX_VALUE)
+                .isEmpty());
+    }
+
+    @Test
+    public void deserializeProcessed_givenCorruptedBytes_expectsEmptyList() {
+        byte[] serialized = OffsetMetadataEncoding.serializeProcessed(5L, sortedSetOf(5L, 6L, 7L), Integer.MAX_VALUE);
+
+        // Corrupt the trailing CRC so validation fails.
+        serialized[serialized.length - 1] ^= 0x01;
+
+        assertTrue(OffsetMetadataEncoding.deserializeProcessed(5L, serialized, Integer.MAX_VALUE)
+                .isEmpty());
+    }
+
+    @Test
+    public void deserializeProcessed_givenTrailingBytes_expectsEmptyList() {
+        byte[] serialized = OffsetMetadataEncoding.serializeProcessed(5L, sortedSetOf(5L, 6L, 7L), Integer.MAX_VALUE);
+
+        byte[] withTrailing = Arrays.copyOf(serialized, serialized.length + 1);
+
+        assertTrue(OffsetMetadataEncoding.deserializeProcessed(5L, withTrailing, Integer.MAX_VALUE)
+                .isEmpty());
+    }
+
+    @Test
+    public void deserializeProcessed_givenMismatchedCommitOffset_expectsEmptyList() {
+        byte[] serialized =
+                OffsetMetadataEncoding.serializeProcessed(100L, sortedSetOf(100L, 101L, 102L), Integer.MAX_VALUE);
+
+        // The CRC is seeded with the commit offset, so decoding under a different commit offset fails validation.
+        assertTrue(OffsetMetadataEncoding.deserializeProcessed(50L, serialized, Integer.MAX_VALUE)
+                .isEmpty());
+    }
+
+    @Test
+    public void deserializeProcessed_givenIncompatibleVersion_expectsEmptyList() {
+        // A single varlong byte decoding to version 2, which is incompatible with the supported version.
+        byte[] incompatibleVersion = new byte[] {0x02};
+
+        assertTrue(OffsetMetadataEncoding.deserializeProcessed(5L, incompatibleVersion, Integer.MAX_VALUE)
+                .isEmpty());
+    }
+
+    @Test
+    public void encodeProcessed_givenOffsets_expectsBase64RoundTrip() {
+        SortedSet<Long> processedOffsets = sortedSetOf(10L, 11L, 13L);
+
+        String encoded = OffsetMetadataEncoding.encodeProcessed(10L, processedOffsets, Integer.MAX_VALUE);
+        List<Long> decoded = OffsetMetadataEncoding.decodeProcessed(10L, encoded, Integer.MAX_VALUE);
+
+        assertEquals(new ArrayList<>(processedOffsets), decoded);
+    }
+
+    @Test
+    public void encodeProcessed_givenEmptyOffsets_expectsEmptyEncoding() {
+        String encoded = OffsetMetadataEncoding.encodeProcessed(5L, new TreeSet<>(), Integer.MAX_VALUE);
+
+        assertEquals("", encoded);
+        assertTrue(OffsetMetadataEncoding.decodeProcessed(5L, encoded, Integer.MAX_VALUE)
+                .isEmpty());
+    }
+
+    @Test
+    public void decodeProcessed_givenInvalidBase64_expectsEmptyList() {
+        assertTrue(OffsetMetadataEncoding.decodeProcessed(5L, "not valid base64!!!", Integer.MAX_VALUE)
+                .isEmpty());
+    }
+
+    @Test
+    public void encodeProcessed_givenWithoutPadding_expectsNoPaddingCharacters() {
+        String encoded = OffsetMetadataEncoding.encodeProcessed(10L, sortedSetOf(10L, 11L, 12L), Integer.MAX_VALUE);
+
+        assertNotEquals("", encoded);
+        assertTrue(encoded.indexOf('=') < 0, "Expected no Base64 padding but was: " + encoded);
+    }
+
+    private static SortedSet<Long> sortedSetOf(Long... offsets) {
+        return new TreeSet<>(Arrays.asList(offsets));
+    }
+}

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/PartitionProcessingMetadataManagerTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/PartitionProcessingMetadataManagerTest.java
@@ -1,0 +1,268 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PartitionProcessingMetadataManagerTest {
+
+    private static final TopicPartition TOPIC_PARTITION = new TopicPartition("topic", 0);
+
+    @Test
+    public void create_givenNonPositiveHonorship_expectsEmptyMapWithoutQueryingCommittedOffsets() {
+        Consumer<?, ?> consumer = mock(Consumer.class);
+
+        Map<TopicPartition, PartitionProcessingMetadataManager> managers =
+                PartitionProcessingMetadataManager.create(0, consumer, Collections.singletonList(TOPIC_PARTITION));
+
+        assertTrue(managers.isEmpty());
+        verify(consumer, never()).committed(anySet());
+    }
+
+    @Test
+    public void create_givenEmptyPartitions_expectsEmptyMapWithoutQueryingCommittedOffsets() {
+        Consumer<?, ?> consumer = mock(Consumer.class);
+
+        Map<TopicPartition, PartitionProcessingMetadataManager> managers =
+                PartitionProcessingMetadataManager.create(10, consumer, Collections.emptyList());
+
+        assertTrue(managers.isEmpty());
+        verify(consumer, never()).committed(anySet());
+    }
+
+    @Test
+    public void create_givenMultiplePartitions_expectsManagerForEachPartition() {
+        TopicPartition otherPartition = new TopicPartition("topic", 1);
+        Consumer<?, ?> consumer = mockConsumerWithCommitted(0L, Collections.emptyMap());
+
+        Map<TopicPartition, PartitionProcessingMetadataManager> managers =
+                PartitionProcessingMetadataManager.create(10, consumer, Arrays.asList(TOPIC_PARTITION, otherPartition));
+
+        assertEquals(2, managers.size());
+        assertTrue(managers.containsKey(TOPIC_PARTITION));
+        assertTrue(managers.containsKey(otherPartition));
+    }
+
+    @Test
+    public void
+            create_givenNoCommittedOffsets_expectsNoPreviouslyProcessedOffsetsButInitialAcknowledgeableOffsetReported() {
+        // No committed offset exists for the partition, but the consumer is still positioned (e.g.
+        // via offset reset). The initial acknowledgeable offset is the offset just before that
+        // position, not the absent committed offset, while there are no previously processed
+        // offsets to decode.
+        Consumer<?, ?> consumer = mockConsumerWithCommitted(50L, Collections.emptyMap());
+
+        PartitionProcessingMetadataManager manager = PartitionProcessingMetadataManager.create(
+                        10, consumer, Collections.singletonList(TOPIC_PARTITION))
+                .get(TOPIC_PARTITION);
+
+        assertEquals(Optional.of(49L), manager.initialAcknowledgeableOffset());
+        assertFalse(manager.previouslyProcessed(50L));
+    }
+
+    @Test
+    public void create_givenPositionDistinctFromCommittedMetadataBasis_expectsMetadataValidatedAgainstPosition() {
+        // The committed metadata was encoded against the committed offset (10), but the consumer is
+        // now positioned at 13. Because decoding validates against the initial position rather than
+        // the committed offset, the metadata fails validation and none of its offsets are reported
+        // as previously processed, even though they are present in the committed metadata.
+        PartitionProcessingMetadataManager manager = createManager(10, 13L, 10L, Arrays.asList(10L, 11L, 15L));
+
+        assertEquals(Optional.of(12L), manager.initialAcknowledgeableOffset());
+        assertFalse(manager.previouslyProcessed(10L));
+        assertFalse(manager.previouslyProcessed(11L));
+        assertFalse(manager.previouslyProcessed(15L));
+    }
+
+    @Test
+    public void create_givenCommittedMetadata_expectsDecodedOffsetsReportedAsPreviouslyProcessed() {
+        // The consumer is positioned at the offset the committed metadata was encoded against (10),
+        // so the metadata validates against the initial position and its offsets are honored. The
+        // initial acknowledgeable offset is the offset just before that position.
+        PartitionProcessingMetadataManager manager = createManager(10, 10L, Arrays.asList(10L, 11L, 15L));
+
+        assertEquals(Optional.of(9L), manager.initialAcknowledgeableOffset());
+
+        // Offsets encoded into the committed metadata are reported as previously processed.
+        assertTrue(manager.previouslyProcessed(10L));
+        assertTrue(manager.previouslyProcessed(11L));
+        assertTrue(manager.previouslyProcessed(15L));
+
+        // Offsets within the encoded range but absent from it are not previously processed.
+        assertFalse(manager.previouslyProcessed(12L));
+
+        // Offsets beyond the largest encoded offset are not previously processed.
+        assertFalse(manager.previouslyProcessed(16L));
+
+        // Offsets below the smallest encoded offset are not previously processed.
+        assertFalse(manager.previouslyProcessed(9L));
+    }
+
+    @Test
+    public void previouslyProcessed_givenEmptyPreviouslyProcessed_expectsAlwaysFalse() {
+        PartitionProcessingMetadataManager manager = createManager(10, 10L, Collections.emptyList());
+
+        assertFalse(manager.previouslyProcessed(0L));
+        assertFalse(manager.previouslyProcessed(10L));
+    }
+
+    @Test
+    public void previouslyProcessed_givenOffsetMarkedProcessedAfterCreation_expectsStillFalse() {
+        PartitionProcessingMetadataManager manager = createManager(10, 10L, Collections.emptyList());
+
+        // Marking an offset as processed within this lifecycle does not make it "previously"
+        // processed, which is determined solely from the metadata present at creation.
+        manager.processed(5L);
+
+        assertFalse(manager.previouslyProcessed(5L));
+    }
+
+    @Test
+    public void updateAndGetMetadataOnCommit_givenProcessedOffsets_expectsThemEncodedIntoMetadata() {
+        PartitionProcessingMetadataManager manager = createManager(10, 5L, Collections.emptyList());
+
+        manager.processed(5L);
+        manager.processed(6L);
+        manager.processed(9L);
+
+        String metadata = manager.updateAndGetMetadataOnCommit(4L);
+
+        assertEquals(
+                Arrays.asList(5L, 6L, 9L), OffsetMetadataEncoding.decodeProcessed(4L, metadata, Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void updateAndGetMetadataOnCommit_givenProcessedOffsetsBelowCommit_expectsThemExcluded() {
+        PartitionProcessingMetadataManager manager = createManager(10, 5L, Collections.emptyList());
+
+        manager.processed(5L);
+        manager.processed(6L);
+        manager.processed(7L);
+        manager.processed(10L);
+
+        // Committing at 7 drops the offsets below it; only 7 and 10 remain at or above the commit.
+        String metadata = manager.updateAndGetMetadataOnCommit(7L);
+
+        assertEquals(Arrays.asList(7L, 10L), OffsetMetadataEncoding.decodeProcessed(7L, metadata, Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void updateAndGetMetadataOnCommit_givenNoProcessedOffsetsAtOrAboveCommit_expectsEmptyMetadata() {
+        PartitionProcessingMetadataManager manager = createManager(10, 5L, Collections.emptyList());
+
+        manager.processed(5L);
+        manager.processed(6L);
+
+        String metadata = manager.updateAndGetMetadataOnCommit(10L);
+
+        assertEquals("", metadata);
+        assertTrue(OffsetMetadataEncoding.decodeProcessed(10L, metadata, Integer.MAX_VALUE)
+                .isEmpty());
+    }
+
+    @Test
+    public void updateAndGetMetadataOnCommit_givenMoreProcessedThanHonorship_expectsOnlySmallestRetained() {
+        PartitionProcessingMetadataManager manager = createManager(2, 10L, Collections.emptyList());
+
+        manager.processed(10L);
+        manager.processed(11L);
+        manager.processed(12L);
+        manager.processed(13L);
+
+        // The honorship of 2 limits the encoded metadata to the two smallest processed offsets.
+        String metadata = manager.updateAndGetMetadataOnCommit(10L);
+
+        assertEquals(Arrays.asList(10L, 11L), OffsetMetadataEncoding.decodeProcessed(10L, metadata, Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void updateAndGetMetadataOnCommit_givenPreviouslyProcessedOffsets_expectsThemCarriedForward() {
+        PartitionProcessingMetadataManager manager = createManager(10, 10L, Arrays.asList(10L, 11L, 15L));
+
+        // Without marking anything new, committing at the original offset re-encodes the previously
+        // processed offsets.
+        String metadata = manager.updateAndGetMetadataOnCommit(10L);
+
+        assertEquals(
+                Arrays.asList(10L, 11L, 15L), OffsetMetadataEncoding.decodeProcessed(10L, metadata, Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void updateAndGetMetadataOnCommit_givenRepeatedCommits_expectsRemovalsToPersist() {
+        PartitionProcessingMetadataManager manager = createManager(10, 5L, Collections.emptyList());
+
+        manager.processed(5L);
+        manager.processed(6L);
+        manager.processed(9L);
+
+        // Committing at 7 permanently removes 5 and 6.
+        manager.updateAndGetMetadataOnCommit(7L);
+
+        // A subsequent commit below 7 cannot resurrect the removed offsets; only 9 remains.
+        String metadata = manager.updateAndGetMetadataOnCommit(5L);
+
+        assertEquals(
+                Collections.singletonList(9L), OffsetMetadataEncoding.decodeProcessed(5L, metadata, Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void noOp_expectsInertBehavior() {
+        PartitionProcessingMetadataManager manager = PartitionProcessingMetadataManager.noOp();
+
+        // Marking offsets processed has no effect and does not throw.
+        manager.processed(5L);
+
+        assertEquals("", manager.updateAndGetMetadataOnCommit(5L));
+        assertFalse(manager.previouslyProcessed(5L));
+        assertEquals(Optional.empty(), manager.initialAcknowledgeableOffset());
+    }
+
+    private static PartitionProcessingMetadataManager createManager(
+            int honorship, long committedOffset, List<Long> previouslyProcessed) {
+        // In the common case, the consumer is positioned at the committed offset on assignment.
+        return createManager(honorship, committedOffset, committedOffset, previouslyProcessed);
+    }
+
+    private static PartitionProcessingMetadataManager createManager(
+            int honorship, long initialPosition, long committedOffset, List<Long> previouslyProcessed) {
+        Map<TopicPartition, OffsetAndMetadata> committed =
+                Collections.singletonMap(TOPIC_PARTITION, toOffsetAndMetadata(committedOffset, previouslyProcessed));
+        Consumer<?, ?> consumer = mockConsumerWithCommitted(initialPosition, committed);
+        return PartitionProcessingMetadataManager.create(honorship, consumer, committed.keySet())
+                .get(TOPIC_PARTITION);
+    }
+
+    private static OffsetAndMetadata toOffsetAndMetadata(long committedOffset, List<Long> processed) {
+        String metadata =
+                OffsetMetadataEncoding.encodeProcessed(committedOffset, new TreeSet<>(processed), Integer.MAX_VALUE);
+        return new OffsetAndMetadata(committedOffset, metadata);
+    }
+
+    private static Consumer<?, ?> mockConsumerWithCommitted(
+            long initialPosition, Map<TopicPartition, OffsetAndMetadata> committed) {
+        Consumer<?, ?> consumer = mock(Consumer.class);
+        // The cast mirrors the production call site, which queries committed offsets for a Set of partitions.
+        when(consumer.committed(anySet())).thenReturn(new HashMap<>(committed));
+        // Initialization is based on the consumer's position, which is queried per assigned partition.
+        when(consumer.position(TOPIC_PARTITION)).thenReturn(initialPosition);
+        return consumer;
+    }
+}


### PR DESCRIPTION
### :pencil: Description
- Add new KafkaReceiverOptions::honoredProcessingAheadOfCommit option
- When enabled, keep track of offsets for records that have completed processing
- Use commit metadata to store offsets of records which have completed processing ahead of the committed offset
- When enabled, load previously processed offsets on partition assignment and skip those records for emission

### :link: Related Issues
#544 
