### PR TITLE
[#560] Kafka: Make `ActivePartition` generic (in terms of received key-value type(s))

### DIFF
--- a/base/core/src/main/java/io/atleon/core/AcknowledgementQueue.java
+++ b/base/core/src/main/java/io/atleon/core/AcknowledgementQueue.java
@@ -63,7 +63,7 @@ public final class AcknowledgementQueue {
      * @return The number of elements drained from this Queue due to completion of Acknowledgement
      */
     public long complete(InFlight toComplete) {
-        return complete(toComplete, InFlight::complete) ? drainFrom(toComplete) : 0L;
+        return complete(toComplete, InFlight::complete);
     }
 
     /**
@@ -72,11 +72,11 @@ public final class AcknowledgementQueue {
      * @return The number of elements drained from this Queue due to completion of Acknowledgement
      */
     public long completeExceptionally(InFlight toComplete, Throwable error) {
-        return complete(toComplete, inFlight -> inFlight.completeExceptionally(error)) ? drainFrom(toComplete) : 0L;
+        return complete(toComplete, inFlight -> inFlight.completeExceptionally(error));
     }
 
-    private boolean complete(InFlight inFlight, Predicate<InFlight> completer) {
-        return completer.test(inFlight);
+    private long complete(InFlight inFlight, Predicate<InFlight> completer) {
+        return completer.test(inFlight) ? drainFrom(inFlight) : 0L;
     }
 
     private long drainFrom(InFlight completed) {

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
@@ -23,11 +23,11 @@ import java.util.function.ToLongFunction;
  * A partition that is currently assigned, being actively consumed, and may be associated with
  * records that are being processed.
  */
-final class ActivePartition {
-
-    private final OffsetTracker offsetTracker;
+final class ActivePartition<K, V> {
 
     private final AcknowledgementQueue acknowledgementQueue;
+
+    private final OffsetTracker offsetTracker;
 
     // This counter doubles as both our publishing state (via polarity: positive == ACTIVE,
     // negative == TERMINABLE, zero == TERMINATED) and our count of activated in-flight records
@@ -48,8 +48,8 @@ final class ActivePartition {
             Sinks.unsafe().many().unicast().onBackpressureError();
 
     public ActivePartition(OffsetTracker offsetTracker, AcknowledgementQueueMode acknowledgementQueueMode) {
-        this.offsetTracker = offsetTracker;
         this.acknowledgementQueue = AcknowledgementQueue.create(acknowledgementQueueMode);
+        this.offsetTracker = offsetTracker;
     }
 
     /**
@@ -58,7 +58,7 @@ final class ActivePartition {
      * and if the configured {@link OffsetTracker} does not prohibit processing, based on the given
      * record's offset.
      */
-    public <K, V> Optional<KafkaReceiverRecord<K, V>> activateForProcessing(ConsumerRecord<K, V> consumerRecord) {
+    public Optional<KafkaReceiverRecord<K, V>> activateForProcessing(ConsumerRecord<K, V> consumerRecord) {
         return activate(ConsumerOffset.create(topicPartition(), consumerRecord)).map(it -> {
             if (offsetTracker.prohibitsProcessing(consumerRecord.offset())) {
                 ack(consumerRecord.offset(), it);

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/EmittableRecord.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/EmittableRecord.java
@@ -11,11 +11,11 @@ import java.util.Optional;
  */
 final class EmittableRecord<K, V> {
 
-    private final ActivePartition activePartition;
+    private final ActivePartition<K, V> activePartition;
 
     private final ConsumerRecord<K, V> consumerRecord;
 
-    public EmittableRecord(ActivePartition activePartition, ConsumerRecord<K, V> consumerRecord) {
+    public EmittableRecord(ActivePartition<K, V> activePartition, ConsumerRecord<K, V> consumerRecord) {
         this.activePartition = activePartition;
         this.consumerRecord = consumerRecord;
     }

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/KafkaReceiverOptions.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/KafkaReceiverOptions.java
@@ -48,6 +48,8 @@ public final class KafkaReceiverOptions<K, V> {
 
     private final PollStrategyFactory pollStrategyFactory;
 
+    private final OffsetTrackingStrategy offsetTrackingStrategy;
+
     private final Supplier<Scheduler> auxiliarySchedulerSupplier;
 
     private final Map<String, Object> consumerProperties;
@@ -68,8 +70,6 @@ public final class KafkaReceiverOptions<K, V> {
 
     private final int maxCommitAttempts;
 
-    private final OffsetTrackingStrategy offsetTrackingStrategy;
-
     private final Duration revocationGracePeriod;
 
     private final Duration terminationGracePeriod;
@@ -81,6 +81,7 @@ public final class KafkaReceiverOptions<K, V> {
             ConsumerListenerFactory consumerListenerFactory,
             ReceptionListenerFactory receptionListenerFactory,
             PollStrategyFactory pollStrategyFactory,
+            OffsetTrackingStrategy offsetTrackingStrategy,
             Supplier<Scheduler> auxiliarySchedulerSupplier,
             Map<String, Object> consumerProperties,
             int fullPollRecordsPrefetch,
@@ -91,7 +92,6 @@ public final class KafkaReceiverOptions<K, V> {
             Duration commitPeriod,
             Duration commitTimeout,
             int maxCommitAttempts,
-            OffsetTrackingStrategy offsetTrackingStrategy,
             Duration revocationGracePeriod,
             Duration terminationGracePeriod,
             Duration closeTimeout) {
@@ -99,6 +99,7 @@ public final class KafkaReceiverOptions<K, V> {
         this.consumerListenerFactory = consumerListenerFactory;
         this.receptionListenerFactory = receptionListenerFactory;
         this.pollStrategyFactory = pollStrategyFactory;
+        this.offsetTrackingStrategy = offsetTrackingStrategy;
         this.auxiliarySchedulerSupplier = auxiliarySchedulerSupplier;
         this.consumerProperties = consumerProperties;
         this.fullPollRecordsPrefetch = fullPollRecordsPrefetch;
@@ -109,7 +110,6 @@ public final class KafkaReceiverOptions<K, V> {
         this.commitPeriod = commitPeriod;
         this.commitTimeout = commitTimeout;
         this.maxCommitAttempts = maxCommitAttempts;
-        this.offsetTrackingStrategy = offsetTrackingStrategy;
         this.revocationGracePeriod = revocationGracePeriod;
         this.terminationGracePeriod = terminationGracePeriod;
         this.closeTimeout = closeTimeout;
@@ -138,6 +138,7 @@ public final class KafkaReceiverOptions<K, V> {
                 .consumerListenerFactory(consumerListenerFactory)
                 .receptionListenerFactory(receptionListenerFactory)
                 .pollStrategyFactory(pollStrategyFactory)
+                .offsetTrackingStrategy(offsetTrackingStrategy)
                 .auxiliarySchedulerSupplier(auxiliarySchedulerSupplier)
                 .consumerProperties(consumerProperties)
                 .fullPollRecordsPrefetch(fullPollRecordsPrefetch)
@@ -148,7 +149,6 @@ public final class KafkaReceiverOptions<K, V> {
                 .commitPeriod(commitPeriod)
                 .commitTimeout(commitTimeout)
                 .maxCommitAttempts(maxCommitAttempts)
-                .offsetTrackingStrategy(offsetTrackingStrategy)
                 .revocationGracePeriod(revocationGracePeriod)
                 .terminationGracePeriod(terminationGracePeriod)
                 .closeTimeout(closeTimeout);
@@ -185,6 +185,22 @@ public final class KafkaReceiverOptions<K, V> {
      */
     public PollStrategy createPollStrategy() {
         return pollStrategyFactory.create();
+    }
+
+    /**
+     * @see Builder#commitlessOffsets(boolean)
+     */
+    @Deprecated
+    public boolean commitlessOffsets() {
+        return offsetTrackingStrategy instanceof OffsetTrackingStrategy.Commitless;
+    }
+
+    /**
+     * @see Builder#simpleOffsetTracking()
+     * @see Builder#commitlessOffsetTracking()
+     */
+    public OffsetTrackingStrategy offsetTrackingStrategy() {
+        return offsetTrackingStrategy;
     }
 
     /**
@@ -271,22 +287,6 @@ public final class KafkaReceiverOptions<K, V> {
     }
 
     /**
-     * @see Builder#commitlessOffsets(boolean)
-     */
-    @Deprecated
-    public boolean commitlessOffsets() {
-        return offsetTrackingStrategy instanceof OffsetTrackingStrategy.Commitless;
-    }
-
-    /**
-     * @see Builder#simpleOffsetTracking()
-     * @see Builder#commitlessOffsetTracking()
-     */
-    public OffsetTrackingStrategy offsetTrackingStrategy() {
-        return offsetTrackingStrategy;
-    }
-
-    /**
      * @see Builder#revocationGracePeriod(Duration)
      */
     public Duration revocationGracePeriod() {
@@ -353,6 +353,8 @@ public final class KafkaReceiverOptions<K, V> {
 
         private PollStrategyFactory pollStrategyFactory = PollStrategyFactory.natural();
 
+        private OffsetTrackingStrategy offsetTrackingStrategy = OffsetTrackingStrategy.simple();
+
         private Supplier<Scheduler> auxiliarySchedulerSupplier = Schedulers::parallel;
 
         private Map<String, Object> consumerProperties = Collections.emptyMap();
@@ -372,8 +374,6 @@ public final class KafkaReceiverOptions<K, V> {
         private Duration commitTimeout = DEFAULT_COMMIT_TIMEOUT;
 
         private int maxCommitAttempts = DEFAULT_MAX_COMMIT_ATTEMPTS;
-
-        private OffsetTrackingStrategy offsetTrackingStrategy = OffsetTrackingStrategy.simple();
 
         private Duration revocationGracePeriod = DEFAULT_REVOCATION_GRACE_PERIOD;
 
@@ -429,6 +429,45 @@ public final class KafkaReceiverOptions<K, V> {
         public Builder<K, V> pollStrategyFactory(PollStrategyFactory pollStrategyFactory) {
             this.pollStrategyFactory = pollStrategyFactory;
             return this;
+        }
+
+        /**
+         * Configures whether offset commitment is disabled, which can be useful for stateless
+         * consumption.
+         * @deprecated Use {@link #commitlessOffsetTracking()}
+         */
+        @Deprecated
+        public Builder<K, V> commitlessOffsets(boolean commitlessOffsets) {
+            if (commitlessOffsets) {
+                return commitlessOffsetTracking();
+            } else if (offsetTrackingStrategy instanceof OffsetTrackingStrategy.Commitless) {
+                return simpleOffsetTracking();
+            } else if (offsetTrackingStrategy instanceof OffsetTrackingStrategy.Simple) {
+                return this;
+            } else {
+                throw new UnsupportedOperationException("Cannot disable commitless offsets with non-trivial strategy");
+            }
+        }
+
+        /**
+         * Sets (or resets) offset tracking strategy to {@link OffsetTrackingStrategy#simple()}.
+         */
+        public Builder<K, V> simpleOffsetTracking() {
+            return offsetTrackingStrategy(OffsetTrackingStrategy.simple());
+        }
+
+        /**
+         * Sets offset tracking strategy to {@link OffsetTrackingStrategy#commitless()}.
+         */
+        public Builder<K, V> commitlessOffsetTracking() {
+            return offsetTrackingStrategy(OffsetTrackingStrategy.commitless());
+        }
+
+        /**
+         * Sets offset tracking strategy to {@link OffsetTrackingStrategy#acknowledgedAheadOfCommit()}.
+         */
+        public Builder<K, V> acknowledgedAheadOfCommitOffsetTracking() {
+            return offsetTrackingStrategy(OffsetTrackingStrategy.acknowledgedAheadOfCommit());
         }
 
         /**
@@ -544,45 +583,6 @@ public final class KafkaReceiverOptions<K, V> {
         }
 
         /**
-         * Configures whether offset commitment is disabled, which can be useful for stateless
-         * consumption.
-         * @deprecated Use {@link #commitlessOffsetTracking()}
-         */
-        @Deprecated
-        public Builder<K, V> commitlessOffsets(boolean commitlessOffsets) {
-            if (commitlessOffsets) {
-                return commitlessOffsetTracking();
-            } else if (offsetTrackingStrategy instanceof OffsetTrackingStrategy.Commitless) {
-                return simpleOffsetTracking();
-            } else if (offsetTrackingStrategy instanceof OffsetTrackingStrategy.Simple) {
-                return this;
-            } else {
-                throw new UnsupportedOperationException("Cannot disable commitless offsets with non-trivial strategy");
-            }
-        }
-
-        /**
-         * Sets (or resets) offset tracking strategy to {@link OffsetTrackingStrategy#simple()}.
-         */
-        public Builder<K, V> simpleOffsetTracking() {
-            return offsetTrackingStrategy(OffsetTrackingStrategy.simple());
-        }
-
-        /**
-         * Sets offset tracking strategy to {@link OffsetTrackingStrategy#commitless()}.
-         */
-        public Builder<K, V> commitlessOffsetTracking() {
-            return offsetTrackingStrategy(OffsetTrackingStrategy.commitless());
-        }
-
-        /**
-         * Sets offset tracking strategy to {@link OffsetTrackingStrategy#acknowledgedAheadOfCommit()}.
-         */
-        public Builder<K, V> acknowledgedAheadOfCommitOffsetTracking() {
-            return offsetTrackingStrategy(OffsetTrackingStrategy.acknowledgedAheadOfCommit());
-        }
-
-        /**
          * Configures the maximum amount of time that will be awaited for in-flight records to be
          * acknowledged from a partition whose assignment is being revoked. The latest acknowledged
          * offsets from such a partition are then used to issue one last commit before
@@ -631,6 +631,7 @@ public final class KafkaReceiverOptions<K, V> {
                     consumerListenerFactory,
                     receptionListenerFactory,
                     pollStrategyFactory,
+                    offsetTrackingStrategy,
                     auxiliarySchedulerSupplier,
                     consumerProperties,
                     fullPollRecordsPrefetch,
@@ -641,7 +642,6 @@ public final class KafkaReceiverOptions<K, V> {
                     commitPeriod,
                     commitTimeout,
                     maxCommitAttempts,
-                    offsetTrackingStrategy,
                     revocationGracePeriod,
                     terminationGracePeriod,
                     closeTimeout);

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/PollingSubscriptionFactory.java
@@ -88,7 +88,7 @@ final class PollingSubscriptionFactory<K, V> {
 
         private final ReceptionListener listener;
 
-        private final PollManager<ActivePartition> pollManager;
+        private final PollManager<ActivePartition<K, V>> pollManager;
 
         private final AtomicInteger freePrefetchCapacity = new AtomicInteger(options.calculateMaxRecordsPrefetch());
 
@@ -144,8 +144,8 @@ final class PollingSubscriptionFactory<K, V> {
         @Override
         public final void onPartitionsAssigned(Consumer<?, ?> consumer, Map<TopicPartition, OffsetTracker> assignment) {
             pollManager.activateAssigned(consumer, assignment.keySet(), partition -> {
-                ActivePartition activePartition =
-                        new ActivePartition(assignment.get(partition), options.acknowledgementQueueMode());
+                ActivePartition<K, V> activePartition =
+                        new ActivePartition<>(assignment.get(partition), options.acknowledgementQueueMode());
                 onPartitionActivated(consumer, activePartition);
                 listener.onPartitionActivated(partition);
 
@@ -159,7 +159,7 @@ final class PollingSubscriptionFactory<K, V> {
 
         @Override
         public final void onPartitionsRevoked(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
-            Collection<ActivePartition> revokedPartitions = pollManager.unassigned(partitions);
+            Collection<ActivePartition<K, V>> revokedPartitions = pollManager.unassigned(partitions);
 
             try {
                 onActivePartitionsRevoked(consumer, revokedPartitions);
@@ -199,10 +199,10 @@ final class PollingSubscriptionFactory<K, V> {
             return pollManager.forcePaused();
         }
 
-        protected abstract void onPartitionActivated(Consumer<?, ?> consumer, ActivePartition partition);
+        protected abstract void onPartitionActivated(Consumer<?, ?> consumer, ActivePartition<K, V> partition);
 
         protected abstract void onActivePartitionsRevoked(
-                Consumer<?, ?> consumer, Collection<ActivePartition> partitions);
+                Consumer<?, ?> consumer, Collection<ActivePartition<K, V>> partitions);
 
         protected abstract void onActivePartitionsLost(Map<TopicPartition, Long> lostPartitionRecordCounts);
 
@@ -289,7 +289,7 @@ final class PollingSubscriptionFactory<K, V> {
 
             int queuedForEmission = 0;
             for (TopicPartition partition : consumerRecords.partitions()) {
-                ActivePartition activePartition = pollManager.activated(partition);
+                ActivePartition<K, V> activePartition = pollManager.activated(partition);
                 for (ConsumerRecord<K, V> consumerRecord : consumerRecords.records(partition)) {
                     emittableRecords.add(new EmittableRecord<>(activePartition, consumerRecord));
                     queuedForEmission++;
@@ -373,14 +373,15 @@ final class PollingSubscriptionFactory<K, V> {
         }
 
         @Override
-        protected void onPartitionActivated(Consumer<?, ?> consumer, ActivePartition partition) {
+        protected void onPartitionActivated(Consumer<?, ?> consumer, ActivePartition<K, V> partition) {
             java.util.function.Consumer<AcknowledgedOffset> acknowledgementHandler =
                     asyncOffsetCommitter.acknowledgementHandlerForAssigned(partition.topicPartition());
             partition.acknowledgedOffsets().subscribe(acknowledgementHandler, this::failSafely);
         }
 
         @Override
-        protected void onActivePartitionsRevoked(Consumer<?, ?> consumer, Collection<ActivePartition> partitions) {
+        protected void onActivePartitionsRevoked(
+                Consumer<?, ?> consumer, Collection<ActivePartition<K, V>> partitions) {
             // Get the latest committable offsets for the partitions that have been revoked (with
             // possible grace period), such that we can commit them synchronously. Although it is
             // possible that these offsets may have been previously committed, it is unlikely that
@@ -495,13 +496,14 @@ final class PollingSubscriptionFactory<K, V> {
         }
 
         @Override
-        protected void onPartitionActivated(Consumer<?, ?> consumer, ActivePartition partition) {
+        protected void onPartitionActivated(Consumer<?, ?> consumer, ActivePartition<K, V> partition) {
             groupMetadata = consumer.groupMetadata();
             partition.acknowledgedOffsets().subscribe(acknowledgedOffsetsQueue::addAndDrain, this::failSafely);
         }
 
         @Override
-        protected void onActivePartitionsRevoked(Consumer<?, ?> consumer, Collection<ActivePartition> partitions) {
+        protected void onActivePartitionsRevoked(
+                Consumer<?, ?> consumer, Collection<ActivePartition<K, V>> partitions) {
             groupMetadata = consumer.groupMetadata();
             Mono<TxOffsetsState> txClosure =
                     offsetsState(TxOffsetsState.INACTIVE).next().cache();

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
@@ -44,7 +44,8 @@ class ActivePartitionTest {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
+        ActivePartition<String, String> activePartition =
+                new ActivePartition<>(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -61,7 +62,8 @@ class ActivePartitionTest {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
+        ActivePartition<String, String> activePartition =
+                new ActivePartition<>(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -81,8 +83,8 @@ class ActivePartitionTest {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition =
-                new ActivePartition(prohibitingOffsetTracker(1L), AcknowledgementQueueMode.STRICT);
+        ActivePartition<String, String> activePartition =
+                new ActivePartition<>(prohibitingOffsetTracker(1L), AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -113,8 +115,8 @@ class ActivePartitionTest {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
 
         ConsumerOffset initialConsumerOffset = new ConsumerOffset(TOPIC_PARTITION, 4L);
-        ActivePartition activePartition =
-                new ActivePartition(initializedOffsetTracker(initialConsumerOffset), AcknowledgementQueueMode.STRICT);
+        ActivePartition<String, String> activePartition =
+                new ActivePartition<>(initializedOffsetTracker(initialConsumerOffset), AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
 
         // Even without any record being acknowledged, an initially committable offset is emitted as
@@ -137,7 +139,8 @@ class ActivePartitionTest {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
+        ActivePartition<String, String> activePartition =
+                new ActivePartition<>(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -157,7 +160,8 @@ class ActivePartitionTest {
         List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
         List<Long> deactivatedRecordCounts = new ArrayList<>();
 
-        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
+        ActivePartition<String, String> activePartition =
+                new ActivePartition<>(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add);
         activePartition.deactivatedRecordCounts().subscribe(deactivatedRecordCounts::add);
 
@@ -196,7 +200,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
+        ActivePartition<String, String> activePartition =
+                new ActivePartition<>(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add, acknowledgedOffsetsError::set);
         activePartition
                 .deactivatedRecordCounts()
@@ -225,7 +230,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
+        ActivePartition<String, String> activePartition =
+                new ActivePartition<>(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add, acknowledgedOffsetsError::set);
         activePartition
                 .deactivatedRecordCounts()
@@ -267,7 +273,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
+        ActivePartition<String, String> activePartition =
+                new ActivePartition<>(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -308,7 +315,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
+        ActivePartition<String, String> activePartition =
+                new ActivePartition<>(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -363,7 +371,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
+        ActivePartition<String, String> activePartition =
+                new ActivePartition<>(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -410,7 +419,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
+        ActivePartition<String, String> activePartition =
+                new ActivePartition<>(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -459,7 +469,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
 
-        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
+        ActivePartition<String, String> activePartition =
+                new ActivePartition<>(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .subscribe(
@@ -495,7 +506,8 @@ class ActivePartitionTest {
         AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
         CompletableFuture<Void> deactivatedRecordCountsCompletion = new CompletableFuture<>();
 
-        ActivePartition activePartition = new ActivePartition(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
+        ActivePartition<String, String> activePartition =
+                new ActivePartition<>(newOffsetTracker(), AcknowledgementQueueMode.STRICT);
         activePartition
                 .acknowledgedOffsets()
                 .publishOn(Schedulers.boundedElastic())


### PR DESCRIPTION
### :pencil: Description
- This will enable typed negative acknowledgement customization within `ActivePartition`

### :link: Related Issues
#560 
