### PR TITLE
[#562] Kafka: Guard against observed ack after negative ack

### DIFF
--- a/base/core/src/main/java/io/atleon/core/AcknowledgementQueue.java
+++ b/base/core/src/main/java/io/atleon/core/AcknowledgementQueue.java
@@ -60,7 +60,8 @@ public final class AcknowledgementQueue {
     /**
      * Complete an In-Flight Acknowledgement in this Queue
      *
-     * @return The number of elements drained from this Queue due to completion of Acknowledgement
+     * @return The number of elements drained from this Queue due to completion of Acknowledgement,
+     *         or {@link Long#MIN_VALUE} if already completed.
      */
     public long complete(InFlight toComplete) {
         return complete(toComplete, InFlight::complete);
@@ -69,14 +70,15 @@ public final class AcknowledgementQueue {
     /**
      * Exceptionally complete an In-Flight Acknowledgement in this Queue
      *
-     * @return The number of elements drained from this Queue due to completion of Acknowledgement
+     * @return The number of elements drained from this Queue due to completion of Acknowledgement,
+     *         or {@link Long#MIN_VALUE} if already completed.
      */
     public long completeExceptionally(InFlight toComplete, Throwable error) {
         return complete(toComplete, inFlight -> inFlight.completeExceptionally(error));
     }
 
     private long complete(InFlight inFlight, Predicate<InFlight> completer) {
-        return completer.test(inFlight) ? drainFrom(inFlight) : 0L;
+        return completer.test(inFlight) ? drainFrom(inFlight) : Long.MIN_VALUE;
     }
 
     private long drainFrom(InFlight completed) {

--- a/base/core/src/test/java/io/atleon/core/AcknowledgementQueueTest.java
+++ b/base/core/src/test/java/io/atleon/core/AcknowledgementQueueTest.java
@@ -33,16 +33,14 @@ public class AcknowledgementQueueTest {
         AcknowledgementQueue.InFlight secondInFlight = queue.add(() -> secondAcknowledged.set(true), error -> {});
         queue.add(() -> thirdAcknowledged.set(true), error -> {});
 
-        long drained = queue.complete(secondInFlight);
+        assertEquals(0L, queue.complete(secondInFlight));
 
-        assertEquals(0L, drained);
         assertFalse(firstAcknowledged.get());
         assertFalse(secondAcknowledged.get());
         assertFalse(thirdAcknowledged.get());
 
-        drained = queue.complete(firstInFlight);
+        assertEquals(2L, queue.complete(firstInFlight));
 
-        assertEquals(2L, drained);
         assertTrue(firstAcknowledged.get());
         assertTrue(secondAcknowledged.get());
         assertFalse(thirdAcknowledged.get());
@@ -62,17 +60,15 @@ public class AcknowledgementQueueTest {
         AcknowledgementQueue.InFlight secondInFlight =
                 queue.add(() -> secondAcknowledged.set(true), secondNacknowledged::set);
 
-        long drained = queue.completeExceptionally(secondInFlight, new IllegalStateException());
+        assertEquals(0L, queue.completeExceptionally(secondInFlight, new IllegalStateException()));
 
-        assertEquals(0L, drained);
         assertFalse(firstAcknowledged.get());
         assertNull(firstNacknowledged.get());
         assertFalse(secondAcknowledged.get());
         assertNull(secondNacknowledged.get());
 
-        drained = queue.complete(firstInFlight);
+        assertEquals(2L, queue.complete(firstInFlight));
 
-        assertEquals(2L, drained);
         assertTrue(firstAcknowledged.get());
         assertNull(firstNacknowledged.get());
         assertFalse(secondAcknowledged.get());
@@ -97,8 +93,8 @@ public class AcknowledgementQueueTest {
         AcknowledgementQueue.InFlight thirdInFlight =
                 queue.add(thirdAcknowledgements::incrementAndGet, thirdNacknowledged::set);
 
-        queue.completeExceptionally(secondInFlight, new IllegalStateException());
-        queue.complete(thirdInFlight);
+        assertEquals(0L, queue.completeExceptionally(secondInFlight, new IllegalStateException()));
+        assertEquals(0L, queue.complete(thirdInFlight));
 
         assertEquals(0, firstAcknowledgements.get());
         assertNull(firstNacknowledged.get());
@@ -107,8 +103,8 @@ public class AcknowledgementQueueTest {
         assertEquals(0, thirdAcknowledgements.get());
         assertNull(thirdNacknowledged.get());
 
-        queue.complete(secondInFlight);
-        queue.completeExceptionally(thirdInFlight, new IllegalStateException());
+        assertEquals(Long.MIN_VALUE, queue.complete(secondInFlight));
+        assertEquals(Long.MIN_VALUE, queue.completeExceptionally(thirdInFlight, new IllegalStateException()));
 
         assertEquals(0, firstAcknowledgements.get());
         assertNull(firstNacknowledged.get());
@@ -117,7 +113,7 @@ public class AcknowledgementQueueTest {
         assertEquals(0, thirdAcknowledgements.get());
         assertNull(thirdNacknowledged.get());
 
-        queue.complete(firstInFlight);
+        assertEquals(3, queue.complete(firstInFlight));
 
         assertEquals(1, firstAcknowledgements.get());
         assertNull(firstNacknowledged.get());
@@ -126,7 +122,7 @@ public class AcknowledgementQueueTest {
         assertEquals(1, thirdAcknowledgements.get());
         assertNull(thirdNacknowledged.get());
 
-        queue.complete(firstInFlight);
+        assertEquals(Long.MIN_VALUE, queue.complete(firstInFlight));
 
         assertEquals(1, firstAcknowledgements.get());
         assertNull(firstNacknowledged.get());
@@ -135,7 +131,7 @@ public class AcknowledgementQueueTest {
         assertEquals(1, thirdAcknowledgements.get());
         assertNull(thirdNacknowledged.get());
 
-        queue.complete(secondInFlight);
+        assertEquals(Long.MIN_VALUE, queue.complete(secondInFlight));
 
         assertEquals(1, firstAcknowledgements.get());
         assertNull(firstNacknowledged.get());
@@ -172,9 +168,7 @@ public class AcknowledgementQueueTest {
         assertTrue(firstAcknowledgementStarted.get());
 
         // Would block indefinitely here if execution blocked since first execution in progress
-        long syncDrained = queue.complete(secondInFlight);
-
-        assertEquals(0, syncDrained);
+        assertEquals(0, queue.complete(secondInFlight));
 
         firstAcknowledgementAllowed.complete(true);
 

--- a/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
+++ b/infrastructures/kafka/src/main/java/io/atleon/kafka/ActivePartition.java
@@ -165,8 +165,13 @@ final class ActivePartition<K, V> {
     }
 
     private void ack(long offset, AcknowledgementQueue.InFlight inFlight) {
-        offsetTracker.acknowledged(offset);
-        acknowledge(queue -> queue.complete(inFlight));
+        acknowledge(queue -> {
+            long result = queue.complete(inFlight);
+            if (result >= 0) {
+                offsetTracker.acknowledged(offset);
+            }
+            return result;
+        });
     }
 
     private void nack(AcknowledgementQueue.InFlight inFlight, Throwable error) {
@@ -176,6 +181,10 @@ final class ActivePartition<K, V> {
     private void acknowledge(ToLongFunction<AcknowledgementQueue> completer) {
         enqueueAndDrain(() -> {
             long completedRecords = completer.applyAsLong(acknowledgementQueue);
+            if (completedRecords <= 0) {
+                return 0L;
+            }
+
             long previousActivated = activated.getAndUpdate(count -> {
                 if (count > 0) {
                     // Not deactivated yet, so just subtract.

--- a/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
+++ b/infrastructures/kafka/src/test/java/io/atleon/kafka/ActivePartitionTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -32,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -260,6 +262,54 @@ class ActivePartitionTest {
                 acknowledgedOffsets.get(0).prepareCommitment().block().getT2().offset());
         assertInstanceOf(IllegalStateException.class, acknowledgedOffsetsError.get());
         assertEquals(Arrays.asList(1L, 3L), deactivatedRecordCounts);
+        assertNull(deactivatedRecordCountsError.get());
+        assertTrue(deactivatedRecordCountsCompleted.get());
+    }
+
+    @Test
+    public void acknowledge_givenRecordAcknowledgedAfterNacknowledgement_expectsAcknowledgementNotTracked() {
+        List<AcknowledgedOffset> acknowledgedOffsets = new ArrayList<>();
+        AtomicReference<Throwable> acknowledgedOffsetsError = new AtomicReference<>();
+        List<Long> deactivatedRecordCounts = new ArrayList<>();
+        AtomicReference<Throwable> deactivatedRecordCountsError = new AtomicReference<>();
+        AtomicBoolean deactivatedRecordCountsCompleted = new AtomicBoolean(false);
+
+        List<Long> trackedAcknowledgedOffsets = new ArrayList<>();
+        ActivePartition<String, String> activePartition = new ActivePartition<>(
+                recordingOffsetTracker(trackedAcknowledgedOffsets::add), AcknowledgementQueueMode.STRICT);
+        activePartition.acknowledgedOffsets().subscribe(acknowledgedOffsets::add, acknowledgedOffsetsError::set);
+        activePartition
+                .deactivatedRecordCounts()
+                .subscribe(
+                        deactivatedRecordCounts::add,
+                        deactivatedRecordCountsError::set,
+                        () -> deactivatedRecordCountsCompleted.set(true));
+
+        ConsumerRecord<String, String> recordA = newConsumerRecord(0);
+        ConsumerRecord<String, String> recordB = newConsumerRecord(1);
+        KafkaReceiverRecord<String, String> receiverRecordA =
+                activePartition.activateForProcessing(recordA).get();
+        KafkaReceiverRecord<String, String> receiverRecordB =
+                activePartition.activateForProcessing(recordB).get();
+
+        // Negatively acknowledge B, then erroneously (positively) acknowledge B, then acknowledge A.
+        receiverRecordB.nacknowledge(new IllegalStateException("Boom"));
+        receiverRecordB.acknowledge();
+        receiverRecordA.acknowledge();
+
+        // A is emitted as acknowledged immediately ahead of the error resulting from B's negative
+        // acknowledgement, and the stream is terminated with that error.
+        assertEquals(1, acknowledgedOffsets.size());
+        assertEquals(
+                recordA.offset() + 1,
+                acknowledgedOffsets.get(0).prepareCommitment().block().getT2().offset());
+        assertInstanceOf(IllegalStateException.class, acknowledgedOffsetsError.get());
+
+        // Crucially, only A's offset was tracked as acknowledged. B's offset must never be tracked,
+        // since B's effective (first) acknowledgement was negative.
+        assertEquals(Collections.singletonList(recordA.offset()), trackedAcknowledgedOffsets);
+
+        assertEquals(Collections.singletonList(2L), deactivatedRecordCounts);
         assertNull(deactivatedRecordCountsError.get());
         assertTrue(deactivatedRecordCountsCompleted.get());
     }
@@ -564,6 +614,17 @@ class ActivePartitionTest {
             Long offset = invocation.getArgument(0);
             return prohibited.contains(offset);
         });
+        return offsetTracker;
+    }
+
+    private static OffsetTracker recordingOffsetTracker(Consumer<Long> acknowledgedOffsets) {
+        OffsetTracker offsetTracker = mock(OffsetTracker.class, AdditionalAnswers.delegatesTo(newOffsetTracker()));
+        doAnswer(invocation -> {
+                    acknowledgedOffsets.accept(invocation.getArgument(0));
+                    return null;
+                })
+                .when(offsetTracker)
+                .acknowledged(anyLong());
         return offsetTracker;
     }
 


### PR DESCRIPTION
### :pencil: Description

### :link: Related Issues
#562 