### PR TITLE
[#544] Kafka: Introduce "offset tracking" abstraction to control offset behavior

### DIFF
--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
@@ -25,7 +25,7 @@ import java.util.function.ToLongFunction;
  */
 final class ActivePartition {
 
-    private final TopicPartition topicPartition;
+    private final OffsetTracker offsetTracker;
 
     private final AcknowledgementQueue acknowledgementQueue;
 
@@ -47,18 +47,27 @@ final class ActivePartition {
     private final Sinks.Many<Long> deactivatedRecordCounts =
             Sinks.unsafe().many().unicast().onBackpressureError();
 
-    public ActivePartition(TopicPartition topicPartition, AcknowledgementQueueMode acknowledgementQueueMode) {
-        this.topicPartition = topicPartition;
+    public ActivePartition(OffsetTracker offsetTracker, AcknowledgementQueueMode acknowledgementQueueMode) {
+        this.offsetTracker = offsetTracker;
         this.acknowledgementQueue = AcknowledgementQueue.create(acknowledgementQueueMode);
     }
 
     /**
      * Activates a {@link ConsumerRecord} for processing, which is a prerequisite for emission.
-     * This will only return a non-empty result if this partition has not yet been deactivated.
+     * This will only return a non-empty result if this partition has not yet been deactivated,
+     * and if the configured {@link OffsetTracker} does not prohibit processing, based on the given
+     * record's offset.
      */
     public <K, V> Optional<KafkaReceiverRecord<K, V>> activateForProcessing(ConsumerRecord<K, V> consumerRecord) {
-        return activate(ConsumerOffset.create(topicPartition, consumerRecord))
-                .map(it -> KafkaReceiverRecord.create(consumerRecord, () -> ack(it), error -> nack(it, error)));
+        return activate(ConsumerOffset.create(topicPartition(), consumerRecord)).map(it -> {
+            if (offsetTracker.prohibitsProcessing(consumerRecord.offset())) {
+                ack(consumerRecord.offset(), it);
+                return null;
+            } else {
+                long offset = consumerRecord.offset();
+                return KafkaReceiverRecord.create(consumerRecord, () -> ack(offset, it), error -> nack(it, error));
+            }
+        });
     }
 
     /**
@@ -119,10 +128,17 @@ final class ActivePartition {
     }
 
     /**
-     * Returns a publisher of offsets that have been acknowledged and may be directly committed.
+     * Returns a publisher of offsets that have been acknowledged and may be prepared for
+     * commitment. The configured {@link OffsetTracker} may provide an initially committable offset
+     * which can be used to create an initially acknowledgeable offset through which updated
+     * metadata can be attached. Such updated metadata is created and subscribed via delegation to
+     * the offset tracker for all acknowledged offsets.
      */
     public Flux<AcknowledgedOffset> acknowledgedOffsets() {
-        return consumerOffsetsOfAcknowledged.asFlux().map(it -> new AcknowledgedOffset(it, __ -> Mono.just("")));
+        return Mono.justOrEmpty(offsetTracker.initiallyCommittableOffset())
+                .map(it -> new ConsumerOffset(topicPartition(), it - 1))
+                .concatWith(consumerOffsetsOfAcknowledged.asFlux())
+                .map(it -> new AcknowledgedOffset(it, offsetTracker::commitMetadata));
     }
 
     public Flux<Long> deactivatedRecordCounts() {
@@ -130,7 +146,7 @@ final class ActivePartition {
     }
 
     public TopicPartition topicPartition() {
-        return topicPartition;
+        return offsetTracker.topicPartition();
     }
 
     private Optional<AcknowledgementQueue.InFlight> activate(ConsumerOffset consumerOffset) {
@@ -149,7 +165,8 @@ final class ActivePartition {
         }
     }
 
-    private void ack(AcknowledgementQueue.InFlight inFlight) {
+    private void ack(long offset, AcknowledgementQueue.InFlight inFlight) {
+        offsetTracker.acknowledged(offset);
         acknowledge(queue -> queue.complete(inFlight));
     }
 

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/ConsumerOffset.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/ConsumerOffset.java
@@ -19,7 +19,7 @@ public final class ConsumerOffset {
 
     private final Optional<Integer> leaderEpoch;
 
-    public ConsumerOffset(TopicPartition topicPartition, long offset) {
+    ConsumerOffset(TopicPartition topicPartition, long offset) {
         this(topicPartition, offset, Optional.empty());
     }
 

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/KafkaBoundedReceiver.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/KafkaBoundedReceiver.java
@@ -109,7 +109,7 @@ public class KafkaBoundedReceiver<K, V> {
         KafkaReceiverOptions<K, V> receiverOptions = KafkaReceiverOptions.<K, V>newBuilder()
                 .consumerListener(ConsumerListener.seekOnce(recordRange.topicPartition(), recordRange.minInclusive()))
                 .consumerProperties(kafkaConfig.nativeProperties())
-                .commitlessOffsets(true)
+                .commitlessOffsetTracking()
                 .pollTimeout(kafkaConfig.loadDuration(POLL_TIMEOUT_CONFIG).orElse(DEFAULT_POLL_TIMEOUT))
                 .closeTimeout(kafkaConfig.loadDuration(CLOSE_TIMEOUT_CONFIG).orElse(DEFAULT_CLOSE_TIMEOUT))
                 .build();

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/KafkaReceiverOptions.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/KafkaReceiverOptions.java
@@ -68,7 +68,7 @@ public final class KafkaReceiverOptions<K, V> {
 
     private final int maxCommitAttempts;
 
-    private final boolean commitlessOffsets;
+    private final OffsetTrackingStrategy offsetTrackingStrategy;
 
     private final Duration revocationGracePeriod;
 
@@ -91,7 +91,7 @@ public final class KafkaReceiverOptions<K, V> {
             Duration commitPeriod,
             Duration commitTimeout,
             int maxCommitAttempts,
-            boolean commitlessOffsets,
+            OffsetTrackingStrategy offsetTrackingStrategy,
             Duration revocationGracePeriod,
             Duration terminationGracePeriod,
             Duration closeTimeout) {
@@ -109,7 +109,7 @@ public final class KafkaReceiverOptions<K, V> {
         this.commitPeriod = commitPeriod;
         this.commitTimeout = commitTimeout;
         this.maxCommitAttempts = maxCommitAttempts;
-        this.commitlessOffsets = commitlessOffsets;
+        this.offsetTrackingStrategy = offsetTrackingStrategy;
         this.revocationGracePeriod = revocationGracePeriod;
         this.terminationGracePeriod = terminationGracePeriod;
         this.closeTimeout = closeTimeout;
@@ -148,7 +148,7 @@ public final class KafkaReceiverOptions<K, V> {
                 .commitPeriod(commitPeriod)
                 .commitTimeout(commitTimeout)
                 .maxCommitAttempts(maxCommitAttempts)
-                .commitlessOffsets(commitlessOffsets)
+                .offsetTrackingStrategy(offsetTrackingStrategy)
                 .revocationGracePeriod(revocationGracePeriod)
                 .terminationGracePeriod(terminationGracePeriod)
                 .closeTimeout(closeTimeout);
@@ -273,8 +273,17 @@ public final class KafkaReceiverOptions<K, V> {
     /**
      * @see Builder#commitlessOffsets(boolean)
      */
+    @Deprecated
     public boolean commitlessOffsets() {
-        return commitlessOffsets;
+        return offsetTrackingStrategy instanceof OffsetTrackingStrategy.Commitless;
+    }
+
+    /**
+     * @see Builder#simpleOffsetTracking()
+     * @see Builder#commitlessOffsetTracking()
+     */
+    public OffsetTrackingStrategy offsetTrackingStrategy() {
+        return offsetTrackingStrategy;
     }
 
     /**
@@ -364,7 +373,7 @@ public final class KafkaReceiverOptions<K, V> {
 
         private int maxCommitAttempts = DEFAULT_MAX_COMMIT_ATTEMPTS;
 
-        private boolean commitlessOffsets = false;
+        private OffsetTrackingStrategy offsetTrackingStrategy = OffsetTrackingStrategy.simple();
 
         private Duration revocationGracePeriod = DEFAULT_REVOCATION_GRACE_PERIOD;
 
@@ -537,10 +546,33 @@ public final class KafkaReceiverOptions<K, V> {
         /**
          * Configures whether offset commitment is disabled, which can be useful for stateless
          * consumption.
+         * @deprecated Use {@link #commitlessOffsetTracking()}
          */
+        @Deprecated
         public Builder<K, V> commitlessOffsets(boolean commitlessOffsets) {
-            this.commitlessOffsets = commitlessOffsets;
-            return this;
+            if (commitlessOffsets) {
+                return commitlessOffsetTracking();
+            } else if (offsetTrackingStrategy instanceof OffsetTrackingStrategy.Commitless) {
+                return simpleOffsetTracking();
+            } else if (offsetTrackingStrategy instanceof OffsetTrackingStrategy.Simple) {
+                return this;
+            } else {
+                throw new UnsupportedOperationException("Cannot disable commitless offsets with non-trivial strategy");
+            }
+        }
+
+        /**
+         * Sets (or resets) offset tracking strategy to {@link OffsetTrackingStrategy#simple()}.
+         */
+        public Builder<K, V> simpleOffsetTracking() {
+            return offsetTrackingStrategy(OffsetTrackingStrategy.simple());
+        }
+
+        /**
+         * Sets offset tracking strategy to {@link OffsetTrackingStrategy#commitless()}.
+         */
+        public Builder<K, V> commitlessOffsetTracking() {
+            return offsetTrackingStrategy(OffsetTrackingStrategy.commitless());
         }
 
         /**
@@ -581,6 +613,11 @@ public final class KafkaReceiverOptions<K, V> {
             return this;
         }
 
+        private Builder<K, V> offsetTrackingStrategy(OffsetTrackingStrategy offsetTrackingStrategy) {
+            this.offsetTrackingStrategy = offsetTrackingStrategy;
+            return this;
+        }
+
         public KafkaReceiverOptions<K, V> build() {
             return new KafkaReceiverOptions<>(
                     consumerSupplierFactory,
@@ -597,7 +634,7 @@ public final class KafkaReceiverOptions<K, V> {
                     commitPeriod,
                     commitTimeout,
                     maxCommitAttempts,
-                    commitlessOffsets,
+                    offsetTrackingStrategy,
                     revocationGracePeriod,
                     terminationGracePeriod,
                     closeTimeout);

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/OffsetTracker.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/OffsetTracker.java
@@ -1,0 +1,124 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.common.TopicPartition;
+import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+
+/**
+ * Per-partition tracker of processing based on offsets. Each instance is specific to a single
+ * assignment lifecycle of a partition being consumed/processed. Non-trivial implementations may
+ * keep track of record offsets that have been acknowledged, and expose that state as serializable
+ * metadata. Implementations may also control native commitment of offsets with metadata to
+ * associate with commitments, or disable native commitment altogether.
+ */
+public interface OffsetTracker {
+
+    /**
+     * Facilitates default offset tracking behavior, where no records are prohibited from
+     * processing and commitment metadata is blank.
+     */
+    static OffsetTracker simple(TopicPartition partition) {
+        return new Simple(partition);
+    }
+
+    /**
+     * Facilitates effectively stateless/empty offset tracking behavior, where no records are
+     * prohibited from processing and native commitment is skipped.
+     */
+    static OffsetTracker commitless(TopicPartition partition) {
+        return new Commitless(partition);
+    }
+
+    /**
+     * Indicates whether the provided offset identifies a record for which processing is
+     * prohibited. This can be used to skip processing of targeted records, e.g. if they have been
+     * previously acknowledged.
+     */
+    boolean prohibitsProcessing(long offset);
+
+    /**
+     * Hook for notification on acknowledgement of {@link ConsumerOffset} with given offset.
+     */
+    void acknowledged(long offset);
+
+    /**
+     * Invoked when commitment is being prepared, subscribed when commitment is executed. Returning
+     * an empty {@link Mono} (e.g. {@code Mono.empty()})  will cause native commitment to be
+     * skipped. Note that this is not the same as returning <i>blank</i> metadata (e.g.
+     * {@code Mono.just("")}), which still triggers native commitment with that blank metadata.
+     */
+    Mono<String> commitMetadata(long commitOffset);
+
+    /**
+     * Initial offset that may be used as commitment offset, which is useful if commitment data may
+     * update prior to a subsequent offset being made available for commit.
+     */
+    Optional<Long> initiallyCommittableOffset();
+
+    TopicPartition topicPartition();
+
+    final class Simple implements OffsetTracker {
+
+        private final TopicPartition topicPartition;
+
+        private Simple(TopicPartition partition) {
+            this.topicPartition = partition;
+        }
+
+        @Override
+        public boolean prohibitsProcessing(long offset) {
+            return false;
+        }
+
+        @Override
+        public void acknowledged(long offset) {}
+
+        @Override
+        public Mono<String> commitMetadata(long commitOffset) {
+            return Mono.just("");
+        }
+
+        @Override
+        public Optional<Long> initiallyCommittableOffset() {
+            return Optional.empty();
+        }
+
+        @Override
+        public TopicPartition topicPartition() {
+            return topicPartition;
+        }
+    }
+
+    final class Commitless implements OffsetTracker {
+
+        private final TopicPartition topicPartition;
+
+        private Commitless(TopicPartition topicPartition) {
+            this.topicPartition = topicPartition;
+        }
+
+        @Override
+        public boolean prohibitsProcessing(long offset) {
+            return false;
+        }
+
+        @Override
+        public void acknowledged(long offset) {}
+
+        @Override
+        public Mono<String> commitMetadata(long commitOffset) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Optional<Long> initiallyCommittableOffset() {
+            return Optional.empty();
+        }
+
+        @Override
+        public TopicPartition topicPartition() {
+            return topicPartition;
+        }
+    }
+}

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/OffsetTrackingStrategy.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/OffsetTrackingStrategy.java
@@ -1,0 +1,58 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Characterizes "strategy" for how offset state is managed during the course of assignment and
+ * processing from any given {@link TopicPartition}.
+ */
+public interface OffsetTrackingStrategy {
+
+    /**
+     * Strategy that assigns {@link OffsetTracker#simple(TopicPartition)} to all assigned
+     * partitions.
+     */
+    static OffsetTrackingStrategy simple() {
+        return new Simple();
+    }
+
+    /**
+     * Strategy that assigns {@link OffsetTracker#commitless(TopicPartition)} to all assigned
+     * partitions.
+     */
+    static OffsetTrackingStrategy commitless() {
+        return new Commitless();
+    }
+
+    /**
+     * Creates a {@link Collection} of {@link OffsetTracker} instances for each of the
+     * provided/assigned {@link TopicPartition}s. Implementations should return an entry for each
+     * given partition.
+     */
+    Collection<OffsetTracker> assignTrackers(Consumer<?, ?> consumer, Collection<TopicPartition> partitions);
+
+    final class Simple implements OffsetTrackingStrategy {
+
+        private Simple() {}
+
+        @Override
+        public List<OffsetTracker> assignTrackers(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+            return partitions.stream().map(OffsetTracker::simple).collect(Collectors.toList());
+        }
+    }
+
+    final class Commitless implements OffsetTrackingStrategy {
+
+        private Commitless() {}
+
+        @Override
+        public List<OffsetTracker> assignTrackers(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+            return partitions.stream().map(OffsetTracker::commitless).collect(Collectors.toList());
+        }
+    }
+}

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
@@ -2,7 +2,6 @@ package io.atleon.kafka;
 
 import io.atleon.core.SerialQueue;
 import io.atleon.core.ShouldBeTerminatedEmitFailureHandler;
-import io.atleon.util.Consuming;
 import io.atleon.util.Publishing;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
@@ -26,7 +25,6 @@ import reactor.util.function.Tuples;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -144,9 +142,10 @@ final class PollingSubscriptionFactory<K, V> {
         }
 
         @Override
-        public final void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
-            pollManager.activateAssigned(consumer, partitions, partition -> {
-                ActivePartition activePartition = new ActivePartition(partition, options.acknowledgementQueueMode());
+        public final void onPartitionsAssigned(Consumer<?, ?> consumer, Map<TopicPartition, OffsetTracker> assignment) {
+            pollManager.activateAssigned(consumer, assignment.keySet(), partition -> {
+                ActivePartition activePartition =
+                        new ActivePartition(assignment.get(partition), options.acknowledgementQueueMode());
                 onPartitionActivated(consumer, activePartition);
                 listener.onPartitionActivated(partition);
 
@@ -375,9 +374,8 @@ final class PollingSubscriptionFactory<K, V> {
 
         @Override
         protected void onPartitionActivated(Consumer<?, ?> consumer, ActivePartition partition) {
-            java.util.function.Consumer<AcknowledgedOffset> acknowledgementHandler = options.commitlessOffsets()
-                    ? Consuming.noOp()
-                    : asyncOffsetCommitter.acknowledgementHandlerForAssigned(partition.topicPartition());
+            java.util.function.Consumer<AcknowledgedOffset> acknowledgementHandler =
+                    asyncOffsetCommitter.acknowledgementHandlerForAssigned(partition.topicPartition());
             partition.acknowledgedOffsets().subscribe(acknowledgementHandler, this::failSafely);
         }
 
@@ -406,8 +404,7 @@ final class PollingSubscriptionFactory<K, V> {
                     prepareCommit(latestAcknowledgedOffsets).as(Publishing::cacheSuccess);
 
             try {
-                Map<TopicPartition, OffsetAndMetadata> offsetsToCommit =
-                        options.commitlessOffsets() ? Collections.emptyMap() : preparedOffsetsToCommit.block();
+                Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = preparedOffsetsToCommit.block();
                 if (!offsetsToCommit.isEmpty()) {
                     LOGGER.info("Committing offsets on revocation: {}", offsetsToCommit);
                     consumer.commitSync(offsetsToCommit, options.commitTimeout());
@@ -626,7 +623,7 @@ final class PollingSubscriptionFactory<K, V> {
 
         private void maybeSendOffsetsInCurrentTransaction(Map<TopicPartition, OffsetAndMetadata> offsets) {
             if (capState.compareAndSet(0, TxCapStates.OFFSETTING)) {
-                if (!options.commitlessOffsets()) {
+                if (!offsets.isEmpty()) {
                     transact(it -> it.sendOffsets(offsets, groupMetadata), () -> {
                         if (capState.compareAndSet(TxCapStates.OFFSETTING, TxCapStates.COMMITTABLE)) {
                             drain();

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/ReceivingConsumer.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/ReceivingConsumer.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
@@ -55,6 +56,8 @@ final class ReceivingConsumer<K, V> implements ConsumerRebalanceListener, Consum
 
     private final Consumer<K, V> externalConsumerProxy;
 
+    private final OffsetTrackingStrategy offsetTrackingStrategy;
+
     private final PartitionListener partitionListener;
 
     private final TaskLoop taskLoop;
@@ -71,6 +74,7 @@ final class ReceivingConsumer<K, V> implements ConsumerRebalanceListener, Consum
             java.util.function.Consumer<Throwable> errorHandler) {
         this.consumer = options.createConsumer();
         this.externalConsumerProxy = Proxying.interfaceMethods(Consumer.class, this::invokeConsumerFromExternal);
+        this.offsetTrackingStrategy = options.offsetTrackingStrategy();
         this.partitionListener = partitionListener;
         this.taskLoop = TaskLoop.start(options.loadConsumerTaskLoopName(), it -> runSafely(it, errorHandler));
         this.consumerListener = options.createConsumerListener(this);
@@ -107,9 +111,9 @@ final class ReceivingConsumer<K, V> implements ConsumerRebalanceListener, Consum
                 assignment.stream().filter(it -> !validAssignment.contains(it)).collect(Collectors.toList());
         if (!invalidAssignment.isEmpty()) {
             throw new IllegalStateException("After rebalancing, there are partitions currently assigned that are"
-                    + " missing from the onPartitionsAssigned callback. These partitions have either never been assigned to"
-                    + " this consumer, or (more likely) were just recently revoked. This is suspected to be a bug in the"
-                    + " Kafka Consumer implementation that could lead to skipped records due to improper position"
+                    + " missing from the onPartitionsAssigned callback. These partitions have either never been assigned"
+                    + " to this consumer, or (more likely) were just recently revoked. This is suspected to be a bug in"
+                    + " the Kafka Consumer implementation that could lead to skipped records due to improper position"
                     + " management on partition reassignment. For future debugging, this condition tends to be correlated"
                     + " with paused partitions being revoked, followed by interruption to the rebalance process due to"
                     + " invoking Consumer.wakeup(). The affected partitions are: "
@@ -124,7 +128,7 @@ final class ReceivingConsumer<K, V> implements ConsumerRebalanceListener, Consum
         // Not wrapping with try-catch. If user does something naughty, let the error be emitted.
         consumerListener.onPartitionsAssigned(externalConsumerProxy, partitions);
         // Done after external listening to account for possible seeking or metadata updates.
-        partitionListener.onPartitionsAssigned(consumer, partitions);
+        partitionListener.onPartitionsAssigned(consumer, assignOffsetTrackers(partitions));
     }
 
     @Override
@@ -177,6 +181,11 @@ final class ReceivingConsumer<K, V> implements ConsumerRebalanceListener, Consum
         externalHandler.accept(externalConsumerProxy, partitions);
     }
 
+    private Map<TopicPartition, OffsetTracker> assignOffsetTrackers(Collection<TopicPartition> partitions) {
+        return offsetTrackingStrategy.assignTrackers(externalConsumerProxy, partitions).stream()
+                .collect(Collectors.toMap(OffsetTracker::topicPartition, Function.identity()));
+    }
+
     private Object invokeConsumerFromExternal(Method method, Object[] args) throws ReflectiveOperationException {
         if (!taskLoop.isSourceOfCurrentThread()) {
             throw new UnsupportedOperationException("Kafka Consumer must be invoked from polling thread");
@@ -215,7 +224,7 @@ final class ReceivingConsumer<K, V> implements ConsumerRebalanceListener, Consum
 
     public interface PartitionListener {
 
-        void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions);
+        void onPartitionsAssigned(Consumer<?, ?> consumer, Map<TopicPartition, OffsetTracker> assignment);
 
         void onPartitionsRevoked(Consumer<?, ?> consumer, Collection<TopicPartition> partitions);
 

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
@@ -2,8 +2,10 @@ package io.atleon.kafka;
 
 import io.atleon.core.AcknowledgementQueueMode;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Test;
+import org.mockito.AdditionalAnswers;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 import reactor.core.scheduler.Schedulers;
@@ -14,10 +16,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -26,6 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ActivePartitionTest {
 
@@ -36,7 +44,7 @@ class ActivePartitionTest {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -53,7 +61,7 @@ class ActivePartitionTest {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -69,11 +77,67 @@ class ActivePartitionTest {
     }
 
     @Test
+    public void activateForProcessing_givenOffsetTrackerProhibitsProcessing_expectsRecordAcknowledgedWithoutEmission() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        List<Long> deactivatedRecordCounts = new ArrayList<>();
+
+        ActivePartition activePartition =
+                new ActivePartition(prohibitingOffsetTracker(1L), AcknowledgementQueueMode.STRICT);
+        activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
+        activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
+
+        ConsumerRecord<String, String> allowedRecord = newConsumerRecord(0);
+        ConsumerRecord<String, String> prohibitedRecord = newConsumerRecord(1);
+        Optional<KafkaReceiverRecord<String, String>> allowed = activePartition.activateForProcessing(allowedRecord);
+        Optional<KafkaReceiverRecord<String, String>> prohibited =
+                activePartition.activateForProcessing(prohibitedRecord);
+
+        assertFalse(prohibited.isPresent());
+        assertTrue(allowed.isPresent());
+        assertTrue(acknowledgedOffsets.isEmpty());
+        assertTrue(deactivatedRecordCounts.isEmpty());
+
+        allowed.get().acknowledge();
+        assertEquals(2, acknowledgedOffsets.size());
+        assertEquals(Collections.singletonList(2L), deactivatedRecordCounts);
+        assertEquals(
+                allowedRecord.offset(),
+                acknowledgedOffsets.get(0).consumerOffset().offset());
+        assertEquals(
+                prohibitedRecord.offset(),
+                acknowledgedOffsets.get(1).consumerOffset().offset());
+    }
+
+    @Test
+    public void acknowledgedOffsets_givenInitiallyCommittableOffset_expectsAcknowledgedOffsetWithUpdatedMetadata() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+
+        long initiallyCommittableOffset = 5L;
+        ActivePartition activePartition = new ActivePartition(
+                committableOffsetTracker(initiallyCommittableOffset), AcknowledgementQueueMode.STRICT);
+        activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
+
+        // Even without any record being acknowledged, an initially committable offset is emitted as
+        // an acknowledged offset eligible for (re)commitment. Its underlying consumer offset is one
+        // less than the committable offset, since the committed offset is the numerical increment.
+        assertEquals(1, acknowledgedOffsets.size());
+        assertEquals(
+                initiallyCommittableOffset - 1,
+                acknowledgedOffsets.get(0).consumerOffset().offset());
+
+        // On commitment, the offset tracker supplies updated metadata for the committable offset.
+        OffsetAndMetadata committed =
+                acknowledgedOffsets.get(0).prepareCommitment().block().getT2();
+        assertEquals(initiallyCommittableOffset, committed.offset());
+        assertEquals("metadata-" + initiallyCommittableOffset, committed.metadata());
+    }
+
+    @Test
     public void acknowledge_givenActivatedRecordIsAcknowledged_expectsCorrectAcknowledgements() {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -93,7 +157,7 @@ class ActivePartitionTest {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -132,7 +196,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add, acknowledgedOffsetsError::set);
         activePartition
                 .deactivatedRecordCounts()
@@ -161,7 +225,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add, acknowledgedOffsetsError::set);
         activePartition
                 .deactivatedRecordCounts()
@@ -203,7 +267,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -244,7 +308,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -299,7 +363,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -346,7 +410,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -395,7 +459,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -431,7 +495,7 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         CompletableFuture<Void> deactivatedRecordCountsCompletion = new CompletableFuture<>();
 
-        ActivePartition activePartition = new ActivePartition(TOPIC_PARTITION, AcknowledgementQueueMode.STRICT);
+        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .publishOn(Schedulers.boundedElastic())
@@ -479,5 +543,27 @@ class ActivePartitionTest {
 
     private static ConsumerRecord<String, String> newConsumerRecord(int offset) {
         return new ConsumerRecord<>(TOPIC_PARTITION.topic(), TOPIC_PARTITION.partition(), offset, "key", "value");
+    }
+
+    private static OffsetTracker prohibitingOffsetTracker(Long... prohibitedOffsets) {
+        Set<Long> prohibited = Stream.of(prohibitedOffsets).collect(Collectors.toSet());
+        OffsetTracker offsetTracker = mock(OffsetTracker.class, AdditionalAnswers.delegatesTo(newOffsetTracker()));
+        when(offsetTracker.prohibitsProcessing(anyLong())).thenAnswer(invocation -> {
+            Long offset = invocation.getArgument(0);
+            return prohibited.contains(offset);
+        });
+        return offsetTracker;
+    }
+
+    private static OffsetTracker committableOffsetTracker(long initiallyCommittableOffset) {
+        OffsetTracker offsetTracker = mock(OffsetTracker.class, AdditionalAnswers.delegatesTo(newOffsetTracker()));
+        when(offsetTracker.initiallyCommittableOffset()).thenReturn(Optional.of(initiallyCommittableOffset));
+        when(offsetTracker.commitMetadata(anyLong()))
+                .thenAnswer(invocation -> Mono.just("metadata-" + invocation.<Long>getArgument(0)));
+        return offsetTracker;
+    }
+
+    private static OffsetTracker newOffsetTracker() {
+        return OffsetTracker.simple(TOPIC_PARTITION);
     }
 }

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/KafkaReceiverTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/KafkaReceiverTest.java
@@ -130,7 +130,7 @@ class KafkaReceiverTest {
         ConsumerListener.Closure closureListener = ConsumerListener.closure();
         KafkaReceiverOptions<String, String> receiverOptions = newStringReceiverOptionsBuilder()
                 .consumerListener(closureListener)
-                .commitlessOffsets(true)
+                .commitlessOffsetTracking()
                 .build();
 
         KafkaReceiver.create(receiverOptions)
@@ -387,11 +387,12 @@ class KafkaReceiverTest {
                 KafkaSenderRecord.create(topic, partition, "key", "value1", null),
                 KafkaSenderRecord.create(topic, partition, "key", "value2", null));
 
-        KafkaReceiverOptions<String, String> receiverOptions = KafkaReceiverOptions.<String, String>newBuilder()
+        KafkaReceiverOptions.Builder<String, String> optionsBuilder = KafkaReceiverOptions.<String, String>newBuilder()
                 .consumerProperties(newStringConsumerProperties(groupId))
-                .commitBatchSize(2)
-                .commitlessOffsets(commitlessOffsets)
-                .build();
+                .commitBatchSize(2);
+        KafkaReceiverOptions<String, String> receiverOptions = commitlessOffsets
+                ? optionsBuilder.commitlessOffsetTracking().build()
+                : optionsBuilder.simpleOffsetTracking().build();
 
         KafkaTxManager txManager = mock(KafkaTxManager.class);
         when(txManager.begin()).thenReturn(Mono.empty());
@@ -796,7 +797,7 @@ class KafkaReceiverTest {
     private static <C extends Collection<Long>> C receiveLongValues(
             String topic, OffsetRangeProvider offsetRangeProvider, Collector<Long, ?, C> collector) {
         KafkaReceiverOptions<Long, Long> receiverOptions =
-                newLongReceiverOptionsBuilder().commitlessOffsets(true).build();
+                newLongReceiverOptionsBuilder().commitlessOffsetTracking().build();
         return receiveLongValues(receiverOptions, topic, offsetRangeProvider, collector);
     }
 

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/ReceivingConsumerTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/ReceivingConsumerTest.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -235,7 +236,7 @@ class ReceivingConsumerTest {
     public static class NoOpPartitionListener implements ReceivingConsumer.PartitionListener {
 
         @Override
-        public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {}
+        public void onPartitionsAssigned(Consumer<?, ?> consumer, Map<TopicPartition, OffsetTracker> assignment) {}
 
         @Override
         public void onPartitionsRevoked(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {}


### PR DESCRIPTION
### :pencil: Description
- Add `OffsetTrackingStrategy` and `OffsetTracker` abstractions used by ActivePartition
- Enable tracking offsets of records emitted for processing and subsequent acknowledgement
- Enable prohibition of processing for records with given offsets
- Enable control of if/when native commitment happens
- Enable consistent metadata management alongside offset commitment
- Replace `commitlessOffsets` flag with offset tracking strategy usage

### :link: Related Issues
#544 
