### PR TITLE
[#544] Kafka: Make metadata commitment async

### DIFF
--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/AcknowledgedOffset.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/AcknowledgedOffset.java
@@ -2,6 +2,9 @@ package io.atleon.kafka;
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import java.util.function.LongFunction;
 
@@ -15,11 +18,17 @@ final class AcknowledgedOffset {
 
     private final ConsumerOffset consumerOffset;
 
-    private final LongFunction<String> offsetCommitmentMetadataFactory;
+    private final LongFunction<Mono<String>> metadataCommitment;
 
-    public AcknowledgedOffset(ConsumerOffset consumerOffset, LongFunction<String> offsetCommitmentMetadataFactory) {
+    public AcknowledgedOffset(ConsumerOffset consumerOffset, LongFunction<Mono<String>> metadataCommitment) {
         this.consumerOffset = consumerOffset;
-        this.offsetCommitmentMetadataFactory = offsetCommitmentMetadataFactory;
+        this.metadataCommitment = metadataCommitment;
+    }
+
+    public Mono<Tuple2<TopicPartition, OffsetAndMetadata>> prepareCommitment() {
+        long commitOffset = consumerOffset.offset() + 1;
+        Mono<String> commitMetadata = metadataCommitment.apply(commitOffset);
+        return commitMetadata.map(it -> Tuples.of(topicPartition(), newOffsetAndMetadata(commitOffset, it)));
     }
 
     public TopicPartition topicPartition() {
@@ -30,17 +39,7 @@ final class AcknowledgedOffset {
         return consumerOffset;
     }
 
-    public OffsetAndMetadata nextOffset() {
-        return nextOffsetAndMetadata(__ -> "");
-    }
-
-    public OffsetAndMetadata commitOffset() {
-        return nextOffsetAndMetadata(offsetCommitmentMetadataFactory);
-    }
-
-    private OffsetAndMetadata nextOffsetAndMetadata(LongFunction<String> nextOffsetMetadataFactory) {
-        long nextOffset = consumerOffset.offset() + 1;
-        String metadata = nextOffsetMetadataFactory.apply(nextOffset);
-        return new OffsetAndMetadata(nextOffset, consumerOffset.leaderEpoch(), metadata);
+    private OffsetAndMetadata newOffsetAndMetadata(long offset, String metadata) {
+        return new OffsetAndMetadata(offset, consumerOffset.leaderEpoch(), metadata);
     }
 }

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
@@ -122,7 +122,7 @@ final class ActivePartition {
      * Returns a publisher of offsets that have been acknowledged and may be directly committed.
      */
     public Flux<AcknowledgedOffset> acknowledgedOffsets() {
-        return consumerOffsetsOfAcknowledged.asFlux().map(it -> new AcknowledgedOffset(it, __ -> ""));
+        return consumerOffsetsOfAcknowledged.asFlux().map(it -> new AcknowledgedOffset(it, __ -> Mono.just("")));
     }
 
     public Flux<Long> deactivatedRecordCounts() {

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/AsyncOffsetCommitter.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/AsyncOffsetCommitter.java
@@ -2,6 +2,7 @@ package io.atleon.kafka;
 
 import io.atleon.core.SerialQueue;
 import io.atleon.core.ShouldBeTerminatedEmitFailureHandler;
+import io.atleon.util.Publishing;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaException;
@@ -9,8 +10,10 @@ import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 import reactor.core.scheduler.Scheduler;
+import reactor.util.function.Tuple2;
 
 import java.time.Duration;
 import java.util.Map;
@@ -120,8 +123,10 @@ final class AsyncOffsetCommitter {
             Map<TopicPartition, OffsetAndMetadata> validatedOffsets = committableOffsets.entrySet().stream()
                     .filter(it -> it.getValue().sequence() == getAssignment(it.getKey()))
                     .filter(it -> commitSequences.get(it.getKey()) == getCommit(it.getKey()))
-                    .collect(Collectors.toMap(
-                            Map.Entry::getKey, it -> it.getValue().commitOffset()));
+                    .map(entry -> entry.getValue().prepareCommitment())
+                    .collect(Collectors.collectingAndThen(Collectors.toList(), Publishing::mergeGreedily))
+                    .collectMap(Tuple2::getT1, Tuple2::getT2)
+                    .block();
             commit(consumer, validatedOffsets, commitSequences);
         });
     }
@@ -210,12 +215,12 @@ final class AsyncOffsetCommitter {
             this.sequence = sequence;
         }
 
-        public TopicPartition topicPartition() {
-            return acknowledgedOffset.topicPartition();
+        public Mono<Tuple2<TopicPartition, OffsetAndMetadata>> prepareCommitment() {
+            return acknowledgedOffset.prepareCommitment();
         }
 
-        public OffsetAndMetadata commitOffset() {
-            return acknowledgedOffset.commitOffset();
+        public TopicPartition topicPartition() {
+            return acknowledgedOffset.topicPartition();
         }
 
         public long sequence() {

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/ConsumerOffset.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/ConsumerOffset.java
@@ -8,10 +8,10 @@ import java.util.Optional;
 
 /**
  * Hydrated descriptor of an offset associated with a consumed (or consumable)
- * {@link org.apache.kafka.clients.consumer.ConsumerRecord}. This includes the originating
- * {@link TopicPartition}, record offset, and epoch of the partition leader.
+ * {@link ConsumerRecord}. This includes the originating {@link TopicPartition}, record offset,
+ * and epoch of the partition leader.
  */
-final class ConsumerOffset {
+public final class ConsumerOffset {
 
     private final TopicPartition topicPartition;
 

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
@@ -26,6 +26,7 @@ import reactor.util.function.Tuples;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -56,6 +57,17 @@ final class PollingSubscriptionFactory<K, V> {
             ConsumptionSpec consumptionSpec,
             Subscriber<? super KafkaReceiverRecord<K, V>> subscriber) {
         return new TransactionalPoller(txManager, consumptionSpec, subscriber);
+    }
+
+    private static Mono<Map<TopicPartition, OffsetAndMetadata>> prepareCommit(Flux<AcknowledgedOffset> offsets) {
+        return offsets.collectMap(AcknowledgedOffset::topicPartition).flatMap(it -> prepareCommit(it.values()));
+    }
+
+    private static Mono<Map<TopicPartition, OffsetAndMetadata>> prepareCommit(Collection<AcknowledgedOffset> offsets) {
+        return offsets.stream()
+                .map(AcknowledgedOffset::prepareCommitment)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), Publishing::mergeGreedily))
+                .collectMap(Tuple2::getT1, Tuple2::getT2);
     }
 
     private static void runSafely(Runnable task, String name) {
@@ -377,17 +389,26 @@ final class PollingSubscriptionFactory<K, V> {
             // this redundancy is significantly undesirable. Under low load, the overhead of a
             // synchronous commit is not likely to meaningfully degrade already-low throughput. As
             // load increases, so does the likelihood that there will be acknowledged uncommitted
-            // offsets, and it becomes more desirable to attempt to honor that progress.
+            // offsets, and it becomes more desirable to attempt to honor that progress. Moreover,
+            // it may be the case that commit metadata has changed, and committing with the most
+            // recent acknowledged offset ensures that update.
             Duration gracePeriod = options.revocationGracePeriod();
-            Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = partitions.stream()
+            Collection<AcknowledgedOffset> latestAcknowledgedOffsets = partitions.stream()
                     .map(it -> it.deactivateLatest(gracePeriod, auxiliaryScheduler, termination.asMono()))
                     .collect(Collectors.collectingAndThen(Collectors.toList(), Publishing::mergeGreedily))
                     .filter(it -> !asyncOffsetCommitter.isCommitTrialExhausted(it.topicPartition()))
-                    .collectMap(AcknowledgedOffset::topicPartition, AcknowledgedOffset::commitOffset)
+                    .collectList()
                     .block();
+            // Prepare offsets for commitment, but defer subscription so we can choose (or not
+            // choose) to block on it inside both try and catch blocks (and cache result so we only
+            // prepare commitment once).
+            Mono<Map<TopicPartition, OffsetAndMetadata>> preparedOffsetsToCommit =
+                    prepareCommit(latestAcknowledgedOffsets).as(Publishing::cacheSuccess);
 
             try {
-                if (!offsetsToCommit.isEmpty() && !options.commitlessOffsets()) {
+                Map<TopicPartition, OffsetAndMetadata> offsetsToCommit =
+                        options.commitlessOffsets() ? Collections.emptyMap() : preparedOffsetsToCommit.block();
+                if (!offsetsToCommit.isEmpty()) {
                     LOGGER.info("Committing offsets on revocation: {}", offsetsToCommit);
                     consumer.commitSync(offsetsToCommit, options.commitTimeout());
                 }
@@ -402,10 +423,10 @@ final class PollingSubscriptionFactory<K, V> {
                 // we retry one LAST time. Note that the wakeup signal is not re-emitted, such as
                 // to let the rebalance continue as normal.
                 try {
-                    consumer.commitSync(offsetsToCommit, options.commitTimeout());
+                    consumer.commitSync(preparedOffsetsToCommit.block(), options.commitTimeout());
                 } catch (WakeupException __) {
                     LOGGER.info("Consumer commit-on-revocation woken (last attempt)");
-                    consumer.commitSync(offsetsToCommit, options.commitTimeout());
+                    consumer.commitSync(preparedOffsetsToCommit.block(), options.commitTimeout());
                 }
             } finally {
                 // Lastly, sanitize sequence counters to account for possible in-flight commits and
@@ -472,7 +493,7 @@ final class PollingSubscriptionFactory<K, V> {
             this.transactionalOffsetsSend = acknowledgedOffsets
                     .asFlux()
                     .windowWhen(offsetsState(TxOffsetsState.PROCESSING), __ -> offsetsState(TxOffsetsState.COMMITTING))
-                    .concatMap(it -> it.collectMap(AcknowledgedOffset::topicPartition, AcknowledgedOffset::nextOffset))
+                    .concatMap(PollingSubscriptionFactory::prepareCommit)
                     .subscribe(this::maybeSendOffsetsInCurrentTransaction, this::failSafely);
         }
 

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
@@ -84,7 +84,7 @@ class ActivePartitionTest {
         assertEquals(TOPIC_PARTITION, acknowledgedOffsets.get(0).topicPartition());
         assertEquals(
                 consumerRecord.offset() + 1,
-                acknowledgedOffsets.get(0).nextOffset().offset());
+                acknowledgedOffsets.get(0).prepareCommitment().block().getT2().offset());
         assertEquals(Collections.singletonList(1L), deactivatedRecordCounts);
     }
 
@@ -114,13 +114,13 @@ class ActivePartitionTest {
         assertEquals(TOPIC_PARTITION, acknowledgedOffsets.get(2).topicPartition());
         assertEquals(
                 receiverRecord1.consumerRecord().offset() + 1,
-                acknowledgedOffsets.get(0).nextOffset().offset());
+                acknowledgedOffsets.get(0).prepareCommitment().block().getT2().offset());
         assertEquals(
                 receiverRecord2.consumerRecord().offset() + 1,
-                acknowledgedOffsets.get(1).nextOffset().offset());
+                acknowledgedOffsets.get(1).prepareCommitment().block().getT2().offset());
         assertEquals(
                 receiverRecord3.consumerRecord().offset() + 1,
-                acknowledgedOffsets.get(2).nextOffset().offset());
+                acknowledgedOffsets.get(2).prepareCommitment().block().getT2().offset());
         assertEquals(Arrays.asList(1L, 2L), deactivatedRecordCounts);
     }
 
@@ -187,7 +187,7 @@ class ActivePartitionTest {
         assertEquals(1, acknowledgedOffsets.size());
         assertEquals(
                 receiverRecord1.consumerRecord().offset() + 1,
-                acknowledgedOffsets.get(0).nextOffset().offset());
+                acknowledgedOffsets.get(0).prepareCommitment().block().getT2().offset());
         assertInstanceOf(IllegalStateException.class, acknowledgedOffsetsError.get());
         assertEquals(Arrays.asList(1L, 3L), deactivatedRecordCounts);
         assertNull(deactivatedRecordCountsError.get());
@@ -471,7 +471,7 @@ class ActivePartitionTest {
         assertEquals(1, acknowledgedOffsets.size());
         assertEquals(
                 receiverRecord1.consumerRecord().offset() + 1,
-                acknowledgedOffsets.get(0).nextOffset().offset());
+                acknowledgedOffsets.get(0).prepareCommitment().block().getT2().offset());
         assertNull(acknowledgedOffsetsError.get());
         assertEquals(Arrays.asList(1L, 2L), deactivatedRecordCounts);
         assertNull(deactivatedRecordCountsError.get());

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/AsyncOffsetCommitterTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/AsyncOffsetCommitterTest.java
@@ -7,6 +7,7 @@ import org.apache.kafka.clients.consumer.RetriableCommitFailedException;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
@@ -48,7 +49,7 @@ class AsyncOffsetCommitterTest {
 
         committer
                 .acknowledgementHandlerForAssigned(topicPartition)
-                .accept(new AcknowledgedOffset(consumerOffset, __ -> ""));
+                .accept(new AcknowledgedOffset(consumerOffset, __ -> Mono.just("")));
 
         assertInstanceOf(UnsupportedOperationException.class, error.get());
         assertFalse(committer.isCommitTrialExhausted(topicPartition));
@@ -84,7 +85,7 @@ class AsyncOffsetCommitterTest {
 
         committer
                 .acknowledgementHandlerForAssigned(topicPartition)
-                .accept(new AcknowledgedOffset(consumerOffset, __ -> ""));
+                .accept(new AcknowledgedOffset(consumerOffset, __ -> Mono.just("")));
 
         assertEquals(2, commitAttempts.get());
         assertNull(error.get());
@@ -117,7 +118,7 @@ class AsyncOffsetCommitterTest {
 
         committer
                 .acknowledgementHandlerForAssigned(topicPartition)
-                .accept(new AcknowledgedOffset(consumerOffset, __ -> ""));
+                .accept(new AcknowledgedOffset(consumerOffset, __ -> Mono.just("")));
 
         assertEquals(maxCommitAttempts, commitAttempts.get());
         assertInstanceOf(KafkaException.class, error.get());

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/TestKafkaConfigSourceFactory.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/TestKafkaConfigSourceFactory.java
@@ -23,7 +23,6 @@ public final class TestKafkaConfigSourceFactory {
                 .with(
                         ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
                         OffsetResetStrategy.EARLIEST.name().toLowerCase())
-                .with(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false) // Avoid flakiness with embedded broker
                 .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
                 .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
                 .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName())


### PR DESCRIPTION
### :pencil: Description
- This will help enable non-trivial "offset tracking" by allowing for thread-safe lockless metadata updates

### :link: Related Issues
#544 