### PR TITLE
[#558] Core: Enable `EAGER` Upstream demand from `AcknowledgementQueue`

### DIFF
--- a/base/core/src/main/java/io/atleon/core/AcknowledgementQueue.java
+++ b/base/core/src/main/java/io/atleon/core/AcknowledgementQueue.java
@@ -58,27 +58,40 @@ public final class AcknowledgementQueue {
     }
 
     /**
-     * Complete an In-Flight Acknowledgement in this Queue
+     * Complete an In-Flight Acknowledgement in this Queue. Depending on configured
+     * {@link AcknowledgementQueueMode}, this method will return either the number of in-flight
+     * elements removed from the queue (non-EAGER), or 1 to represent successful completion of the
+     * provided {@link InFlight} (and {@link Long#MIN_VALUE} otherwise).
      *
-     * @return The number of elements drained from this Queue due to completion of Acknowledgement,
-     *         or {@link Long#MIN_VALUE} if already completed.
+     * @return The number of elements <i>effectively/logically</i> dequeued, or
+     *         {@link Long#MIN_VALUE} if already completed.
      */
     public long complete(InFlight toComplete) {
         return complete(toComplete, InFlight::complete);
     }
 
     /**
-     * Exceptionally complete an In-Flight Acknowledgement in this Queue
+     * Exceptionally complete an In-Flight Acknowledgement in this Queue. Depending on configured
+     * {@link AcknowledgementQueueMode}, this method will return either the number of in-flight
+     * elements removed from the queue (non-EAGER), or 1 to represent successful completion of the
+     * provided {@link InFlight} (and {@link Long#MIN_VALUE} otherwise).
      *
-     * @return The number of elements drained from this Queue due to completion of Acknowledgement,
-     *         or {@link Long#MIN_VALUE} if already completed.
+     * @return The number of elements <i>effectively/logically</i> dequeued, or
+     *         {@link Long#MIN_VALUE} if already completed.
      */
     public long completeExceptionally(InFlight toComplete, Throwable error) {
         return complete(toComplete, inFlight -> inFlight.completeExceptionally(error));
     }
 
     private long complete(InFlight inFlight, Predicate<InFlight> completer) {
-        return completer.test(inFlight) ? drainFrom(inFlight) : Long.MIN_VALUE;
+        if (!completer.test(inFlight)) {
+            return Long.MIN_VALUE;
+        } else if (mode.isDemandEager()) {
+            drainFrom(inFlight);
+            return 1L;
+        } else {
+            return drainFrom(inFlight);
+        }
     }
 
     private long drainFrom(InFlight completed) {
@@ -123,7 +136,7 @@ public final class AcknowledgementQueue {
     }
 
     private long drainNonHead(InFlight nonHead) {
-        return mode == AcknowledgementQueueMode.COMPACT ? nonHead.tryCompact() : 0L;
+        return mode.isCompact() ? nonHead.tryCompact() : 0L;
     }
 
     public static final class InFlight {

--- a/base/core/src/main/java/io/atleon/core/AcknowledgementQueueMode.java
+++ b/base/core/src/main/java/io/atleon/core/AcknowledgementQueueMode.java
@@ -1,16 +1,66 @@
 package io.atleon.core;
 
 /**
- * Controls the behavior of queuing in {@link AcknowledgementQueue}
+ * Controls the behavior of queuing in {@link AcknowledgementQueue} along two independent axes:
+ * <ul>
+ * <li><b>Execution Compaction:</b> By default, all completed in-flights have their associated
+ * acknowledgements executed. This can rather be configured to enable "compaction", where
+ * consecutively completed in-flights may have execution skipped in favor of executing the latest
+ * completed in-flight. Compaction optimizes memory usage by allowing consecutively completed
+ * in-flights to coalesce into a single acknowledgement execution. This is useful (for example)
+ * when consumption is based on monotonically-increasing offsets.</li>
+ * <li><b>Upstream Demand Timing:</b> By default, demand is only signaled on in-flight completion
+ * when its acknowledgement is executed and it (as well as any others that are executed) is drained
+ * from the queue. This can rather be configured to happen immediately on completion (EAGER), such
+ * as to eagerly request more elements from upstream as soon as processing an element has
+ * completed, and (possibly) before its acknowledgement has executed.</li>
+ * </ul>
  */
 public enum AcknowledgementQueueMode {
     /**
-     * Every queued acknowledgement will be executed in order
+     * Every queued acknowledgement will be executed in order. Completion reports the number of
+     * elements actually drained from the queue, which may be zero when completion is blocked
+     * behind earlier in-flight acknowledgements.
      */
-    STRICT,
+    STRICT(false, false),
     /**
-     * Acknowledgements may be skipped when multiple sequential acknowledgements are ready to be
-     * executed
+     * Acknowledgement executions may be skipped when multiple sequential acknowledgements are
+     * ready to be executed. Completion <i>may</i> signal demand if/when acknowledgements are
+     * coalesced, which may not coincide with any acknowledgement execution.
      */
-    COMPACT
+    COMPACT(true, false),
+    /**
+     * As {@link #STRICT}, but each completion is reported as a single upstream demand as soon as
+     * the in-flight completes, rather than only when it is executed+drained. This frees downstream
+     * backpressure capacity per logical completion instead of waiting for in-order execution, at
+     * the cost of allowing more work to be requested ahead of that execution. Note that this mode
+     * can result in unbounded memory usage if/when an in-flight at the head of the queue takes a
+     * long time to complete (or never does), while elements continue to be processed.
+     */
+    EAGER(false, true),
+    /**
+     * Combines {@link #COMPACT} and {@link #EAGER}, where acknowledgements are allowed to coalesce
+     * when multiple sequential acknowledgements are ready to be executed, and each completion is
+     * reported as a single upstream demand as soon as the in-flight completes. This mode is
+     * protected from unbounded memory usage, although the queue may hold up to twice as many
+     * acknowledgements as the number of allowed in-flight elements.
+     */
+    COMPACT_EAGER(true, true);
+
+    private final boolean compact;
+
+    private final boolean demandEager;
+
+    AcknowledgementQueueMode(boolean compact, boolean demandEager) {
+        this.compact = compact;
+        this.demandEager = demandEager;
+    }
+
+    public boolean isCompact() {
+        return compact;
+    }
+
+    boolean isDemandEager() {
+        return demandEager;
+    }
 }

--- a/base/core/src/main/java/io/atleon/core/AcknowledgementQueueMode.java
+++ b/base/core/src/main/java/io/atleon/core/AcknowledgementQueueMode.java
@@ -30,20 +30,9 @@ public enum AcknowledgementQueueMode {
      */
     COMPACT(true, false),
     /**
-     * As {@link #STRICT}, but each completion is reported as a single upstream demand as soon as
-     * the in-flight completes, rather than only when it is executed+drained. This frees downstream
-     * backpressure capacity per logical completion instead of waiting for in-order execution, at
-     * the cost of allowing more work to be requested ahead of that execution. Note that this mode
-     * can result in unbounded memory usage if/when an in-flight at the head of the queue takes a
-     * long time to complete (or never does), while elements continue to be processed.
-     */
-    EAGER(false, true),
-    /**
-     * Combines {@link #COMPACT} and {@link #EAGER}, where acknowledgements are allowed to coalesce
-     * when multiple sequential acknowledgements are ready to be executed, and each completion is
-     * reported as a single upstream demand as soon as the in-flight completes. This mode is
-     * protected from unbounded memory usage, although the queue may hold up to twice as many
-     * acknowledgements as the number of allowed in-flight elements.
+     * As {@link #COMPACT}, where acknowledgements are allowed to coalesce when multiple sequential
+     * acknowledgements are ready to be executed, but each completion is reported as a single
+     * upstream demand as soon as each in-flight completes.
      */
     COMPACT_EAGER(true, true);
 

--- a/base/core/src/test/java/io/atleon/core/AcknowledgementQueueTest.java
+++ b/base/core/src/test/java/io/atleon/core/AcknowledgementQueueTest.java
@@ -249,7 +249,7 @@ public class AcknowledgementQueueTest {
 
         assertEquals(count, drained.get());
         assertEquals(errorCount.get(), negativeCount.get());
-        if (mode != AcknowledgementQueueMode.COMPACT) {
+        if (!mode.isCompact()) {
             assertEquals(count, positiveCount.get() + negativeCount.get());
         }
     }

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/AloKafkaReceiver.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/AloKafkaReceiver.java
@@ -530,7 +530,7 @@ public class AloKafkaReceiver<K, V> {
             revocationGracePeriod = revocationGracePeriod.isPresent()
                     ? revocationGracePeriod
                     : config.loadDuration(MAX_DELAY_REBALANCE_CONFIG);
-            return revocationGracePeriod.isPresent() || acknowledgementQueueMode == AcknowledgementQueueMode.STRICT
+            return revocationGracePeriod.isPresent() || !acknowledgementQueueMode.isCompact()
                     ? revocationGracePeriod
                     : Optional.of(Duration.ZERO); // By default, disable delay if acknowledgements may be skipped
         }


### PR DESCRIPTION
### :pencil: Description
- Allow for demand-on-completion behavior when using acknowledgement queueing

### :link: Related Issues
#558 
