### PR TITLE
[#586] core: Replace dependence on Bucket4j 

### DIFF
--- a/base/core/pom.xml
+++ b/base/core/pom.xml
@@ -20,10 +20,6 @@
 
         <!-- Third Party Compile Dependencies -->
         <dependency>
-            <groupId>com.bucket4j</groupId>
-            <artifactId>bucket4j_jdk17-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
         </dependency>

--- a/base/core/src/main/java/io/atleon/core/ThroughputLimitingTransformer.java
+++ b/base/core/src/main/java/io/atleon/core/ThroughputLimitingTransformer.java
@@ -5,6 +5,7 @@ import io.github.bucket4j.Bucket;
 import io.github.bucket4j.BucketConfiguration;
 import io.github.bucket4j.TimeMeter;
 import io.github.bucket4j.TokensInheritanceStrategy;
+import io.github.bucket4j.local.SynchronizationStrategy;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -15,6 +16,7 @@ import reactor.core.scheduler.Schedulers;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.ToIntFunction;
 
@@ -180,19 +182,17 @@ public final class ThroughputLimitingTransformer<T, V> implements Function<Publi
             // Implementation notes:
             // 1. Limits are kept dynamic/updated on the created grantor by subscribing to the
             //    limits with a side effect on the grantor.
-            // 2. We can safely skip the emission of initial limits that equal the initial limit,
-            //    since we know the grantor is initialized with that limit. Zero and consecutive
-            //    equal limits are also skipped to avoid needless resetting/configuration on the
-            //    grantor.
+            // 2. Zero and consecutive equal limits (including starting limits equal to the initial
+            //    limit) are skipped to avoid needless resetting/configuration on the grantor.
             // 3. The limit updating process is characterized as a publisher that never completes,
             //    which allows us to use it as a "takeUntilOther" condition on the source
             //    publisher. This makes it such that errors on the limit stream are propagated
             //    to the main publisher, and termination of the main publisher also terminates
             //    the limit updating process. Using "takeUntilOther" rather than "merge" prevents
             //    inadvertent introduction of an unnecessary prefetch buffer.
-            ThroughputGrantor grantor = new Bucket4jThroughputGrantor(scheduler, initialLimit);
-            Mono<Void> limitUpdating = limits.skipWhile(initialLimit::equals)
-                    .filter(it -> !it.isZero())
+            ThroughputGrantor grantor = new Bucket4jThroughputGrantor(scheduler);
+            Mono<Void> limitUpdating = limits.filter(it -> !it.isZero())
+                    .startWith(initialLimit)
                     .distinctUntilChanged()
                     .doOnNext(grantor::updateLimit)
                     .thenEmpty(Mono.never());
@@ -202,9 +202,9 @@ public final class ThroughputLimitingTransformer<T, V> implements Function<Publi
         }
 
         private Mono<T> maybeDelay(ThroughputGrantor grantor, T t) {
-            int weight = weighting.applyAsInt(t);
-            long delayNanos = grantor.reserveCapacity(weight);
-            return delayNanos <= 0 ? Mono.just(t) : Mono.just(t).delayElement(Duration.ofNanos(delayNanos), scheduler);
+            return grantor.reserveCapacity(weighting.applyAsInt(t))
+                    .delayUntil(it -> it > 0 ? Mono.delay(Duration.ofNanos(it), scheduler) : Mono.empty())
+                    .thenReturn(t);
         }
     }
 
@@ -218,20 +218,22 @@ public final class ThroughputLimitingTransformer<T, V> implements Function<Publi
 
     /**
      * API through which throughput capacity is reserved and updated. Reservation of throughput
-     * capacity may require waiting/delaying until the return number of nanoseconds has elapsed.
-     * Limitation of available throughput capacity can be dynamic, in which case the grantor will
+     * capacity may require waiting/delaying until the emitted number of nanoseconds has elapsed.
+     * Limitation of available throughput capacity can be dynamic, in which case the grantor should
      * update its internal state to reflect the new limit.
      */
     private interface ThroughputGrantor {
 
         /**
-         * Request reservation of throughput capacity for the provided throughput weight. Returns
-         * the number of nanoseconds to wait before safely using the reserved capacity.
+         * Creates reservation of throughput capacity for the provided throughput weight. Returns
+         * a {@link Mono} that may emit the number of nanoseconds to wait before safely using the
+         * reserved capacity. Emitting nothing or a non-positive value is treated as "no wait
+         * necessary".
          *
          * @param weight The weight of throughput capacity to reserve
-         * @return The number of nanoseconds to wait before safely using the reserved capacity
+         * @return A {@link Mono} emitting number of nanoseconds to wait before using reservation
          */
-        long reserveCapacity(int weight);
+        Mono<Long> reserveCapacity(int weight);
 
         /**
          * Requests a change in any configured throughput limit.
@@ -246,34 +248,50 @@ public final class ThroughputLimitingTransformer<T, V> implements Function<Publi
         private final TimeMeter timeMeter;
 
         // Nullity signifies the difference between infinite and non-infinite limits
-        private volatile Bucket bucket;
+        private volatile SerialQueue<Consumer<Bucket>> bucketQueue = null;
 
-        public Bucket4jThroughputGrantor(Scheduler scheduler, Rate initialLimit) {
+        public Bucket4jThroughputGrantor(Scheduler scheduler) {
             this.timeMeter = new SchedulerTimeMeter(scheduler);
-            this.bucket = initialLimit.isInfinite() ? null : newBucket(initialLimit, timeMeter);
         }
 
         @Override
-        public long reserveCapacity(int weight) {
-            Bucket nvBucket = bucket;
-            return nvBucket != null ? nvBucket.consumeIgnoringRateLimits(weight) : 0L;
+        public Mono<Long> reserveCapacity(int weight) {
+            SerialQueue<Consumer<Bucket>> nvBucketQueue = bucketQueue;
+            return nvBucketQueue != null ? reserveCapacity(nvBucketQueue, weight) : Mono.empty();
         }
 
         @Override
         public void updateLimit(Rate limit) {
-            Bucket nvBucket = bucket;
+            SerialQueue<Consumer<Bucket>> nvBucketQueue = bucketQueue;
             if (limit.isInfinite()) {
-                bucket = null;
-            } else if (nvBucket != null) {
-                updateLimit(nvBucket, limit);
+                bucketQueue = null;
+            } else if (nvBucketQueue != null) {
+                nvBucketQueue.addAndDrain(it -> updateLimit(it, limit));
             } else {
-                bucket = newBucket(limit, timeMeter);
+                bucketQueue = SerialQueue.on(newBucket(limit, timeMeter));
             }
+        }
+
+        private static Mono<Long> reserveCapacity(SerialQueue<Consumer<Bucket>> queue, int weight) {
+            return Mono.create(sink -> queue.addAndDrain(bucket -> {
+                try {
+                    if (weight > 0) {
+                        sink.success(bucket.consumeIgnoringRateLimits(weight));
+                    } else if (weight == 0) {
+                        sink.success();
+                    } else {
+                        throw new IllegalArgumentException("Weight must be non-negative: " + weight);
+                    }
+                } catch (Throwable error) {
+                    sink.error(error);
+                }
+            }));
         }
 
         private static Bucket newBucket(Rate limit, TimeMeter timeMeter) {
             return Bucket.builder()
                     .addLimit(it -> applyLimit(it, limit))
+                    .withSynchronizationStrategy(SynchronizationStrategy.NONE)
                     .withCustomTimePrecision(timeMeter)
                     .build();
         }

--- a/base/core/src/main/java/io/atleon/core/ThroughputLimitingTransformer.java
+++ b/base/core/src/main/java/io/atleon/core/ThroughputLimitingTransformer.java
@@ -1,11 +1,5 @@
 package io.atleon.core;
 
-import io.github.bucket4j.BandwidthBuilder;
-import io.github.bucket4j.Bucket;
-import io.github.bucket4j.BucketConfiguration;
-import io.github.bucket4j.TimeMeter;
-import io.github.bucket4j.TokensInheritanceStrategy;
-import io.github.bucket4j.local.SynchronizationStrategy;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -190,7 +184,7 @@ public final class ThroughputLimitingTransformer<T, V> implements Function<Publi
             //    to the main publisher, and termination of the main publisher also terminates
             //    the limit updating process. Using "takeUntilOther" rather than "merge" prevents
             //    inadvertent introduction of an unnecessary prefetch buffer.
-            ThroughputGrantor grantor = new Bucket4jThroughputGrantor(scheduler);
+            ThroughputGrantor grantor = new TokenBucketThroughputGrantor(scheduler);
             Mono<Void> limitUpdating = limits.filter(it -> !it.isZero())
                     .startWith(initialLimit)
                     .distinctUntilChanged()
@@ -243,40 +237,40 @@ public final class ThroughputLimitingTransformer<T, V> implements Function<Publi
         void updateLimit(Rate limit);
     }
 
-    private static final class Bucket4jThroughputGrantor implements ThroughputGrantor {
+    private static final class TokenBucketThroughputGrantor implements ThroughputGrantor {
 
-        private final TimeMeter timeMeter;
+        private final Scheduler scheduler;
 
         // Nullity signifies the difference between infinite and non-infinite limits
-        private volatile SerialQueue<Consumer<Bucket>> bucketQueue = null;
+        private volatile SerialQueue<Consumer<TokenBucket>> bucketQueue = null;
 
-        public Bucket4jThroughputGrantor(Scheduler scheduler) {
-            this.timeMeter = new SchedulerTimeMeter(scheduler);
+        public TokenBucketThroughputGrantor(Scheduler scheduler) {
+            this.scheduler = scheduler;
         }
 
         @Override
         public Mono<Long> reserveCapacity(int weight) {
-            SerialQueue<Consumer<Bucket>> nvBucketQueue = bucketQueue;
+            SerialQueue<Consumer<TokenBucket>> nvBucketQueue = bucketQueue;
             return nvBucketQueue != null ? reserveCapacity(nvBucketQueue, weight) : Mono.empty();
         }
 
         @Override
         public void updateLimit(Rate limit) {
-            SerialQueue<Consumer<Bucket>> nvBucketQueue = bucketQueue;
+            SerialQueue<Consumer<TokenBucket>> nvBucketQueue = bucketQueue;
             if (limit.isInfinite()) {
                 bucketQueue = null;
             } else if (nvBucketQueue != null) {
-                nvBucketQueue.addAndDrain(it -> updateLimit(it, limit));
+                nvBucketQueue.addAndDrain(it -> it.updateLimit(limit));
             } else {
-                bucketQueue = SerialQueue.on(newBucket(limit, timeMeter));
+                bucketQueue = SerialQueue.on(new TokenBucket(scheduler, limit));
             }
         }
 
-        private static Mono<Long> reserveCapacity(SerialQueue<Consumer<Bucket>> queue, int weight) {
+        private static Mono<Long> reserveCapacity(SerialQueue<Consumer<TokenBucket>> queue, int weight) {
             return Mono.create(sink -> queue.addAndDrain(bucket -> {
                 try {
                     if (weight > 0) {
-                        sink.success(bucket.consumeIgnoringRateLimits(weight));
+                        sink.success(bucket.reserveCapacity(weight));
                     } else if (weight == 0) {
                         sink.success();
                     } else {
@@ -287,44 +281,91 @@ public final class ThroughputLimitingTransformer<T, V> implements Function<Publi
                 }
             }));
         }
-
-        private static Bucket newBucket(Rate limit, TimeMeter timeMeter) {
-            return Bucket.builder()
-                    .addLimit(it -> applyLimit(it, limit))
-                    .withSynchronizationStrategy(SynchronizationStrategy.NONE)
-                    .withCustomTimePrecision(timeMeter)
-                    .build();
-        }
-
-        private static void updateLimit(Bucket bucket, Rate limit) {
-            BucketConfiguration configuration = BucketConfiguration.builder()
-                    .addLimit(it -> applyLimit(it, limit))
-                    .build();
-            bucket.replaceConfiguration(configuration, TokensInheritanceStrategy.PROPORTIONALLY);
-        }
-
-        private static BandwidthBuilder.BandwidthBuilderBuildStage applyLimit(
-                BandwidthBuilder.BandwidthBuilderCapacityStage bandwidthBuilder, Rate limit) {
-            return bandwidthBuilder.capacity(limit.count()).refillGreedy(limit.count(), limit.duration());
-        }
     }
 
-    private static final class SchedulerTimeMeter implements TimeMeter {
+    /**
+     * A token bucket whose capacity is continuously (rather than discretely) replenished, i.e. a
+     * bucket holding up to {@link Rate#count()} tokens which are replenished smoothly over
+     * {@link Rate#duration()}. Reservation of capacity is always granted, and results in the
+     * number of nanoseconds that must elapse before the reserved capacity is safely usable.
+     *
+     * <p>Rather than tracking available tokens directly, this bucket tracks the point in time at
+     * which it is depleted, such that the number of tokens available at any given time is
+     * {@code min(count, ((now - depletion) * count) / duration)}. Reserving capacity is therefore
+     * implemented by pushing the point of depletion further in to the future, and the resulting
+     * delay is however much of that push extends beyond the current time. Note that this also
+     * means a full bucket is equivalent to a point of depletion exactly one duration in the past,
+     * which is used both to bound available capacity when reserving and to preserve the proportion
+     * of available capacity when the enforced limit changes.
+     *
+     * <p>This bucket is not thread safe, and therefore requires that invocation of its methods is
+     * serialized by the caller.
+     */
+    private static final class TokenBucket {
 
         private final Scheduler scheduler;
 
-        private SchedulerTimeMeter(Scheduler scheduler) {
+        private long count;
+
+        private long durationNanos;
+
+        private long depletionNanos;
+
+        // Remainder of division by count, which keeps replenishment exact for counts that do not
+        // evenly divide their duration
+        private long depletionRemainder;
+
+        public TokenBucket(Scheduler scheduler, Rate limit) {
             this.scheduler = scheduler;
+            this.count = limit.count();
+            this.durationNanos = limit.duration().toNanos();
+            this.depletionNanos = now() - durationNanos;
+            this.depletionRemainder = 0L;
         }
 
-        @Override
-        public long currentTimeNanos() {
+        public long reserveCapacity(int weight) {
+            long nowNanos = now();
+
+            // Check if this is the first request (in a "while") and if so, reset depletion time
+            long fullDepletionNanos = nowNanos - durationNanos;
+            if (depletionNanos < fullDepletionNanos) {
+                depletionNanos = fullDepletionNanos;
+                depletionRemainder = 0L;
+            }
+
+            // Push the depletion time forward based on weighted reservation
+            long pushNanos = Math.multiplyExact(durationNanos, weight) + depletionRemainder;
+            depletionNanos += pushNanos / count;
+            depletionRemainder = pushNanos % count;
+
+            // Delay is however far into the future the depletion time is (negative if no delay)
+            return (depletionNanos - nowNanos) + (depletionRemainder > 0L ? 1L : 0L);
+        }
+
+        public void updateLimit(Rate limit) {
+            long nowNanos = now();
+            long remainingNanos = Math.max(depletionNanos, nowNanos - durationNanos) - nowNanos;
+            long limitNanos = limit.duration().toNanos();
+
+            count = limit.count();
+            depletionNanos = nowNanos + scale(remainingNanos, limitNanos, durationNanos);
+            depletionRemainder = 0L;
+            durationNanos = limitNanos;
+        }
+
+        private long now() {
             return scheduler.now(TimeUnit.NANOSECONDS);
         }
 
-        @Override
-        public boolean isWallClockBased() {
-            return false;
+        /**
+         * Returns {@code (nanos * numerator) / denominator}, applied separately to the quotient
+         * and remainder of {@code nanos / denominator} such that the intermediate multiplication
+         * cannot overflow. Note that a naive multiplication would overflow once the point of
+         * depletion is more than roughly nine seconds in the future, which is reachable at low
+         * limits with many concurrently reserving streams.
+         */
+        private static long scale(long nanos, long numerator, long denominator) {
+            return ((nanos / denominator) * numerator) + (((nanos % denominator) * numerator) / denominator);
         }
     }
 }

--- a/base/core/src/test/java/io/atleon/core/ThroughputLimitingTransformerTest.java
+++ b/base/core/src/test/java/io/atleon/core/ThroughputLimitingTransformerTest.java
@@ -74,6 +74,25 @@ class ThroughputLimitingTransformerTest {
                 .verifyComplete();
     }
 
+    @Test
+    public void concatMap_givenLimitIndivisibleByItsDuration_expectsExactlyLimitedThroughput() {
+        StepVerifier.withVirtualTime(() -> Flux.just(1L, 2L, 3L, 4L, 5L, 6L)
+                        .transform(newConcatMap()
+                                .limits(Mono.just(Rate.perSecond(3)))
+                                .build()))
+                .expectNext(1L, 2L, 3L)
+                .expectNoEvent(Duration.ofMillis(333))
+                .thenAwait(Duration.ofMillis(1))
+                .expectNext(4L)
+                .expectNoEvent(Duration.ofMillis(332))
+                .thenAwait(Duration.ofMillis(1))
+                .expectNext(5L)
+                .expectNoEvent(Duration.ofMillis(332))
+                .thenAwait(Duration.ofMillis(1))
+                .expectNext(6L)
+                .verifyComplete();
+    }
+
     // ===== concatMap: Weighting scenarios =====
 
     @Test
@@ -88,6 +107,28 @@ class ThroughputLimitingTransformerTest {
                 .thenAwait(Duration.ofMillis(500))
                 .expectNext(2L)
                 .verifyComplete();
+    }
+
+    @Test
+    public void concatMap_givenZeroWeighting_expectsNoThroughputLimit() {
+        StepVerifier.withVirtualTime(() -> Flux.just(1L, 2L, 3L)
+                        .transform(newConcatMap()
+                                .limits(Mono.just(Rate.perSecond(1)))
+                                .weighting(__ -> 0)
+                                .build()))
+                .expectNext(1L, 2L, 3L)
+                .verifyComplete();
+    }
+
+    @Test
+    public void concatMap_givenNegativeWeighting_expectsError() {
+        StepVerifier.withVirtualTime(() -> Flux.just(1L, 2L, 3L)
+                        .transform(newConcatMap()
+                                .limits(Mono.just(Rate.perSecond(1)))
+                                .weighting(__ -> -1)
+                                .build()))
+                .expectError(IllegalArgumentException.class)
+                .verify();
     }
 
     // ===== concatMap: Dynamic limit change scenarios =====
@@ -261,6 +302,71 @@ class ThroughputLimitingTransformerTest {
                 .expectNext(1L)
                 .then(() -> limitSink.tryEmitNext(Rate.zero()))
                 .expectNoEvent(Duration.ofSeconds(5))
+                .thenCancel()
+                .verify();
+    }
+
+    @Test
+    public void innerConcatMap_givenBacklogOfReservations_expectsLimitEnforcedAfterLimitChange() {
+        Sinks.Many<Rate> limitSink = Sinks.many().multicast().onBackpressureBuffer();
+        Sinks.Many<Flux<Long>> innerSink = Sinks.many().multicast().onBackpressureBuffer();
+
+        StepVerifier.withVirtualTime(() -> innerSink
+                        .asFlux()
+                        .transform(
+                                newInnerConcatMap().limits(limitSink.asFlux()).build())
+                        .flatMap(Function.identity()))
+                .expectSubscription()
+                .then(() -> limitSink.tryEmitNext(Rate.perSecond(1)))
+                // Concurrently reserve enough capacity to push the point of depletion many
+                // seconds in to the future, which must be preserved across a change of limit
+                .then(() -> {
+                    for (long i = 0; i < 12; i++) {
+                        innerSink.tryEmitNext(Flux.just(i));
+                    }
+                })
+                .expectNext(0L)
+                .then(() -> limitSink.tryEmitNext(Rate.perSecond(2)))
+                .then(() -> innerSink.tryEmitNext(Flux.just(100L)))
+                .thenAwait(Duration.ofSeconds(11))
+                .expectNext(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L)
+                .thenAwait(Duration.ofMillis(500))
+                .expectNext(100L)
+                .thenCancel()
+                .verify();
+    }
+
+    @Test
+    public void innerConcatMap_givenBacklogOfReservations_expectsLowerLimitEnforcedAfterLimitChange() {
+        Sinks.Many<Rate> limitSink = Sinks.many().multicast().onBackpressureBuffer();
+        Sinks.Many<Flux<Long>> innerSink = Sinks.many().multicast().onBackpressureBuffer();
+
+        StepVerifier.withVirtualTime(() -> innerSink
+                        .asFlux()
+                        .transform(
+                                newInnerConcatMap().limits(limitSink.asFlux()).build())
+                        .flatMap(Function.identity()))
+                .expectSubscription()
+                .then(() -> limitSink.tryEmitNext(Rate.perSecond(2)))
+                // Concurrently reserve enough capacity to push the point of depletion several
+                // seconds in to the future, which must be preserved across a change of limit
+                .then(() -> {
+                    for (long i = 0; i < 10; i++) {
+                        innerSink.tryEmitNext(Flux.just(i));
+                    }
+                })
+                .expectNext(0L, 1L)
+                .then(() -> limitSink.tryEmitNext(Rate.perSecond(1)))
+                .then(() -> innerSink.tryEmitNext(Flux.just(100L)))
+                // Already granted reservations keep their originally scheduled times, i.e.
+                // lowering the limit does not retroactively slow down the existing backlog
+                .thenAwait(Duration.ofSeconds(4))
+                .expectNext(2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L)
+                // The reservation made after the change is spaced by the lowered limit, i.e. a
+                // full second past the backlog rather than the half second the prior limit implied
+                .expectNoEvent(Duration.ofMillis(999))
+                .thenAwait(Duration.ofMillis(1))
+                .expectNext(100L)
                 .thenCancel()
                 .verify();
     }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -16,7 +16,6 @@
         <apache-kafka.version>3.9.2</apache-kafka.version>
         <apache-kafka-doc.version>39</apache-kafka-doc.version>
         <avro.version>1.12.1</avro.version>
-        <bucket4j.version>8.17.0</bucket4j.version>
         <bytebuddy.version>1.18.3</bytebuddy.version>
         <confluent.version>7.9.5</confluent.version> <!-- https://docs.confluent.io/platform/current/installation/versions-interoperability.html -->
         <jackson.version>2.22.1</jackson.version>
@@ -142,11 +141,6 @@
             </dependency>
 
             <!-- Third Party Dependencies -->
-            <dependency>
-                <groupId>com.bucket4j</groupId>
-                <artifactId>bucket4j_jdk17-core</artifactId>
-                <version>${bucket4j.version}</version>
-            </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>


### PR DESCRIPTION
### :pencil: Description
- Implement simple, smooth, token-bucket-esque rate limiting within `ThroughputLimitingTransformer`
- Remove dependence on Bucket4j in favor of using the small subset of re-implemented token-bucketed capacity limiting now available locally

### :link: Related Issues
#586 