### PR TITLE
[#544] Kafka: Enable non-volatile ahead-of-commit offset tracking

### DIFF
--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
@@ -129,14 +129,13 @@ final class ActivePartition {
 
     /**
      * Returns a publisher of offsets that have been acknowledged and may be prepared for
-     * commitment. The configured {@link OffsetTracker} may provide an initially committable offset
-     * which can be used to create an initially acknowledgeable offset through which updated
-     * metadata can be attached. Such updated metadata is created and subscribed via delegation to
-     * the offset tracker for all acknowledged offsets.
+     * commitment. The configured {@link OffsetTracker} may provide an initial consumer offset
+     * which can be used to create an initial acknowledgeable offset through which updated metadata
+     * can be attached. Such updated metadata is created and subscribed via delegation to the
+     * offset tracker for all acknowledged offsets.
      */
     public Flux<AcknowledgedOffset> acknowledgedOffsets() {
-        return Mono.justOrEmpty(offsetTracker.initiallyCommittableOffset())
-                .map(it -> new ConsumerOffset(topicPartition(), it - 1))
+        return Mono.justOrEmpty(offsetTracker.initialConsumerOffset())
                 .concatWith(consumerOffsetsOfAcknowledged.asFlux())
                 .map(it -> new AcknowledgedOffset(it, offsetTracker::commitMetadata));
     }

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/AloKafkaReceiver.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/AloKafkaReceiver.java
@@ -64,6 +64,19 @@ public class AloKafkaReceiver<K, V> {
     public static final String CONFIG_PREFIX = "kafka.receiver.";
 
     /**
+     * Configures the {@link OffsetTrackingStrategy} used to control behavior of offset state
+     * management.
+     *
+     * @see OffsetTrackingStrategy
+     */
+    public static final String OFFSET_TRACKING_STRATEGY_CONFIG = CONFIG_PREFIX + "offset.tracking.strategy";
+
+    public static final String OFFSET_TRACKING_STRATEGY_TYPE_SIMPLE = "simple";
+
+    public static final String OFFSET_TRACKING_STRATEGY_TYPE_ACKNOWLEDGED_AHEAD_OF_COMMIT =
+            "acknowledged-ahead-of-commit";
+
+    /**
      * Configures the operating mode of the Acknowledgement Queue used to maintain commitment order
      * of consumer offsets. By default, the mode is STRICT, where any given record's offset is not
      * committed until all records received before it have been committed, and each record's offset
@@ -108,6 +121,7 @@ public class AloKafkaReceiver<K, V> {
      * When negative acknowledgement results in emitting the corresponding error, this configures
      * the timeout on successfully emitting that error.
      */
+    @Deprecated
     public static final String ERROR_EMISSION_TIMEOUT_CONFIG = CONFIG_PREFIX + "error.emission.timeout";
 
     /**
@@ -483,6 +497,7 @@ public class AloKafkaReceiver<K, V> {
                     .commitPeriod(config.loadDuration(COMMIT_INTERVAL_CONFIG).orElse(defaultOptions.commitPeriod()))
                     .maxCommitAttempts(
                             config.loadInt(MAX_COMMIT_ATTEMPTS_CONFIG).orElse(defaultOptions.maxCommitAttempts()))
+                    .offsetTrackingStrategy(loadOffsetTrackingStrategy().orElseGet(OffsetTrackingStrategy::simple))
                     .revocationGracePeriod(loadRevocationGracePeriod().orElse(defaultOptions.revocationGracePeriod()))
                     .terminationGracePeriod(config.loadDuration(TERMINATION_GRACE_PERIOD_CONFIG)
                             .orElse(defaultOptions.terminationGracePeriod()))
@@ -501,6 +516,13 @@ public class AloKafkaReceiver<K, V> {
                             CommonClientConfigs.CLIENT_ID_CONFIG, (__, id) -> incrementId(id.toString()));
                 }
             });
+        }
+
+        private Optional<OffsetTrackingStrategy> loadOffsetTrackingStrategy() {
+            return config.loadInstanceWithPredefinedTypes(
+                    OFFSET_TRACKING_STRATEGY_CONFIG,
+                    OffsetTrackingStrategy.class,
+                    ReceiveResources::newPredefinedOffsetTrackingStrategy);
         }
 
         private Optional<Duration> loadRevocationGracePeriod() {
@@ -535,6 +557,16 @@ public class AloKafkaReceiver<K, V> {
                 aloRecords = aloRecords.tap(factory);
             }
             return aloRecords;
+        }
+
+        private static Optional<OffsetTrackingStrategy> newPredefinedOffsetTrackingStrategy(String typeName) {
+            if (typeName.equalsIgnoreCase(OFFSET_TRACKING_STRATEGY_TYPE_SIMPLE)) {
+                return Optional.of(OffsetTrackingStrategy.simple());
+            } else if (typeName.equalsIgnoreCase(OFFSET_TRACKING_STRATEGY_TYPE_ACKNOWLEDGED_AHEAD_OF_COMMIT)) {
+                return Optional.of(OffsetTrackingStrategy.acknowledgedAheadOfCommit());
+            } else {
+                return Optional.empty();
+            }
         }
 
         private static PollStrategyFactory createPollStrategyFactory(KafkaConfig config) {

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/ConsumerOffset.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/ConsumerOffset.java
@@ -23,7 +23,7 @@ public final class ConsumerOffset {
         this(topicPartition, offset, Optional.empty());
     }
 
-    private ConsumerOffset(TopicPartition topicPartition, long offset, Optional<Integer> leaderEpoch) {
+    ConsumerOffset(TopicPartition topicPartition, long offset, Optional<Integer> leaderEpoch) {
         this.topicPartition = topicPartition;
         this.offset = offset;
         this.leaderEpoch = leaderEpoch;

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/ConsumerPartition.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/ConsumerPartition.java
@@ -1,0 +1,56 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.LongUnaryOperator;
+import java.util.stream.Collectors;
+
+/**
+ * Encapsulates a {@link TopicPartition} that is either being or will imminently be consumed, with
+ * extra metadata available at the time of instantiation. This is useful, for example, when the
+ * given partition has been assigned and associated resource initialization needs access to the
+ * current {@link Consumer#position(TopicPartition) position} and/or committed
+ * {@link OffsetAndMetadata}.
+ */
+public final class ConsumerPartition {
+
+    private final TopicPartition topicPartition;
+
+    private final long position;
+
+    private final @Nullable OffsetAndMetadata committed;
+
+    private ConsumerPartition(TopicPartition topicPartition, long position, @Nullable OffsetAndMetadata committed) {
+        this.topicPartition = topicPartition;
+        this.committed = committed;
+        this.position = position;
+    }
+
+    public static List<ConsumerPartition> create(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+        Set<TopicPartition> partitionSet = new LinkedHashSet<>(partitions);
+        Map<TopicPartition, OffsetAndMetadata> committedByPartition = consumer.committed(partitionSet);
+        return partitionSet.stream()
+                .map(it -> new ConsumerPartition(it, consumer.position(it), committedByPartition.get(it)))
+                .collect(Collectors.toList());
+    }
+
+    public ConsumerOffset newOffsetFromPosition(LongUnaryOperator positionToOffset) {
+        long offset = positionToOffset.applyAsLong(position);
+        return committed != null
+                ? new ConsumerOffset(topicPartition, offset, committed.leaderEpoch())
+                : new ConsumerOffset(topicPartition, offset);
+    }
+
+    public Optional<String> committedMetadata() {
+        return Optional.ofNullable(committed).map(OffsetAndMetadata::metadata);
+    }
+}

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/KafkaReceiverOptions.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/KafkaReceiverOptions.java
@@ -576,6 +576,13 @@ public final class KafkaReceiverOptions<K, V> {
         }
 
         /**
+         * Sets offset tracking strategy to {@link OffsetTrackingStrategy#acknowledgedAheadOfCommit()}.
+         */
+        public Builder<K, V> acknowledgedAheadOfCommitOffsetTracking() {
+            return offsetTrackingStrategy(OffsetTrackingStrategy.acknowledgedAheadOfCommit());
+        }
+
+        /**
          * Configures the maximum amount of time that will be awaited for in-flight records to be
          * acknowledged from a partition whose assignment is being revoked. The latest acknowledged
          * offsets from such a partition are then used to issue one last commit before
@@ -613,7 +620,7 @@ public final class KafkaReceiverOptions<K, V> {
             return this;
         }
 
-        private Builder<K, V> offsetTrackingStrategy(OffsetTrackingStrategy offsetTrackingStrategy) {
+        Builder<K, V> offsetTrackingStrategy(OffsetTrackingStrategy offsetTrackingStrategy) {
             this.offsetTrackingStrategy = offsetTrackingStrategy;
             return this;
         }

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/OffsetMetadataEncoding.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/OffsetMetadataEncoding.java
@@ -1,0 +1,283 @@
+package io.atleon.kafka;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.PrimitiveIterator;
+import java.util.function.LongConsumer;
+import java.util.zip.CRC32;
+import java.util.zip.CheckedOutputStream;
+import java.util.zip.Checksum;
+
+/**
+ * Encodes a set of {@link Offsets} into a compact, Base64-encoded {@link String} suitable for use
+ * as Kafka offset commit metadata, and decodes it back again. Offsets are stored relative to a
+ * base offset (typically decremented commit offset) as a sequence of "delta-runs" (a delta paired
+ * with a repetition count), keeping the encoding proportional to the number of distinct gaps
+ * rather than the number of offsets.
+ *
+ * <p>The serialized layout is {@code [version][offset count][delta-runs][checksum]}, where
+ * deltas and counts are written as unsigned variable-length long values, and a trailing CRC32
+ * checksum (seeded with the base offset) guards against corruption and base-offset mismatch.
+ *
+ * <p>Encoding is bounded by {@code maxSizeOnWrite}: if the offsets do not fit, the leading
+ * delta-runs that do fit are retained and the remainder are truncated. {@link #decode(long, String)}
+ * is lenient, returning empty {@link Offsets} (rather than throwing) on any malformed, corrupt, or
+ * version-incompatible input.
+ */
+final class OffsetMetadataEncoding {
+
+    private static final byte VERSION = 1;
+
+    private static final byte RUN_MARKER = 0;
+
+    private static final byte[] EMPTY_BYTES = new byte[0];
+
+    private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder().withoutPadding();
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OffsetMetadataEncoding.class);
+
+    private final int maxSizeOnWrite;
+
+    public OffsetMetadataEncoding(int maxSizeOnWrite) {
+        this.maxSizeOnWrite = maxSizeOnWrite;
+    }
+
+    public String encode(long baseOffset, Offsets offsets) {
+        // Take Base64 expansion into account when calculating max serialization bytes
+        int maxBytes = maxSizeOnWrite < Integer.MAX_VALUE ? (int) ((long) maxSizeOnWrite * 3 / 4) : Integer.MAX_VALUE;
+        return BASE64_ENCODER.encodeToString(serialize(baseOffset, offsets, maxBytes));
+    }
+
+    public Offsets decode(long baseOffset, String metadata) {
+        try {
+            return deserializeUnsafe(baseOffset, Base64.getDecoder().decode(metadata));
+        } catch (Exception e) {
+            LOGGER.warn("Failed to deserialize offsets from metadata", e);
+            return new Offsets();
+        }
+    }
+
+    private byte[] serialize(long baseOffset, Offsets offsets, int maxBytes) {
+        if (offsets.isEmpty()) {
+            return EMPTY_BYTES;
+        }
+
+        // In order to calculate the maximum bytes available to write delta-runs, we start with the
+        // total byte limit, and then subtract:
+        // 1. One for byte needed for version
+        // 2. Pathological bytes needed to represent offset count
+        // 3. Byte count needed to represent checksum as integer
+        // We then serialize as many delta-runs as possible while fitting within remaining byte
+        // limit. If none fit, we log and return an empty result.
+        int maxBytesForDeltaRuns = maxBytes - 1 - varLongSizeOf(offsets.size()) - Integer.BYTES;
+        DeltaRuns deltaRuns = serializeDeltaRuns(baseOffset, offsets, maxBytesForDeltaRuns);
+        if (deltaRuns.totalCount() <= 0) {
+            LOGGER.warn("Offset delta-runs cannot be represented with maxBytes: {}", maxBytes);
+            return EMPTY_BYTES;
+        }
+
+        // Realize serialization format: [version][offset count][delta-runs][checksum]
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        CheckedOutputStream checkedStream = new CheckedOutputStream(byteStream, initializeChecksum(baseOffset));
+        writeByte(checkedStream, VERSION);
+        writeUnsignedVarLong(checkedStream, deltaRuns.totalCount());
+        deltaRuns.writeBytesTo(checkedStream);
+        writeLeastSignificantInt(byteStream, checkedStream.getChecksum().getValue());
+
+        return byteStream.toByteArray();
+    }
+
+    private DeltaRuns serializeDeltaRuns(long baseOffset, Offsets offsets, int maxBytes) {
+        DeltaRuns deltaRuns = new DeltaRuns(maxBytes);
+        long previousOffset = baseOffset;
+        long currentRunDelta = 0;
+        int currentRunLength = 0;
+        PrimitiveIterator.OfLong offsetIterator = offsets.longIterator();
+        while (offsetIterator.hasNext()) {
+            long offset = offsetIterator.nextLong();
+            long delta = offset - previousOffset;
+            if (delta <= 0) {
+                throw new IllegalArgumentException("Offsets must monotonically increase from base offset");
+            } else if (delta == currentRunDelta) {
+                currentRunLength++;
+            } else if (deltaRuns.flush(currentRunDelta, currentRunLength)) {
+                currentRunDelta = delta;
+                currentRunLength = 1;
+            } else {
+                return deltaRuns;
+            }
+            previousOffset = offset;
+        }
+        deltaRuns.flush(currentRunDelta, currentRunLength);
+        return deltaRuns;
+    }
+
+    private Offsets deserializeUnsafe(long baseOffset, byte[] metadata) {
+        Offsets.Builder builder = new Offsets.Builder();
+        if (metadata.length > 0) {
+            deserializeUnsafe(baseOffset, metadata, builder::addNext);
+        }
+        return builder.build();
+    }
+
+    private void deserializeUnsafe(long baseOffset, byte[] metadata, LongConsumer consumer) {
+        // Validate checksum first for fail-fast behavior
+        ByteBuffer buffer = ByteBuffer.wrap(metadata, metadata.length - Integer.BYTES, Integer.BYTES);
+        Checksum expectedChecksum = initializeChecksum(baseOffset);
+        expectedChecksum.update(metadata, 0, buffer.position());
+        if (readLeastSignificantInt(buffer) != expectedChecksum.getValue()) {
+            throw new IllegalArgumentException("Checksum validation failed");
+        }
+
+        // Initialize data deserialization with version check
+        buffer.position(0).limit(metadata.length - Integer.BYTES);
+        byte version = buffer.get();
+        if (version != VERSION) {
+            throw new IllegalArgumentException("Incompatible version in offset commit metadata: " + version);
+        }
+
+        // Read number of encoded offsets and all delta-runs while consuming effective offsets
+        long remaining = readUnsignedVarLong(buffer);
+        long previousOffset = baseOffset;
+        while (remaining > 0) {
+            long value = readUnsignedVarLong(buffer);
+
+            boolean running = value == RUN_MARKER;
+            long delta = running ? readUnsignedVarLong(buffer) : value;
+            long length = running ? readUnsignedVarLong(buffer) : 1;
+
+            remaining -= length;
+            while (length > 0) {
+                consumer.accept(previousOffset += delta);
+                length--;
+            }
+        }
+
+        // Validate full consumption
+        if (buffer.hasRemaining()) {
+            throw new IllegalArgumentException("Buffer not fully consumed");
+        }
+    }
+
+    private static Checksum initializeChecksum(long offset) {
+        Checksum checksum = new CRC32();
+        checksum.update((int) (offset >>> 56));
+        checksum.update((int) (offset >>> 48));
+        checksum.update((int) (offset >>> 40));
+        checksum.update((int) (offset >>> 32));
+        checksum.update((int) (offset >>> 24));
+        checksum.update((int) (offset >>> 16));
+        checksum.update((int) (offset >>> 8));
+        checksum.update((int) offset);
+        return checksum;
+    }
+
+    private static int varLongSizeOf(long value) {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(10);
+        writeUnsignedVarLong(outputStream, value);
+        return outputStream.size();
+    }
+
+    private static void writeUnsignedVarLong(OutputStream out, long value) {
+        while ((value & ~0x7FL) != 0) {
+            writeByte(out, (int) ((value & 0x7F) | 0x80));
+            value >>>= 7;
+        }
+        writeByte(out, (int) value);
+    }
+
+    private static long readUnsignedVarLong(ByteBuffer buffer) {
+        long value = 0;
+        for (int shift = 0; shift < 64 && buffer.hasRemaining(); shift += 7) {
+            byte nextByte = buffer.get();
+            value |= (long) (nextByte & 0x7F) << shift;
+            if ((nextByte & 0x80) == 0) {
+                return value;
+            }
+        }
+        throw new IllegalArgumentException("Malformed VarLong");
+    }
+
+    private static void writeLeastSignificantInt(OutputStream out, long value) {
+        writeByte(out, (int) value >>> 24);
+        writeByte(out, (int) value >>> 16);
+        writeByte(out, (int) value >>> 8);
+        writeByte(out, (int) value);
+    }
+
+    private static long readLeastSignificantInt(ByteBuffer buffer) {
+        int value = 0;
+        value |= (buffer.get() & 0xFF) << 24;
+        value |= (buffer.get() & 0xFF) << 16;
+        value |= (buffer.get() & 0xFF) << 8;
+        value |= (buffer.get() & 0xFF);
+        return Integer.toUnsignedLong(value);
+    }
+
+    private static void writeByte(OutputStream out, int value) {
+        try {
+            out.write(value);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to write byte to OutputStream", e);
+        }
+    }
+
+    private static void writeBytes(OutputStream out, byte[] value, int length) {
+        try {
+            out.write(value, 0, length);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to write bytes to OutputStream", e);
+        }
+    }
+
+    private static final class DeltaRuns {
+
+        private final int maxBytes;
+
+        private final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+        private int totalCount = 0;
+
+        private int stopIndex = 0;
+
+        public DeltaRuns(int maxBytes) {
+            this.maxBytes = maxBytes;
+        }
+
+        public boolean flush(long delta, int count) {
+            if (count == 1) {
+                writeUnsignedVarLong(bytes, delta);
+            } else if (count == 2) {
+                writeUnsignedVarLong(bytes, delta);
+                writeUnsignedVarLong(bytes, delta);
+            } else if (count >= 3) {
+                writeUnsignedVarLong(bytes, RUN_MARKER);
+                writeUnsignedVarLong(bytes, delta);
+                writeUnsignedVarLong(bytes, count);
+            }
+
+            if (bytes.size() <= maxBytes) {
+                totalCount += count;
+                stopIndex = bytes.size();
+                return true;
+            } else {
+                LOGGER.warn("Offset delta-runs are being truncated");
+                return false;
+            }
+        }
+
+        public int totalCount() {
+            return totalCount;
+        }
+
+        public void writeBytesTo(OutputStream outputStream) {
+            writeBytes(outputStream, bytes.toByteArray(), stopIndex);
+        }
+    }
+}

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/OffsetTracker.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/OffsetTracker.java
@@ -1,9 +1,17 @@
 package io.atleon.kafka;
 
+import io.atleon.core.SerialQueue;
 import org.apache.kafka.common.TopicPartition;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoSink;
 
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * Per-partition tracker of processing based on offsets. Each instance is specific to a single
@@ -13,6 +21,10 @@ import java.util.Optional;
  * associate with commitments, or disable native commitment altogether.
  */
 public interface OffsetTracker {
+
+    int DEFAULT_METADATA_MAX_BYTES = 4096; // Kafka default
+
+    int DEFAULT_BUFFER_MAX_SIZE = 10_000;
 
     /**
      * Facilitates default offset tracking behavior, where no records are prohibited from
@@ -28,6 +40,26 @@ public interface OffsetTracker {
      */
     static OffsetTracker commitless(TopicPartition partition) {
         return new Commitless(partition);
+    }
+
+    /**
+     * @see #acknowledgedAheadOfCommit(ConsumerPartition, int, int)
+     */
+    static OffsetTracker acknowledgedAheadOfCommit(ConsumerPartition partition) {
+        return acknowledgedAheadOfCommit(partition, DEFAULT_METADATA_MAX_BYTES, DEFAULT_BUFFER_MAX_SIZE);
+    }
+
+    /**
+     * Activates tracking of acknowledged offsets which are ahead of the committed offset. This
+     * results in queue-like behavior by storing acknowledged offsets in commit metadata, serving
+     * as a non-volatile record (across rebalances) of processing that has completed ahead of the
+     * offset that is safe to commit at commit time. This method allows configuring the max
+     * serialized size of metadata (limited by broker-side {@code offset.metadata.max.bytes}), and
+     * the maximum number of "buffered" offsets, which helps control memory usage.
+     */
+    static OffsetTracker acknowledgedAheadOfCommit(
+            ConsumerPartition partition, int metadataMaxBytes, int bufferMaxSize) {
+        return new AcknowledgedAheadOfCommit(partition, metadataMaxBytes, bufferMaxSize);
     }
 
     /**
@@ -51,10 +83,12 @@ public interface OffsetTracker {
     Mono<String> commitMetadata(long commitOffset);
 
     /**
-     * Initial offset that may be used as commitment offset, which is useful if commitment data may
-     * update prior to a subsequent offset being made available for commit.
+     * Initial {@link ConsumerOffset} that may be used as a basis for commitment, in the absence of
+     * commitment offset advancement. This is useful if commitment metadata may update prior to a
+     * subsequent offset being made available for commitment. Generally, the contained raw offset
+     * value should be one less than the initial position/committed offset.
      */
-    Optional<Long> initiallyCommittableOffset();
+    Optional<ConsumerOffset> initialConsumerOffset();
 
     TopicPartition topicPartition();
 
@@ -80,7 +114,7 @@ public interface OffsetTracker {
         }
 
         @Override
-        public Optional<Long> initiallyCommittableOffset() {
+        public Optional<ConsumerOffset> initialConsumerOffset() {
             return Optional.empty();
         }
 
@@ -112,13 +146,88 @@ public interface OffsetTracker {
         }
 
         @Override
-        public Optional<Long> initiallyCommittableOffset() {
+        public Optional<ConsumerOffset> initialConsumerOffset() {
             return Optional.empty();
         }
 
         @Override
         public TopicPartition topicPartition() {
             return topicPartition;
+        }
+    }
+
+    final class AcknowledgedAheadOfCommit implements OffsetTracker {
+
+        private final ConsumerOffset initialConsumerOffset;
+
+        private final OffsetMetadataEncoding metadataEncoding;
+
+        private final int bufferMaxSize;
+
+        private final SerialQueue<Consumer<Set<Long>>> acknowledgedQueue = SerialQueue.on(new HashSet<>());
+
+        // Written only under the `acknowledgedQueue` (serialized RMW), but read on the poll thread
+        // in prohibitsProcessing without synchronization. Intentionally NOT volatile, since we
+        // assume prohibition only needs the initially decoded set, and in-session offsets are
+        // assumed to monotonically increase with processing. A stale read on the poll thread is
+        // therefore harmless. Reconsider making this volatile if this non-local invariant ever
+        // changes (e.g. prohibition must reflect in-session acknowledgements).
+        private Offsets aheadOfCommit;
+
+        private AcknowledgedAheadOfCommit(ConsumerPartition partition, int metadataMaxSize, int bufferMaxSize) {
+            this.initialConsumerOffset = partition.newOffsetFromPosition(it -> it - 1);
+            this.metadataEncoding = new OffsetMetadataEncoding(metadataMaxSize);
+            this.bufferMaxSize = bufferMaxSize;
+            this.aheadOfCommit = partition
+                    .committedMetadata()
+                    .map(it -> metadataEncoding.decode(initialConsumerOffset.offset(), it))
+                    .orElseGet(Offsets::new);
+        }
+
+        @Override
+        public boolean prohibitsProcessing(long offset) {
+            return aheadOfCommit.contains(offset);
+        }
+
+        @Override
+        public void acknowledged(long offset) {
+            acknowledgedQueue.addAndDrain(it -> {
+                if (it.add(offset) && it.size() >= bufferMaxSize) {
+                    drainAcknowledgedBuffer(it, Long.MIN_VALUE);
+                }
+            });
+        }
+
+        @Override
+        public Mono<String> commitMetadata(long commitOffset) {
+            return Mono.<Offsets>create(sink -> drainAcknowledgedBuffer(sink, commitOffset))
+                    .map(it -> metadataEncoding.encode(commitOffset - 1, it));
+        }
+
+        @Override
+        public Optional<ConsumerOffset> initialConsumerOffset() {
+            return Optional.of(initialConsumerOffset);
+        }
+
+        @Override
+        public TopicPartition topicPartition() {
+            return initialConsumerOffset.topicPartition();
+        }
+
+        private void drainAcknowledgedBuffer(MonoSink<Offsets> sink, long minimumOffset) {
+            acknowledgedQueue.addAndDrain(it -> {
+                drainAcknowledgedBuffer(it, minimumOffset);
+                sink.success(aheadOfCommit);
+            });
+        }
+
+        private void drainAcknowledgedBuffer(Set<Long> acknowledgedBuffer, long minimumOffset) {
+            SortedSet<Long> bufferedAheadOfCommit = acknowledgedBuffer.stream()
+                    .filter(it -> it >= minimumOffset)
+                    .collect(Collectors.toCollection(TreeSet::new));
+
+            aheadOfCommit = aheadOfCommit.minimumMerge(minimumOffset, bufferedAheadOfCommit);
+            acknowledgedBuffer.clear();
         }
     }
 }

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/OffsetTrackingStrategy.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/OffsetTrackingStrategy.java
@@ -30,6 +30,16 @@ public interface OffsetTrackingStrategy {
     }
 
     /**
+     * Strategy that assigns {@link OffsetTracker#acknowledgedAheadOfCommit(ConsumerPartition)}
+     * to all assigned partitions.
+     */
+    static OffsetTrackingStrategy acknowledgedAheadOfCommit() {
+        return (consumer, partitions) -> ConsumerPartition.create(consumer, partitions).stream()
+                .map(OffsetTracker::acknowledgedAheadOfCommit)
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Creates a {@link Collection} of {@link OffsetTracker} instances for each of the
      * provided/assigned {@link TopicPartition}s. Implementations should return an entry for each
      * given partition.

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/Offsets.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/Offsets.java
@@ -1,0 +1,236 @@
+package io.atleon.kafka;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.AbstractCollection;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.PrimitiveIterator;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link Collection} of {@code long} offsets backed by a sorted {@link List} of contiguous
+ * "ranges". Storing runs of consecutive offsets as a single range (rather than one entry per
+ * offset) keeps memory proportional to the number of <i>gaps</i> rather than the number of
+ * offsets, which suits intended usage with mostly-contiguous acknowledged offsets. Offsets are
+ * iterated in ascending order and duplicates are not retained.
+ *
+ * <p>The sole available "mutation" is {@link #minimumMerge(long, Collection)}, which returns a
+ * <i>new</i> instance by combining the contained offsets with additional offsets while discarding
+ * any below a given floor (i.e. the commit offset).
+ */
+final class Offsets extends AbstractCollection<Long> {
+
+    // More performant usable value for representing "null" without boxing.
+    private static final long NO_VALUE = Long.MIN_VALUE;
+
+    // Sorted ascending by start, non-overlapping, and non-adjacent (there is always a gap of at
+    // least one offset between consecutive ranges; otherwise they would have been consolidated).
+    private final List<Range> ranges;
+
+    // Precomputed to avoid unnecessary traversal.
+    private final int offsetCount;
+
+    public Offsets() {
+        this.ranges = Collections.emptyList();
+        this.offsetCount = 0;
+    }
+
+    private Offsets(ArrayList<Range> ranges, int offsetCount) {
+        this.ranges = ranges;
+        this.offsetCount = offsetCount;
+    }
+
+    public Offsets minimumMerge(long minimum, Collection<Long> sortedAdditionalOffsets) {
+        Builder builder = new Builder();
+        MergingIterator mergingIterator = new MergingIterator(longIterator(), sortedAdditionalOffsets.iterator());
+        while (mergingIterator.hasNext()) {
+            long nextOffset = mergingIterator.nextLong();
+            if (nextOffset >= minimum) {
+                builder.addNext(nextOffset);
+            }
+        }
+        return builder.build();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return o != null && o.getClass() == Long.class && contains(((Long) o).longValue());
+    }
+
+    public boolean contains(long offset) {
+        // Fast path: Most checks will be for offsets that are greater than current max
+        int lastIndex = ranges.size() - 1;
+        if (lastIndex < 0 || ranges.get(lastIndex).end() < offset) {
+            return false;
+        }
+
+        int floorIndex = -1;
+        int low = 0;
+        int high = lastIndex;
+        while (low <= high) {
+            int mid = (low + high) >>> 1;
+            if (ranges.get(mid).start() <= offset) {
+                floorIndex = mid;
+                low = mid + 1;
+            } else {
+                high = mid - 1;
+            }
+        }
+        return floorIndex >= 0 && offset <= ranges.get(floorIndex).end();
+    }
+
+    @Override
+    public int size() {
+        return offsetCount;
+    }
+
+    @Override
+    public @NonNull Iterator<Long> iterator() {
+        return longIterator();
+    }
+
+    public PrimitiveIterator.OfLong longIterator() {
+        return new PrimitiveIterator.OfLong() {
+
+            private int rangeIndex = 0;
+
+            private long next = ranges.isEmpty() ? 0 : ranges.get(0).start();
+
+            @Override
+            public boolean hasNext() {
+                return rangeIndex < ranges.size();
+            }
+
+            @Override
+            public long nextLong() {
+                long result = next;
+
+                if (result != ranges.get(rangeIndex).end()) {
+                    next = result + 1;
+                } else if (++rangeIndex < ranges.size()) {
+                    next = ranges.get(rangeIndex).start();
+                }
+
+                return result;
+            }
+        };
+    }
+
+    @Override
+    public String toString() {
+        return ranges.stream().map(Range::toString).collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    static final class Builder {
+
+        private final List<Range> ranges = new LinkedList<>();
+
+        private long startOffset = NO_VALUE;
+
+        private long previousOffset = NO_VALUE;
+
+        private int offsetCount = 0;
+
+        public Offsets build() {
+            if (startOffset != NO_VALUE) {
+                ArrayList<Range> builtRanges = new ArrayList<>(ranges.size() + 1);
+                builtRanges.addAll(ranges);
+                builtRanges.add(new Range(startOffset, previousOffset));
+                return new Offsets(builtRanges, offsetCount);
+            } else {
+                return new Offsets();
+            }
+        }
+
+        public void addNext(long offset) {
+            if (startOffset == NO_VALUE) {
+                startOffset = offset;
+            } else if (offset > previousOffset + 1) {
+                ranges.add(new Range(startOffset, previousOffset));
+                startOffset = offset;
+            } else if (offset < previousOffset) {
+                throw new IllegalArgumentException("Offsets to add must be done so in sorted order");
+            }
+            if (offset != previousOffset) {
+                previousOffset = offset;
+                offsetCount++;
+            }
+        }
+    }
+
+    private static final class MergingIterator implements PrimitiveIterator.OfLong {
+
+        private final PrimitiveIterator.OfLong left;
+
+        private final Iterator<Long> right;
+
+        private long nextLeft;
+
+        private long nextRight;
+
+        public MergingIterator(PrimitiveIterator.OfLong left, Iterator<Long> right) {
+            this.left = left;
+            this.right = right;
+            this.nextLeft = left.hasNext() ? left.nextLong() : NO_VALUE;
+            this.nextRight = right.hasNext() ? right.next() : NO_VALUE;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return nextLeft != NO_VALUE || nextRight != NO_VALUE;
+        }
+
+        @Override
+        public long nextLong() {
+            if (nextLeft == NO_VALUE) {
+                return getAndAdvanceRight();
+            } else if (nextRight == NO_VALUE || nextLeft <= nextRight) {
+                return getAndAdvanceLeft();
+            } else {
+                return getAndAdvanceRight();
+            }
+        }
+
+        private long getAndAdvanceLeft() {
+            long result = nextLeft;
+            nextLeft = left.hasNext() ? left.nextLong() : NO_VALUE;
+            return result;
+        }
+
+        private long getAndAdvanceRight() {
+            long result = nextRight;
+            nextRight = right.hasNext() ? right.next() : NO_VALUE;
+            return result;
+        }
+    }
+
+    private static final class Range {
+
+        private final long start;
+
+        private final long end;
+
+        public Range(long start, long end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        @Override
+        public String toString() {
+            return start == end ? Long.toString(start) : (start + ".." + end);
+        }
+
+        public long start() {
+            return start;
+        }
+
+        public long end() {
+            return end;
+        }
+    }
+}

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
@@ -112,9 +112,9 @@ class ActivePartitionTest {
     public void acknowledgedOffsets_givenInitiallyCommittableOffset_expectsAcknowledgedOffsetWithUpdatedMetadata() {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
 
-        long initiallyCommittableOffset = 5L;
-        ActivePartition activePartition = new ActivePartition(
-                committableOffsetTracker(initiallyCommittableOffset), AcknowledgementQueueMode.STRICT);
+        ConsumerOffset initialConsumerOffset = new ConsumerOffset(TOPIC_PARTITION, 4L);
+        ActivePartition activePartition =
+                new ActivePartition(initializedOffsetTracker(initialConsumerOffset), AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
 
         // Even without any record being acknowledged, an initially committable offset is emitted as
@@ -122,14 +122,14 @@ class ActivePartitionTest {
         // less than the committable offset, since the committed offset is the numerical increment.
         assertEquals(1, acknowledgedOffsets.size());
         assertEquals(
-                initiallyCommittableOffset - 1,
+                initialConsumerOffset.offset(),
                 acknowledgedOffsets.get(0).consumerOffset().offset());
 
         // On commitment, the offset tracker supplies updated metadata for the committable offset.
         OffsetAndMetadata committed =
                 acknowledgedOffsets.get(0).prepareCommitment().block().getT2();
-        assertEquals(initiallyCommittableOffset, committed.offset());
-        assertEquals("metadata-" + initiallyCommittableOffset, committed.metadata());
+        assertEquals(initialConsumerOffset.offset() + 1, committed.offset());
+        assertEquals("metadata-" + (initialConsumerOffset.offset() + 1), committed.metadata());
     }
 
     @Test
@@ -555,9 +555,9 @@ class ActivePartitionTest {
         return offsetTracker;
     }
 
-    private static OffsetTracker committableOffsetTracker(long initiallyCommittableOffset) {
+    private static OffsetTracker initializedOffsetTracker(ConsumerOffset initialConsumerOffset) {
         OffsetTracker offsetTracker = mock(OffsetTracker.class, AdditionalAnswers.delegatesTo(newOffsetTracker()));
-        when(offsetTracker.initiallyCommittableOffset()).thenReturn(Optional.of(initiallyCommittableOffset));
+        when(offsetTracker.initialConsumerOffset()).thenReturn(Optional.of(initialConsumerOffset));
         when(offsetTracker.commitMetadata(anyLong()))
                 .thenAnswer(invocation -> Mono.just("metadata-" + invocation.<Long>getArgument(0)));
         return offsetTracker;

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/KafkaReceiverTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/KafkaReceiverTest.java
@@ -19,6 +19,8 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -374,6 +376,122 @@ class KafkaReceiverTest {
                     .block();
             assertEquals(1, maxOffset);
         }
+    }
+
+    @Test
+    public void receiveManual_givenAcknowledgedRecordAheadOfCommit_expectsHonoredProcessingOnResubscription() {
+        String topic = UUID.randomUUID().toString();
+        String groupId = UUID.randomUUID().toString();
+
+        // All records share the same key so that they are produced to (and consumed from) the same
+        // partition, where ahead-of-commit honorship applies.
+        KafkaSenderRecord<String, String, Object> senderRecord1 =
+                KafkaSenderRecord.create(topic, "key", "value1", null);
+        KafkaSenderRecord<String, String, Object> senderRecord2 =
+                KafkaSenderRecord.create(topic, "key", "value2", null);
+        KafkaSenderRecord<String, String, Object> senderRecord3 =
+                KafkaSenderRecord.create(topic, "key", "value3", null);
+        KafkaSenderRecord<String, String, Object> senderRecord4 =
+                KafkaSenderRecord.create(topic, "key", "value4", null);
+        KafkaSenderRecord<String, String, Object> senderRecord5 =
+                KafkaSenderRecord.create(topic, "key", "value5", null);
+
+        sendStrings(senderRecord1, senderRecord2, senderRecord3, senderRecord4, senderRecord5);
+
+        ConsumerListener.Closure closureListener = ConsumerListener.closure();
+        KafkaReceiverOptions<String, String> receiverOptions = KafkaReceiverOptions.<String, String>newBuilder()
+                .consumerListener(closureListener)
+                .consumerProperties(newStringConsumerProperties(groupId))
+                .acknowledgedAheadOfCommitOffsetTracking()
+                .build();
+
+        // Receive all five records, then acknowledge the first and the fourth. Strict acknowledgement
+        // ordering advances the committed offset only past the first record, while the fourth record's
+        // completed processing is recorded ahead of the committed offset as commit metadata.
+        List<KafkaReceiverRecord<String, String>> receivedRecords = new ArrayList<>();
+        KafkaReceiver.create(receiverOptions)
+                .receiveManual(Collections.singletonList(topic))
+                .as(StepVerifier::create)
+                .consumeNextWith(receivedRecords::add)
+                .consumeNextWith(receivedRecords::add)
+                .consumeNextWith(receivedRecords::add)
+                .consumeNextWith(receivedRecords::add)
+                .consumeNextWith(receivedRecords::add)
+                .then(() -> {
+                    receivedRecords.get(0).acknowledge();
+                    receivedRecords.get(3).acknowledge();
+                })
+                .thenCancel()
+                .verify();
+
+        assertEquals(
+                Arrays.asList("value1", "value2", "value3", "value4", "value5"),
+                receivedRecords.stream().map(KafkaReceiverRecord::value).collect(Collectors.toList()));
+        assertNull(closureListener.closed().block());
+
+        // On resubscription, consumption resumes from the committed offset (past the first record),
+        // and the honored fourth record is not re-emitted, leaving the second, third, and fifth.
+        KafkaReceiver.create(receiverOptions)
+                .receiveManual(Collections.singletonList(topic))
+                .as(StepVerifier::create)
+                .consumeNextWith(it -> assertEquals(senderRecord2.value(), it.value()))
+                .consumeNextWith(it -> assertEquals(senderRecord3.value(), it.value()))
+                .consumeNextWith(it -> assertEquals(senderRecord5.value(), it.value()))
+                .thenCancel()
+                .verify();
+    }
+
+    @Test
+    public void receiveManual_givenAcknowledgedRecordAheadOfNoCommit_expectsHonoredProcessingOnResubscription() {
+        String topic = UUID.randomUUID().toString();
+        String groupId = UUID.randomUUID().toString();
+
+        // All records share the same key so that they are produced to (and consumed from) the same
+        // partition, where ahead-of-commit honorship applies.
+        KafkaSenderRecord<String, String, Object> senderRecord1 =
+                KafkaSenderRecord.create(topic, "key", "value1", null);
+        KafkaSenderRecord<String, String, Object> senderRecord2 =
+                KafkaSenderRecord.create(topic, "key", "value2", null);
+        KafkaSenderRecord<String, String, Object> senderRecord3 =
+                KafkaSenderRecord.create(topic, "key", "value3", null);
+
+        sendStrings(senderRecord1, senderRecord2, senderRecord3);
+
+        ConsumerListener.Closure closureListener = ConsumerListener.closure();
+        KafkaReceiverOptions<String, String> receiverOptions = KafkaReceiverOptions.<String, String>newBuilder()
+                .consumerListener(closureListener)
+                .consumerProperties(newStringConsumerProperties(groupId))
+                .acknowledgedAheadOfCommitOffsetTracking()
+                .build();
+
+        // Receive all three records, then acknowledge the second. Since the first is not
+        // acknowledged the committed offset will not advance, but we should still end up honoring
+        // uncommitted progress.
+        List<KafkaReceiverRecord<String, String>> receivedRecords = new ArrayList<>();
+        KafkaReceiver.create(receiverOptions)
+                .receiveManual(Collections.singletonList(topic))
+                .as(StepVerifier::create)
+                .consumeNextWith(receivedRecords::add)
+                .consumeNextWith(receivedRecords::add)
+                .consumeNextWith(receivedRecords::add)
+                .then(() -> receivedRecords.get(1).acknowledge())
+                .thenCancel()
+                .verify();
+
+        assertEquals(
+                Arrays.asList("value1", "value2", "value3"),
+                receivedRecords.stream().map(KafkaReceiverRecord::value).collect(Collectors.toList()));
+        assertNull(closureListener.closed().block());
+
+        // On resubscription, consumption resumes from the initializing offset ("earliest")
+        // and the honored second record is not re-emitted, leaving the first and third.
+        KafkaReceiver.create(receiverOptions)
+                .receiveManual(Collections.singletonList(topic))
+                .as(StepVerifier::create)
+                .consumeNextWith(it -> assertEquals(senderRecord1.value(), it.value()))
+                .consumeNextWith(it -> assertEquals(senderRecord3.value(), it.value()))
+                .thenCancel()
+                .verify();
     }
 
     @ParameterizedTest

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/OffsetMetadataEncodingTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/OffsetMetadataEncodingTest.java
@@ -1,0 +1,173 @@
+package io.atleon.kafka;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OffsetMetadataEncodingTest {
+
+    private final OffsetMetadataEncoding encoding = new OffsetMetadataEncoding(Integer.MAX_VALUE);
+
+    @Test
+    public void encode_givenEmptyOffsets_producesEmptyString() {
+        assertEquals("", encoding.encode(-1L, new Offsets()));
+    }
+
+    @Test
+    public void decode_givenEmptyString_producesEmptyOffsets() {
+        Offsets decoded = encoding.decode(-1L, "");
+
+        assertTrue(decoded.isEmpty());
+    }
+
+    @Test
+    public void encodeDecode_givenSingleOffset_roundTrips() {
+        assertRoundTrips(-1L, 0L);
+    }
+
+    @Test
+    public void encodeDecode_givenContiguousOffsets_roundTrips() {
+        // A long run of consecutive offsets exercises the RUN_MARKER (count >= 3) encoding path
+        assertRoundTrips(-1L, 0L, 1L, 2L, 3L, 4L, 5L, 6L);
+    }
+
+    @Test
+    public void encodeDecode_givenRunOfLengthTwo_roundTrips() {
+        // Two consecutive equal deltas exercise the count == 2 encoding path (no RUN_MARKER)
+        assertRoundTrips(0L, 1L, 2L);
+    }
+
+    @Test
+    public void encodeDecode_givenGappedOffsets_roundTrips() {
+        assertRoundTrips(-1L, 0L, 1L, 5L, 6L, 7L, 10L);
+    }
+
+    @Test
+    public void encodeDecode_givenAlternatingDeltas_roundTrips() {
+        // Alternating deltas force many single-count delta-runs
+        assertRoundTrips(-1L, 0L, 1L, 3L, 4L, 6L, 7L, 9L, 10L);
+    }
+
+    @Test
+    public void encodeDecode_givenLargeDeltasAndBaseOffset_roundTrips() {
+        // Large values exercise multi-byte VarLong encoding for deltas, counts, and the base offset
+        assertRoundTrips(1_000_000L, 1_000_001L, 2_500_000L, 2_500_001L, 2_500_002L, 9_999_999_999L);
+    }
+
+    @Test
+    public void encodeDecode_givenManyConsecutiveOffsets_roundTrips() {
+        long base = 42L;
+        long[] offsets = new long[5000];
+        for (int i = 0; i < offsets.length; i++) {
+            offsets[i] = base + 1 + i;
+        }
+        assertRoundTrips(base, offsets);
+    }
+
+    @Test
+    public void encode_givenBaseOffsetEqualToFirstOffset_throws() {
+        Offsets offsets = build(5L, 6L);
+
+        assertThrows(IllegalArgumentException.class, () -> encoding.encode(5L, offsets));
+    }
+
+    @Test
+    public void encode_givenBaseOffsetAboveFirstOffset_throws() {
+        Offsets offsets = build(5L, 6L);
+
+        assertThrows(IllegalArgumentException.class, () -> encoding.encode(10L, offsets));
+    }
+
+    @Test
+    public void decode_givenInvalidBase64_producesEmptyOffsets() {
+        Offsets decoded = encoding.decode(-1L, "not valid base64 !!!");
+
+        assertTrue(decoded.isEmpty());
+    }
+
+    @Test
+    public void decode_givenMismatchedBaseOffset_producesEmptyOffsets() {
+        // The base offset seeds the checksum, so decoding against a different base fails validation
+        String encoded = encoding.encode(-1L, build(0L, 1L, 2L));
+
+        Offsets decoded = encoding.decode(5L, encoded);
+
+        assertTrue(decoded.isEmpty());
+    }
+
+    @Test
+    public void decode_givenCorruptedMetadata_producesEmptyOffsets() {
+        String encoded = encoding.encode(-1L, build(0L, 1L, 2L));
+        String corrupted = mutateLastCharacter(encoded);
+
+        assertNotEquals(encoded, corrupted);
+        assertTrue(encoding.decode(-1L, corrupted).isEmpty());
+    }
+
+    @Test
+    public void encode_givenInsufficientMaxSize_producesEmptyString() {
+        OffsetMetadataEncoding tinyEncoding = new OffsetMetadataEncoding(1);
+
+        assertEquals("", tinyEncoding.encode(-1L, build(0L, 1L, 2L)));
+    }
+
+    @Test
+    public void encodeDecode_givenMaxSizeBelowFullSize_truncatesToPrefix() {
+        OffsetMetadataEncoding boundedEncoding = new OffsetMetadataEncoding(200);
+
+        // Alternating deltas yield mostly single-count runs (~1 byte each), exceeding the limit
+        long[] offsets = new long[2000];
+        long previous = -1L;
+        for (int i = 0; i < offsets.length; i++) {
+            previous += (i % 2 == 0) ? 1L : 2L;
+            offsets[i] = previous;
+        }
+        Offsets full = build(offsets);
+
+        String encoded = boundedEncoding.encode(-1L, full);
+        Offsets decoded = boundedEncoding.decode(-1L, encoded);
+
+        assertFalse(decoded.isEmpty());
+        assertTrue(decoded.size() < full.size());
+        // Whatever survives truncation must be a leading prefix of the original offsets
+        assertEquals(toList(full).subList(0, decoded.size()), toList(decoded));
+    }
+
+    private void assertRoundTrips(long baseOffset, long... offsets) {
+        Offsets original = build(offsets);
+
+        String encoded = encoding.encode(baseOffset, original);
+        Offsets decoded = encoding.decode(baseOffset, encoded);
+
+        assertEquals(toList(original), toList(decoded));
+        assertEquals(original.size(), decoded.size());
+    }
+
+    private static String mutateLastCharacter(String encoded) {
+        char[] chars = encoded.toCharArray();
+        int lastIndex = chars.length - 1;
+        chars[lastIndex] = chars[lastIndex] == 'A' ? 'B' : 'A';
+        return new String(chars);
+    }
+
+    private static Offsets build(long... offsets) {
+        Offsets.Builder builder = new Offsets.Builder();
+        for (long offset : offsets) {
+            builder.addNext(offset);
+        }
+        return builder.build();
+    }
+
+    private static List<Long> toList(Offsets offsets) {
+        List<Long> result = new ArrayList<>();
+        offsets.iterator().forEachRemaining(result::add);
+        return result;
+    }
+}

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/OffsetTrackerTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/OffsetTrackerTest.java
@@ -1,0 +1,100 @@
+package io.atleon.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OffsetTrackerTest {
+
+    private static final TopicPartition TOPIC_PARTITION = new TopicPartition("topic", 0);
+
+    @Test
+    public void acknowledgedAheadOfCommit_givenNoPriorMetadata_expectsNoneProhibited() {
+        OffsetTracker tracker = newAcknowledgedAheadOfCommitTracker(5L, null);
+
+        assertFalse(tracker.prohibitsProcessing(5L));
+        assertFalse(tracker.prohibitsProcessing(6L));
+    }
+
+    @Test
+    public void acknowledgedAheadOfCommit_givenOffsetsAcknowledgedInPriorAssignment_expectsThemProhibited() {
+        // A prior assignment acknowledged offsets 6 and 8 while the commit offset remained at 5
+        // (offsets 5 and 7 were never acknowledged), and persisted that state to commit metadata.
+        OffsetTracker priorTracker = newAcknowledgedAheadOfCommitTracker(5L, null);
+        priorTracker.acknowledged(6L);
+        priorTracker.acknowledged(8L);
+        String metadata = priorTracker.commitMetadata(5L).block();
+
+        // The next assignment resumes from the same position with that metadata restored
+        OffsetTracker resumedTracker = newAcknowledgedAheadOfCommitTracker(5L, metadata);
+
+        assertTrue(resumedTracker.prohibitsProcessing(6L));
+        assertTrue(resumedTracker.prohibitsProcessing(8L));
+        assertFalse(resumedTracker.prohibitsProcessing(5L));
+        assertFalse(resumedTracker.prohibitsProcessing(7L));
+        assertFalse(resumedTracker.prohibitsProcessing(9L));
+    }
+
+    @Test
+    public void acknowledgedAheadOfCommit_givenNoAcknowledgedOffsets_expectsBlankMetadata() {
+        OffsetTracker tracker = newAcknowledgedAheadOfCommitTracker(5L, null);
+
+        // Blank (not absent) metadata means native commitment still happens, just with no offsets
+        assertEquals("", tracker.commitMetadata(5L).block());
+    }
+
+    @Test
+    public void acknowledgedAheadOfCommit_givenAcknowledgedOffsets_expectsOnlyOffsetsAtOrAboveCommitRetained() {
+        OffsetTracker tracker = newAcknowledgedAheadOfCommitTracker(0L, null);
+        tracker.acknowledged(2L);
+        tracker.acknowledged(5L);
+        tracker.acknowledged(8L);
+
+        // Committing at offset 6 drops acknowledged offsets below it (2 and 5) and retains 8
+        String metadata = tracker.commitMetadata(6L).block();
+        OffsetTracker resumedTracker = newAcknowledgedAheadOfCommitTracker(6L, metadata);
+        assertTrue(resumedTracker.prohibitsProcessing(8L));
+        assertFalse(resumedTracker.prohibitsProcessing(2L));
+        assertFalse(resumedTracker.prohibitsProcessing(5L));
+
+        // The dropped offsets are gone for good; a later commit cannot resurrect them
+        String laterMetadata = tracker.commitMetadata(0L).block();
+        OffsetTracker laterResumedTracker = newAcknowledgedAheadOfCommitTracker(0L, laterMetadata);
+        assertTrue(laterResumedTracker.prohibitsProcessing(8L));
+        assertFalse(laterResumedTracker.prohibitsProcessing(2L));
+        assertFalse(laterResumedTracker.prohibitsProcessing(5L));
+    }
+
+    @Test
+    public void acknowledgedAheadOfCommit_givenInitialPosition_expectsInitialConsumerOffset() {
+        OffsetTracker tracker = newAcknowledgedAheadOfCommitTracker(5L, null);
+
+        assertEquals(
+                4L,
+                tracker.initialConsumerOffset().orElseThrow(AssertionError::new).offset());
+    }
+
+    private static OffsetTracker newAcknowledgedAheadOfCommitTracker(long position, String committedMetadata) {
+        return OffsetTracker.acknowledgedAheadOfCommit(consumerPartition(position, committedMetadata));
+    }
+
+    private static ConsumerPartition consumerPartition(long position, String committedMetadata) {
+        Consumer<?, ?> consumer = mock(Consumer.class);
+        when(consumer.position(TOPIC_PARTITION)).thenReturn(position);
+        OffsetAndMetadata committed =
+                committedMetadata == null ? null : new OffsetAndMetadata(position, committedMetadata);
+        when(consumer.committed(anySet())).thenReturn(Collections.singletonMap(TOPIC_PARTITION, committed));
+        return ConsumerPartition.create(consumer, Collections.singletonList(TOPIC_PARTITION))
+                .get(0);
+    }
+}

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/OffsetsTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/OffsetsTest.java
@@ -1,0 +1,150 @@
+package io.atleon.kafka;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OffsetsTest {
+
+    @Test
+    public void newInstance_isEmpty() {
+        Offsets offsets = new Offsets();
+
+        assertTrue(offsets.isEmpty());
+        assertEquals(0, offsets.size());
+        assertFalse(offsets.contains(0L));
+        assertFalse(offsets.iterator().hasNext());
+    }
+
+    @Test
+    public void builder_givenContiguousOffsets_consolidatesIntoSingleRange() {
+        Offsets offsets = build(0L, 1L, 2L, 3L);
+
+        assertFalse(offsets.isEmpty());
+        assertEquals(4, offsets.size());
+        assertEquals(Arrays.asList(0L, 1L, 2L, 3L), toList(offsets));
+        assertEquals("[0..3]", offsets.toString());
+    }
+
+    @Test
+    public void builder_givenGappedOffsets_producesMultipleRanges() {
+        Offsets offsets = build(0L, 1L, 5L, 6L, 7L, 10L);
+
+        assertEquals(6, offsets.size());
+        assertEquals(Arrays.asList(0L, 1L, 5L, 6L, 7L, 10L), toList(offsets));
+        assertEquals("[0..1, 5..7, 10]", offsets.toString());
+    }
+
+    @Test
+    public void builder_givenDuplicateOffset_retainsSingleOccurrence() {
+        Offsets offsets = build(3L, 3L, 4L);
+
+        assertEquals(2, offsets.size());
+        assertEquals(Arrays.asList(3L, 4L), toList(offsets));
+    }
+
+    @Test
+    public void builder_givenOutOfOrderOffsets_throws() {
+        Offsets.Builder builder = new Offsets.Builder();
+        builder.addNext(5L);
+
+        assertThrows(IllegalArgumentException.class, () -> builder.addNext(4L));
+    }
+
+    @Test
+    public void contains_reflectsPresenceAcrossRangesAndGaps() {
+        Offsets offsets = build(0L, 1L, 5L, 6L, 7L);
+
+        assertTrue(offsets.contains(0L));
+        assertTrue(offsets.contains(1L));
+        assertTrue(offsets.contains(6L));
+        assertTrue(offsets.contains(7L));
+        assertFalse(offsets.contains(2L));
+        assertFalse(offsets.contains(4L));
+        assertFalse(offsets.contains(8L));
+    }
+
+    @Test
+    public void contains_givenNonLong_returnsFalse() {
+        Offsets offsets = build(1L, 2L);
+
+        assertFalse(offsets.contains((Object) "1"));
+        assertFalse(offsets.contains((Object) Integer.valueOf(1)));
+        assertFalse(offsets.contains(null));
+    }
+
+    @Test
+    public void minimumMerge_givenAdditionalOffsets_combinesWithExisting() {
+        Offsets offsets = build(1L, 2L, 5L);
+
+        Offsets merged = offsets.minimumMerge(0L, Arrays.asList(3L, 4L, 6L));
+
+        assertEquals(Arrays.asList(1L, 2L, 3L, 4L, 5L, 6L), toList(merged));
+        assertEquals("[1..6]", merged.toString());
+    }
+
+    @Test
+    public void minimumMerge_discardsOffsetsBelowMinimum() {
+        Offsets offsets = build(1L, 2L, 3L);
+
+        Offsets merged = offsets.minimumMerge(3L, Arrays.asList(4L, 5L));
+
+        assertEquals(Arrays.asList(3L, 4L, 5L), toList(merged));
+    }
+
+    @Test
+    public void minimumMerge_givenAllOffsetsBelowMinimum_returnsEmpty() {
+        Offsets offsets = build(1L, 2L, 3L);
+
+        Offsets merged = offsets.minimumMerge(10L, Collections.emptyList());
+
+        assertTrue(merged.isEmpty());
+    }
+
+    @Test
+    public void minimumMerge_dedupesOverlapBetweenExistingAndAdditional() {
+        Offsets offsets = build(1L, 2L, 3L);
+
+        Offsets merged = offsets.minimumMerge(0L, Arrays.asList(2L, 3L, 4L));
+
+        assertEquals(Arrays.asList(1L, 2L, 3L, 4L), toList(merged));
+    }
+
+    @Test
+    public void minimumMerge_givenUnsortedAdditionalOffsets_throws() {
+        Offsets offsets = build(1L);
+
+        assertThrows(IllegalArgumentException.class, () -> offsets.minimumMerge(0L, Arrays.asList(5L, 3L)));
+    }
+
+    @Test
+    public void minimumMerge_doesNotMutateOriginal() {
+        Offsets offsets = build(1L, 2L);
+
+        offsets.minimumMerge(0L, Arrays.asList(3L, 4L));
+
+        assertEquals(Arrays.asList(1L, 2L), toList(offsets));
+    }
+
+    private static Offsets build(long... offsets) {
+        Offsets.Builder builder = new Offsets.Builder();
+        for (long offset : offsets) {
+            builder.addNext(offset);
+        }
+        return builder.build();
+    }
+
+    private static List<Long> toList(Offsets offsets) {
+        List<Long> result = new ArrayList<>();
+        offsets.iterator().forEachRemaining(result::add);
+        return result;
+    }
+}


### PR DESCRIPTION
### :pencil: Description
- Implement new `OffsetTracker` (with configurable strategy) to track acknowledged offsets ahead of committed offset
- Use offset commitment metadata to make acknowledged-ahead-of-commit offsets non-volatile
- Honor prohibition of duplicate processing upon assignment by loading acknowledged-ahead-of-commit offsets from assignment commit metadata

### :link: Related Issues
#544 